### PR TITLE
Add POW Cache support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -549,6 +549,8 @@ libraptoreum_consensus_a_SOURCES = \
   prevector.h \
   primitives/block.cpp \
   primitives/block.h \
+  primitives/powcache.cpp \
+  primitives/powcache.h \
   primitives/transaction.cpp \
   primitives/transaction.h \
   pubkey.cpp \

--- a/src/hash.h
+++ b/src/hash.h
@@ -309,7 +309,7 @@ inline uint256 HashGR(const T1 pbegin, const T1 pend, const uint256 PrevBlockHas
 			lenToHash = 64;
 		}
 		int coreSelection;
-		int cnSelection = -1;   
+		int cnSelection = -1;
 		if(i < 5) {
 			coreSelection = coreHashIndexes[i];
 		} else if(i < 11) {

--- a/src/hash.h
+++ b/src/hash.h
@@ -309,7 +309,7 @@ inline uint256 HashGR(const T1 pbegin, const T1 pend, const uint256 PrevBlockHas
 			lenToHash = 64;
 		}
 		int coreSelection;
-		int cnSelection = -1;
+		int cnSelection = -1;   
 		if(i < 5) {
 			coreSelection = coreHashIndexes[i];
 		} else if(i < 11) {
@@ -332,6 +332,6 @@ inline uint256 HashGR(const T1 pbegin, const T1 pend, const uint256 PrevBlockHas
 		coreHash(toHash, &hash[i], lenToHash, coreSelection);
 		cnHash(&hash[i-1], &hash[i], lenToHash, cnSelection);
 	}
-	return hash[17].trim256();;
+	return hash[17].trim256();
 }
 #endif // BITCOIN_HASH_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -68,6 +68,8 @@
 #include <llmq/quorums_signing.h>
 #include <llmq/quorums_utils.h>
 
+#include <primitives/powcache.h>
+
 #include <statsd_client.h>
 
 #include <stdint.h>
@@ -281,6 +283,8 @@ void PrepareShutdown()
             CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
             flatdb3.Dump(governance);
         }
+        CFlatDB<CPowCache> flatdb7("powcache.dat", "powCache");
+        flatdb7.Dump(CPowCache::Instance());
     }
 
     // After the threads that potentially access these pointers have been stopped,
@@ -2214,6 +2218,19 @@ bool AppInitMain()
         CNetFulfilledRequestManager netfulfilledmanTmp;
         if(!flatdb4.Dump(netfulfilledmanTmp)) {
             return InitError(_("Failed to clear fulfilled requests cache at") + "\n" + (pathDB / strDBName).string());
+        }
+    }
+
+    strDBName = "powcache.dat";
+    uiInterface.InitMessage(_("Loading POW cache..."));
+    CFlatDB<CPowCache> flatdb7(strDBName, "powCache");
+    if (fLoadCacheFiles) {
+        if(!flatdb7.Load(CPowCache::Instance())) {
+            return InitError(_("Failed to load POW cache from") + "\n" + (pathDB / strDBName).string());
+        }
+    } else {
+        if(!flatdb7.Dump(CPowCache::Instance())) {
+            return InitError(_("Failed to clear POW cache at") + "\n" + (pathDB / strDBName).string());
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2221,17 +2221,12 @@ bool AppInitMain()
         }
     }
 
+    // Always load the powcache if available:
     strDBName = "powcache.dat";
     uiInterface.InitMessage(_("Loading POW cache..."));
     CFlatDB<CPowCache> flatdb7(strDBName, "powCache");
-    if (fLoadCacheFiles) {
-        if(!flatdb7.Load(CPowCache::Instance())) {
-            return InitError(_("Failed to load POW cache from") + "\n" + (pathDB / strDBName).string());
-        }
-    } else {
-        if(!flatdb7.Dump(CPowCache::Instance())) {
-            return InitError(_("Failed to clear POW cache at") + "\n" + (pathDB / strDBName).string());
-        }
+    if(!flatdb7.Load(CPowCache::Instance())) {
+        return InitError(_("Failed to load POW cache from") + "\n" + (pathDB / strDBName).string());
     }
 
     // ********************************************************* Step 10c: schedule Raptoreum-specific tasks

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -9,6 +9,8 @@
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
+#include <util.h>
+#include <unordered_lru_cache.h>
 
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,

--- a/src/primitives/powcache.cpp
+++ b/src/primitives/powcache.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 The Raptoreum developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <primitives/powcache.h>
+#include <hash.h>
+#include <util.h>
+
+CPowCache* CPowCache::instance = nullptr;
+
+CPowCache& CPowCache::Instance()
+{
+    if (CPowCache::instance == nullptr)
+    {
+        int powCacheSize = gArgs.GetArg("-powhashcache", DEFAULT_POW_CACHE_SIZE);
+        powCacheSize = powCacheSize == 0 ? DEFAULT_POW_CACHE_SIZE : powCacheSize;
+
+        CPowCache::instance = new CPowCache(powCacheSize);
+    }
+    return *instance;
+}
+
+CPowCache::CPowCache(int maxSize) : unordered_lru_cache<uint256, uint256, std::hash<uint256>>(maxSize)
+{
+}
+
+CPowCache::~CPowCache()
+{
+}
+
+void CPowCache::Clear()
+{
+   cacheMap.clear();
+}
+
+void CPowCache::CheckAndRemove()
+{
+}
+
+std::string CPowCache::ToString() const
+{
+    std::ostringstream info;
+    info << "Powcache: elements: " << (int)cacheMap.size();
+    return info.str();
+}

--- a/src/primitives/powcache.h
+++ b/src/primitives/powcache.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2022 The Raptoreum developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RTM_POWCACHE_H
+#define RTM_POWCACHE_H
+
+#include <uint256.h>
+#include <sync.h>
+#include <serialize.h>
+#include <unordered_lru_cache.h>
+#include <util.h>
+
+class CPowCache : public unordered_lru_cache<uint256, uint256, std::hash<uint256>>
+{
+    private:
+        static CPowCache* instance;
+        static const int CURRENT_VERSION = 1;
+
+        int nVersion;
+        CCriticalSection cs;
+
+    public:
+        static CPowCache& Instance();
+
+        CPowCache(int maxSize = DEFAULT_POW_CACHE_SIZE);
+        virtual ~CPowCache();
+
+        void Clear();
+        void CheckAndRemove();
+
+        std::string ToString() const;
+
+
+
+        ADD_SERIALIZE_METHODS
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
+        {
+            LOCK(cs);
+            READWRITE(nVersion);
+
+            uint64_t cacheSize = (uint64_t)cacheMap.size();
+            READWRITE(COMPACTSIZE(cacheSize));
+
+            if (ser_action.ForRead())
+            {
+                uint256 headerHash;
+                uint256 powHash;
+                for (int i = 0; i < cacheSize; ++i)
+                {
+                    READWRITE(headerHash);
+                    READWRITE(powHash);
+                    insert(headerHash, powHash);
+                }
+            }
+            else
+            {
+                for (auto it = cacheMap.begin(); it != cacheMap.end(); ++it)
+                {
+                    uint256 headerHash = it->first;
+                    uint256 powHash    = it->second.first;
+                    READWRITE(headerHash);
+                    READWRITE(powHash);
+                };
+            }
+        }
+};
+
+#endif // RTM_POWCACHE_H

--- a/src/unordered_lru_cache.h
+++ b/src/unordered_lru_cache.h
@@ -11,7 +11,7 @@
 template<typename Key, typename Value, typename Hasher, size_t MaxSize = 0, size_t TruncateThreshold = 0>
 class unordered_lru_cache
 {
-private:
+protected:
     typedef std::unordered_map<Key, std::pair<Value, int64_t>, Hasher> MapType;
 
     MapType cacheMap;
@@ -24,7 +24,7 @@ public:
         maxSize(_maxSize),
         truncateThreshold(_truncateThreshold == 0 ? _maxSize * 2 : _truncateThreshold)
     {
-        // either specify maxSize through template arguments or the contructor and fail otherwise
+        // either specify maxSize through template arguments or the constructor and fail otherwise
         assert(_maxSize != 0);
     }
 


### PR DESCRIPTION
This PR expands on the POW LRU cache, saving and loading the cache from disk.  This dramatically speeds up (20-30x) re-syncing/rescanning processes and is also helpful for develop/debug testing cycles.