### PR TITLE
Upgrade the HMAC Relay to protect Raptoreum SmartNodes Smart Contracts

### DIFF
--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -8,22 +8,22 @@
 
 CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {
-    unsigned char rkey[128];
-    if (keylen <= 128) {
+    unsigned char rkey[512];
+    if (keylen <= 512) {
         memcpy(rkey, key, keylen);
-        memset(rkey + keylen, 0, 128 - keylen);
+        memset(rkey + keylen, 0, 512 - keylen);
     } else {
         CSHA512().Write(key, keylen).Finalize(rkey);
         memset(rkey + 64, 0, 64);
     }
 
-    for (int n = 0; n < 128; n++)
+    for (int n = 0; n < 512; n++)
         rkey[n] ^= 0x5c;
-    outer.Write(rkey, 128);
+    outer.Write(rkey, 512);
 
-    for (int n = 0; n < 128; n++)
+    for (int n = 0; n < 512; n++)
         rkey[n] ^= 0x5c ^ 0x36;
-    inner.Write(rkey, 128);
+    inner.Write(rkey, 512);
 }
 
 void CHMAC_SHA512::Finalize(unsigned char hash[OUTPUT_SIZE])


### PR DESCRIPTION
Upgrading the HMAC keys to 512 Bits from 128 Bits will provide security to protect the non-tampered flow of Smart Contracts and Assets through SmartNodes

Making Man-In-The-Middle attacks to tamper much more difficult!