### PR TITLE
Bug/watch only transactions

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -38,7 +38,8 @@ public:
     //! at which height this containing transaction was included in the active block chain
     uint32_t nHeight : 31;
 
-    int16_t nType;
+    // At this fault this is a normal transaction which is nType = 0
+    int16_t nType = 0;
 
     std::vector<uint8_t> vExtraPayload;
 

--- a/src/future/utils.h
+++ b/src/future/utils.h
@@ -12,7 +12,7 @@ class Coin;
 class COutPoint;
 class CBlockIndex;
 
-void maybeSetPayload(Coin& coin, const COutPoint& outpoint, const int16_t& nType, const std::vector<uint8_t>& vExtraPayload);
+void maybeSetPayload(Coin& coin, const COutPoint& outputIndex, const int16_t& nType, const std::vector<uint8_t>& vExtraPayload);
 //const char *validateFutureCoin(const std::vector<uint8_t>& payload, int maturity, uint32_t confirmedTime);
 
 #endif //RAPTOREUM_FUTILS_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -319,7 +319,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             }
             continue;
         }
-        LogPrintf("TransactionRecord::%s TxId: %s, vOutIdx: %d, Unhandled\n", __func__, hash.ToString(), vOutIdx);
+        //LogPrintf("TransactionRecord::%s TxId: %s, vOutIdx: %d, Unhandled\n", __func__, hash.ToString(), vOutIdx);
     }
     return parts;
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -275,6 +275,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             sub.type = isFuture ? TransactionRecord::FutureSend : (validDestination ? TransactionRecord::SendToAddress : TransactionRecord::SendToOther);
 
             // Sent from wallet:
+            sub.involvesWatchAddress = false;
             sub.debit = -(txout.nValue + nTxFee);
             nTxFee = 0; // Add fee to first output
             sub.credit = 0;

--- a/src/raptoreum-tx.cpp
+++ b/src/raptoreum-tx.cpp
@@ -20,6 +20,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
+#include "future/utils.h"
 
 #include <stdio.h>
 
@@ -576,6 +577,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
                     newcoin.out.nValue = AmountFromValue(prevOut["amount"]);
                 }
                 newcoin.nHeight = 1;
+                maybeSetPayload(newcoin, out, tx.nType, tx.vExtraPayload);
                 view.AddCoin(out, std::move(newcoin), true);
             }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -34,6 +34,7 @@
 #include "evo/providertx.h"
 #include "evo/cbtx.h"
 #include "rpc/specialtx_utilities.h"
+#include "future/utils.h"
 
 #include "llmq/quorums_chainlocks.h"
 #include "llmq/quorums_commitment.h"
@@ -866,6 +867,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
                     newcoin.out.nValue = AmountFromValue(find_value(prevOut, "amount"));
                 }
                 newcoin.nHeight = 1;
+                maybeSetPayload(newcoin, out, mtx.nType, mtx.vExtraPayload);
                 view.AddCoin(out, std::move(newcoin), true);
             }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -397,12 +397,12 @@ bool ContextualCheckTransaction(const CTransaction& tx, CValidationState &state,
                 tx.nType != TRANSACTION_COINBASE &&
                 tx.nType != TRANSACTION_QUORUM_COMMITMENT &&
 				tx.nType != TRANSACTION_FUTURE) {
-                return state.DoS(100, false, REJECT_INVALID, "bad-txns-type");
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-type-"+tx.nType);
             }
             if (tx.IsCoinBase() && tx.nType != TRANSACTION_COINBASE)
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-cb-type");
         } else if (tx.nType != TRANSACTION_NORMAL) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-type");
+            return state.DoS(100, false, REJECT_INVALID, tx.nVersion + "-bad-txns-type-"+tx.nType);
         }
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -490,8 +490,8 @@ public:
     }
 
     //! filter decides which addresses will count towards the debit
-    CAmount GetDebit(const isminefilter& filter) const;
-    CAmount GetCredit(const isminefilter& filter) const;
+    CAmount GetDebit(const isminefilter& filter, isminefilter* mineTypes = nullptr) const;
+    CAmount GetCredit(const isminefilter& filter, isminefilter* mineTypes = nullptr) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
     CAmount GetAvailableCredit(bool fUseCache=true) const;
     CAmount GetImmatureWatchOnlyCredit(const bool& fUseCache=true) const;
@@ -1128,18 +1128,18 @@ public:
      * Returns amount of debit if the input matches the
      * filter, otherwise returns 0
      */
-    CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
+    CAmount GetDebit(const CTxIn& txin, const isminefilter& filter, isminefilter* mineTypes = nullptr) const;
     isminetype IsMine(const CTxOut& txout) const;
-    CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
+    CAmount GetCredit(const CTxOut& txout, const isminefilter& filter, isminefilter* mineTypes = nullptr) const;
     bool IsChange(const CTxOut& txout) const;
     CAmount GetChange(const CTxOut& txout) const;
     bool IsMine(const CTransaction& tx) const;
     /** should probably be renamed to IsRelevantToMe */
     bool IsFromMe(const CTransaction& tx) const;
-    CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
+    CAmount GetDebit(const CTransaction& tx, const isminefilter& filter, isminefilter* mineTypes = nullptr) const;
     /** Returns whether all of the inputs match the filter */
     bool IsAllFromMe(const CTransaction& tx, const isminefilter& filter) const;
-    CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
+    CAmount GetCredit(const CTransaction& tx, const isminefilter& filter, isminefilter* mineTypes = nullptr) const;
     CAmount GetChange(const CTransaction& tx) const;
     void SetBestChain(const CBlockLocator& loc) override;
 


### PR DESCRIPTION
Reworked transaction records - improves watched address handling and future transactions.  Fixes #29.

Watched addresses act like a secondary, non-spendable wallet.  So, sending a transaction from your wallet to a watched address will generate two records in the transaction log - the send and the watched receive.
