### PR TITLE
Fix libbacktrace compile on alpine/musl arch.

### DIFF
--- a/depends/packages/backtrace.mk
+++ b/depends/packages/backtrace.mk
@@ -9,6 +9,7 @@ $(package)_config_opts=--disable-shared --enable-host-shared --prefix=$(host_pre
 endef
 
 define $(package)_config_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub . && \
   $($(package)_autoconf)
 endef
 


### PR DESCRIPTION
Alpine is using musl architecture. It is not properly detected now with the 2018 version of libbacktrace.
This fix allows proper dependency build on the alpine system.
I tested it on the current develop chain and it compiled, synced, and run just fine.

Same thing as was referenced and pushed on Dash repo: https://github.com/dashpay/dash/pull/4417