### PR TITLE
Slow RPC call to getblockchaininfo during header sync

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -11,13 +11,16 @@
 void CChain::SetTip(CBlockIndex *pindex) {
     if (pindex == nullptr) {
         vChain.clear();
-        return;
     }
-    vChain.resize(pindex->nHeight + 1);
-    while (pindex && vChain[pindex->nHeight] != pindex) {
-        vChain[pindex->nHeight] = pindex;
-        pindex = pindex->pprev;
+    else
+    {
+        vChain.resize(pindex->nHeight + 1);
+        while (pindex && vChain[pindex->nHeight] != pindex) {
+            vChain[pindex->nHeight] = pindex;
+            pindex = pindex->pprev;
+        }
     }
+    atomicHeight = Height();
 }
 
 CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {

--- a/src/chain.h
+++ b/src/chain.h
@@ -442,6 +442,7 @@ public:
 class CChain {
 private:
     std::vector<CBlockIndex*> vChain;
+    std::atomic<size_t> atomicHeight;
 
 public:
     /** Returns the index entry for the genesis block of this chain, or nullptr if none. */
@@ -483,6 +484,11 @@ public:
     /** Return the maximal height in the chain. Is equal to chain.Tip() ? chain.Tip()->nHeight : -1. */
     int Height() const {
         return vChain.size() - 1;
+    }
+
+    /** Return the Height - no lock required */
+    int AtomicHeight() const {
+        return atomicHeight;
     }
 
     /** Set/initialize a chain with a given tip. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3989,7 +3989,10 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
         // Start block sync
         if (pindexBestHeader == nullptr)
+        {
             pindexBestHeader = chainActive.Tip();
+            atomicHeaderHeight = pindexBestHeader ? pindexBestHeader->nHeight : -1;
+        }
         bool fFetch = state.fPreferredDownload || (nPreferredDownload == 0 && !pto->fClient && !pto->fOneShot); // Download if this is a nice peer, or we have no nice peers and this one might do.
         if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex && pto->CanRelay()) {
             // Only actively request headers from a single peer, unless we're close to end of initial download.

--- a/src/validation.h
+++ b/src/validation.h
@@ -163,6 +163,8 @@ extern CConditionVariable g_best_block_cv;
 extern uint256 g_best_block;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
+extern std::atomic_bool fProcessingHeaders;
+extern std::atomic<int> atomicHeaderHeight;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern bool fAddressIndex;


### PR DESCRIPTION
Resovles #157 
Added flag for header sync and atomic accessors for key blockchain data.

During header sync, the RPC call getblockchaininfo could take several minutes to return, causing problems with scripts monitoring nodes.  With the new logic in place, the RPC call was always returning quickly and during the entire sync process, the longest wait I had on my local machine was 157mSec.