### PR TITLE
Fixed protx list issue for valid nodes with collateral changes

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -382,6 +382,16 @@ public:
     }
 
     template <typename Callback>
+    void ForEachMN(bool onlyValid, int height, Callback&& cb) const
+    {
+        for (const auto& p : mnMap) {
+            if (!onlyValid || IsMNValid(p.second, height)) {
+                cb(p.second);
+            }
+        }
+    }
+
+    template <typename Callback>
     void ForEachMN(bool onlyValid, Callback&& cb) const
     {
         for (const auto& p : mnMap) {
@@ -415,6 +425,7 @@ public:
 
     bool IsMNValid(const uint256& proTxHash) const;
     bool IsMNPoSeBanned(const uint256& proTxHash) const;
+    static bool IsMNValid(const CDeterministicMNCPtr& dmn, int height);
     static bool IsMNValid(const CDeterministicMNCPtr& dmn);
     static bool IsMNPoSeBanned(const CDeterministicMNCPtr& dmn);
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1343,7 +1343,7 @@ UniValue protx_list(const JSONRPCRequest& request)
         }
 
         std::vector<COutPoint> vOutpts;
-        pwallet->ListProTxCoins(vOutpts);
+        pwallet->ListProTxCoins(height, vOutpts);
         std::set<COutPoint> setOutpts;
         for (const auto& outpt : vOutpts) {
             setOutpts.emplace(outpt);
@@ -1374,9 +1374,16 @@ UniValue protx_list(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid height specified");
         }
 
+        cout << "protx_list: height" << height << ", chainActive.Height(): " << chainActive.Height() << ", fSpentIndex: " << fSpentIndex << endl;
+
+        if (height != chainActive.Height() && !fSpentIndex)
+        {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "specifying height requires spentindex enabled");
+        }
+
         CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(chainActive[height]);
         bool onlyValid = type == "valid";
-        mnList.ForEachMN(onlyValid, [&](const CDeterministicMNCPtr& dmn) {
+        mnList.ForEachMN(onlyValid, height, [&](const CDeterministicMNCPtr& dmn) {
             ret.push_back(BuildDMNListEntry(pwallet, dmn, detailed));
         });
     } else {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4842,9 +4842,8 @@ void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts) const
     }
 }
 
-void CWallet::ListProTxCoins(std::vector<COutPoint>& vOutpts) const
+void CWallet::GetProTxCoins(const CDeterministicMNList& mnList, std::vector<COutPoint>& vOutpts) const
 {
-    auto mnList = deterministicMNManager->GetListAtChainTip();
     AssertLockHeld(cs_wallet);
     for (const auto &o : setWalletUTXO) {
         auto it = mapWallet.find(o.hash);
@@ -4855,6 +4854,16 @@ void CWallet::ListProTxCoins(std::vector<COutPoint>& vOutpts) const
             }
         }
     }
+}
+
+void CWallet::ListProTxCoins(int height, std::vector<COutPoint>& vOutpts) const
+{
+    GetProTxCoins(deterministicMNManager->GetListForBlock(chainActive[height]), vOutpts);
+}
+
+void CWallet::ListProTxCoins(std::vector<COutPoint>& vOutpts) const
+{
+    GetProTxCoins(deterministicMNManager->GetListAtChainTip(), vOutpts);
 }
 
 /** @} */ // end of Actions

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -963,6 +963,8 @@ public:
     void UnlockCoin(const COutPoint& output) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void UnlockAllCoins() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void ListLockedCoins(std::vector<COutPoint>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void GetProTxCoins(const CDeterministicMNList& mnList, std::vector<COutPoint>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void ListProTxCoins(int height, std::vector<COutPoint>& vOutpts)  const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void ListProTxCoins(std::vector<COutPoint>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /*


### PR DESCRIPTION
This resolves #110 

`protx list valid` when specifying a height (other than the tip), does not properly account for collateral upgrades.

See #58 for original work.
