### PR TITLE
Minor cleanup of uint512, unit/regression test updates.

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -170,11 +170,17 @@ std::string base_uint<BITS>::GetHex() const
 	}
 }
 
-//template <unsigned int BITS>
-//void base_uint<BITS>::SetHex(const char* psz)
-//{
-//    *this = UintToArith256(uint256S(psz));
-//}
+template <>
+void base_uint<256>::SetHex(const char* psz)
+{
+   *this = UintToArith256(uint256S(psz));
+}
+
+template <>
+void base_uint<512>::SetHex(const char* psz)
+{
+   *this = UintToArith512(uint512S(psz));
+}
 
 template <unsigned int BITS>
 void base_uint<BITS>::SetHex(const std::string& str)
@@ -316,10 +322,7 @@ template base_uint<512>& base_uint<512>::operator/=(const base_uint<512>& b);
 template int base_uint<512>::CompareTo(const base_uint<512>&) const;
 template bool base_uint<512>::EqualTo(uint64_t) const;
 template double base_uint<512>::getdouble() const;
-template std::string base_uint<512>::GetHex() const;
 template std::string base_uint<512>::ToString() const;
-template void base_uint<512>::SetHex(const char*);
-template void base_uint<512>::SetHex(const std::string&);
 template unsigned int base_uint<512>::bits() const;
 template int base_uint<512>::GET_WIDTH() const;
 template uint32_t base_uint<512>::GET_PN(int index) const;

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -212,14 +212,6 @@ public:
         return ret;
     }
 
-    void SetHex(const char* psz) {
-    	base_uint<BITS> b;
-		for(int x=0; x<b.WIDTH; ++x) {
-			memcpy((char*)&b.pn[x], psz + x*4, 4);
-		}
-		*this = b;
-    }
-
     int CompareTo(const base_uint& b) const;
     bool EqualTo(uint64_t b) const;
 
@@ -245,6 +237,7 @@ public:
     int GET_WIDTH() const;
     uint32_t GET_PN(int index) const;
     std::string GetHex() const;
+    void SetHex(const char* str);
     void SetHex(const std::string& str);
     std::string ToString() const;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -985,10 +985,10 @@ public:
         nDefaultPort = 19899;
         nPruneAfterHeight = 1000;
 
-        genesis = CreateGenesisBlock(1417713337, 1096447, 0x207fffff, 1, 50 * COIN);
+        genesis = CreateGenesisBlock(1614369600, 1130, 0x20001fff, 4, 5000 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x000008ca1832a4baf228eb1553c03d3a2c8e02399550dd6ea8d65cec3ef23d2e"));
-        assert(genesis.hashMerkleRoot == uint256S("0xe0028eb9648db56b1ac77cf090b99048a8007e2bb64b68f092c03c7f56a662c7"));
+        assert(consensus.hashGenesisBlock == uint256S("0xb79e5df07278b9567ada8fc655ffbfa9d3f586dc38da3dd93053686f41caeea0"));
+        assert(genesis.hashMerkleRoot == uint256S("0x87a48bc22468acdd72ee540aab7c086a5bbcddc12b51c6ac925717a74c269453"));
         consensus.nFutureRewardShare = Consensus::FutureRewardShare(0.8,0.2,0.0);
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
@@ -1009,7 +1009,7 @@ public:
         nPoolNewMaxParticipants = 20;
 
         // privKey: cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK
-        vSporkAddresses = {"yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW"};
+        vSporkAddresses = {"RWGvGpd3yJdnfh9ziyHNDEoHMJBvnZ23zK"};
         nMinSporkKeys = 1;
         // regtest usually has no smartnodes in most tests, so don't check for upgraged MNs
         fBIP9CheckSmartnodesUpgraded = false;

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(ToStringTest)
 {
     CFeeRate feeRate;
     feeRate = CFeeRate(1);
-    BOOST_CHECK_EQUAL(feeRate.ToString(), "0.00000001 RAPTOREUM/kB");
+    BOOST_CHECK_EQUAL(feeRate.ToString(), "0.00000001 RTM/kB");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -78,4 +78,10 @@ template std::string base_blob<256>::GetHex() const;
 template std::string base_blob<256>::ToString() const;
 template void base_blob<256>::SetHex(const char*);
 template void base_blob<256>::SetHex(const std::string&);
+
+// Explicit instantiations for base_blob<512>
+template base_blob<512>::base_blob(const std::vector<unsigned char>&);
 template std::string base_blob<512>::GetHex() const;
+template std::string base_blob<512>::ToString() const;
+template void base_blob<512>::SetHex(const char*);
+template void base_blob<512>::SetHex(const std::string&);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -181,6 +181,27 @@ public:
     }
 };
 
+/* uint512 from const char *.
+* This is a separate function because the constructor uint512(const char*) can result
+* in dangerously catching uint512(0).
+*/
+inline uint512 uint512S(const char *str)
+{
+    uint512 rv;
+    rv.SetHex(str);
+    return rv;
+}
+/* uint512 from std::string.
+* This is a separate function because the constructor uint512(const std::string &str) can result
+* in dangerously catching uint512(0) via std::string(const char*).
+*/
+inline uint512 uint512S(const std::string& str)
+{
+    uint512 rv;
+    rv.SetHex(str);
+    return rv;
+}
+
 namespace std {
     template <>
     struct hash<uint256>


### PR DESCRIPTION
Updated uint512 and SetHex operations to be more consistent with the uint256 implementations.

I made some updates to the regression and unit test setup for testing the arithmetic operations.  Further work is needed to adapt the full test suite.

I ran a full sync on the mainnet with this code with no issues.