### PR TITLE
Remove redundant icon pixmap dance to fix icon render fuckup.

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -206,28 +206,8 @@ QString getThemedStyleQString(ThemedStyle style)
 
 QIcon getIcon(const QString& strIcon, const ThemedColor color, const ThemedColor colorAlternative, const QString& strIconPath)
 {
-    QColor qcolor = getThemedQColor(color);
-    QColor qcolorAlternative = getThemedQColor(colorAlternative);
     QIcon icon(strIconPath + strIcon);
-    QIcon themedIcon;
-    for (const QSize& size : icon.availableSizes()) {
-        QImage image(icon.pixmap(size).toImage());
-        image = image.convertToFormat(QImage::Format_ARGB32);
-        for (int x = 0; x < image.width(); ++x) {
-            for (int y = 0; y < image.height(); ++y) {
-                const QRgb rgb = image.pixel(x, y);
-                QColor* pColor;
-                if ((rgb & RGB_MASK) < RGB_HALF) {
-                    pColor = &qcolor;
-                } else {
-                    pColor = &qcolorAlternative;
-                }
-                image.setPixel(x, y, qRgba(pColor->red(), pColor->green(), pColor->blue(), qAlpha(rgb)));
-            }
-        }
-        themedIcon.addPixmap(QPixmap::fromImage(image));
-    }
-    return themedIcon;
+    return icon;
 }
 
 QIcon getIcon(const QString& strIcon, const ThemedColor color, const QString& strIconPath)


### PR DESCRIPTION
From this:
<img width="117" alt="crap1" src="https://user-images.githubusercontent.com/183117/160239243-42869a5f-4fdd-4fc1-a89f-6baddcbbf748.png">
<img width="127" alt="crap2" src="https://user-images.githubusercontent.com/183117/160239244-f6441774-b193-4857-9540-00c004a82b2f.png">

To:
<img width="116" alt="Screenshot 2022-03-26 at 14 02 39" src="https://user-images.githubusercontent.com/183117/160239251-21e72215-e2e6-4f20-9c0b-4afaed544a08.png">
<img width="126" alt="better" src="https://user-images.githubusercontent.com/183117/160239255-bb28b363-87fb-482f-a55c-cd1f08dbb7c2.png">


