### PR TITLE
Avoid potential deadlock when a new smart node is added.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2651,21 +2651,19 @@ void CConnman::ThreadOpenSmartnodeConnections()
 
         CDeterministicMNCPtr connectToDmn;
         bool isProbe = false;
-        { // don't hold lock while calling OpenSmartnodeConnection as cs_main is locked deep inside
-            {
-                // GetValidMN also acquires cs_main (GetUTXOCoin), avoid a deadlock with cs_vNodes by locking only cs_vPendingSmartnodes here
-                LOCK(cs_vPendingSmartnodes);
-                if (!vPendingSmartnodes.empty()) {
-                    auto dmn = mnList.GetValidMN(vPendingSmartnodes.front());
-                    vPendingSmartnodes.erase(vPendingSmartnodes.begin());
-                    if (dmn && !connectedNodes.count(dmn->pdmnState->addr) && !IsSmartnodeOrDisconnectRequested(dmn->pdmnState->addr)) {
-                        connectToDmn = dmn;
-                        LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- opening pending smartnode connection to %s, service=%s\n", __func__, dmn->proTxHash.ToString(), dmn->pdmnState->addr.ToString(false));
-                    }
+        {
+            LOCK(cs_main); // Lock cs_main first to avoid deadlocks (it is recursively locked deeper)
+            LOCK2(cs_vNodes, cs_vPendingSmartnodes);
+
+            if (!vPendingSmartnodes.empty()) {
+                auto dmn = mnList.GetValidMN(vPendingSmartnodes.front());
+                vPendingSmartnodes.erase(vPendingSmartnodes.begin());
+                if (dmn && !connectedNodes.count(dmn->pdmnState->addr) && !IsSmartnodeOrDisconnectRequested(dmn->pdmnState->addr)) {
+                    connectToDmn = dmn;
+                    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- opening pending smartnode connection to %s, service=%s\n", __func__, dmn->proTxHash.ToString(), dmn->pdmnState->addr.ToString(false));
                 }
             }
 
-            LOCK2(cs_vNodes, cs_vPendingSmartnodes);
             if (!connectToDmn) {
                 std::vector<CDeterministicMNCPtr> pending;
                 for (const auto& group : smartnodeQuorumNodes) {


### PR DESCRIPTION
This fixes a potential deadlock when a new smart node is added.
