### PR TITLE
Use atomic instead of lock for RPC getblockcount.

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -195,8 +195,7 @@ UniValue getblockcount(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockcount", "")
         );
 
-    LOCK(cs_main);
-    return chainActive.Height();
+    return chainActive.AtomicHeight();
 }
 
 UniValue getbestblockhash(const JSONRPCRequest& request)


### PR DESCRIPTION
Updated RPC getblockcount call to use atomic fetch instead of locked access to prevent delays.