### PR TITLE
missing headers at src/chain.h

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -6,6 +6,9 @@
 #ifndef BITCOIN_CHAIN_H
 #define BITCOIN_CHAIN_H
 
+#include <atomic>
+#include <memory>
+
 #include <arith_uint256.h>
 #include <consensus/params.h>
 #include <primitives/block.h>

--- a/src/chain.h
+++ b/src/chain.h
@@ -7,7 +7,6 @@
 #define BITCOIN_CHAIN_H
 
 #include <atomic>
-#include <memory>
 
 #include <arith_uint256.h>
 #include <consensus/params.h>


### PR DESCRIPTION
Fixing compilation error under ubuntu due to:
"incomplete type std::atomic<size_t> atomicHeight"
included and brought at #158