### PR TITLE
Fixed verification bug with future tx validation

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -21,7 +21,7 @@
 #include <coins.h>
 #include <utilmoneystr.h>
 
-extern CChain chainActive;
+extern CChain& chainActive;
 
 static void checkSpecialTxFee(const CTransaction &tx, CAmount& nFeeTotal, CAmount& specialTxFee) {
 	if(tx.nVersion >= 3) {


### PR DESCRIPTION
This was a subtle bug, but the extern was not by reference, so the activeChain was wrong.  The wrong reference was only used by the future TX verification logic.