### PR TITLE
Updated AvailableCoins to mark future, immature transactions NOT safe.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3016,7 +3016,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
         if (nDepth == 0 && !pcoin->InMempool())
             continue;
 
-        bool safeTx = pcoin->IsTrusted();
+        bool safeTx = pcoin->IsTrusted(); // This doesn't account for future Tx outputs - we check that below.
 
         if (fOnlySafe && !safeTx) {
             continue;
@@ -3065,9 +3065,9 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
 
             bool fSpendableIn = ((mine & ISMINE_SPENDABLE) != ISMINE_NO) || (coinControl && coinControl->fAllowWatchOnly && (mine & ISMINE_WATCH_SOLVABLE) != ISMINE_NO);
             bool fSolvableIn = (mine & (ISMINE_SPENDABLE | ISMINE_WATCH_SOLVABLE)) != ISMINE_NO;
-            bool isCoinSpenable = pcoin->isFutureSpendable(i);
+            bool isCoinSpendable = pcoin->isFutureSpendable(i);
 
-            vCoins.push_back(COutput(pcoin, i, nDepth, fSpendableIn, fSolvableIn, safeTx, pcoin->tx->nType == TRANSACTION_FUTURE, isCoinSpenable));
+            vCoins.push_back(COutput(pcoin, i, nDepth, fSpendableIn, fSolvableIn, safeTx && isCoinSpendable, pcoin->tx->nType == TRANSACTION_FUTURE, isCoinSpendable));
             // Checks the sum amount of all UTXO's.
             if (nMinimumSumAmount != MAX_MONEY) {
                 nTotal += pcoin->tx->vout[i].nValue;


### PR DESCRIPTION
Resolves #153

Updated to exclude immature future transactions from "safe" unspent coins.  For a test, I sent 1000 tRTM in the future.  The transaction returned ~60 tRTM back to me.  Here is what `listunspent 0 100` returned:
```
test
[
  {
    "txid": "bde02875bc87cf5df93a5b32b3e127491133c9b9a64fb527940f640c048de911",
    "vout": 0,
    "address": "rjnEvY9mAjRVRSuQkt88dT75YmEEs9S1XK",
    "scriptPubKey": "76a9149bd919e0082e2aec04ccd98dea6de8971643582b88ac",
    "amount": 59.99999805,
    "confirmations": 1,
    "spendable": true,
    "solvable": true,
    "future": true,
    "futureSpendable": true,
    "safe": true,
    "coinjoin_rounds": -2
  },
  {
    "txid": "bde02875bc87cf5df93a5b32b3e127491133c9b9a64fb527940f640c048de911",
    "vout": 1,
    "address": "rk16VAsP39xUReLG76NRiGfDch74xh19Cr",
    "label": "Fut Dest",
    "scriptPubKey": "76a9149e47772601b4c9cb83808ae0e050e69cb16d7d1788ac",
    "amount": 1000.00000000,
    "confirmations": 1,
    "spendable": true,
    "solvable": true,
    "future": true,
    "futureSpendable": false,
    "safe": false,
    "coinjoin_rounds": -2
  }
]
```

The returned coins are spendable/safe, but the future transaction is not.