### PR TITLE
Clarified "Subtract fee from amount" when sending future transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Raptoreum Core staging tree 0.17
 |CI|master|develop|
 |-|-|-|
 
-The name Raptoreum is derived from the Victoria term for a bird of prey and ium/eum place for a pertaining to in this case birds of prey. The name comes from the team’s extensive experience in the security field with top level skills covering all aspects of it. This is a unique strength in the crypto community and will leverage well into a successful project.
+The name Raptoreum is derived from the Victorian term for a bird of prey and ium/eum place for a pertaining to in this case birds of prey. The name comes from the team’s extensive experience in the security field with top level skills covering all aspects of it. This is a unique strength in the crypto community and will leverage well into a successful project.
 
 Introduction
 Raptoreum began as the fairly simple idea, introducing smart contracts which would allow on chain, trustless transfers (goodbye centralized marketplaces) on the Ravencoin codebase, however with the automation of assets and RTM (Raptoreum).

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -166,10 +166,10 @@
       <item>
        <widget class="QCheckBox" name="checkboxSubtractFeeFromAmount">
         <property name="toolTip">
-         <string>The fee will be deducted from the amount being sent. The recipient will receive a lower amount of Raptoreum than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
+         <string>The network fee will be deducted from the amount being sent. The recipient will receive a lower amount of Raptoreum than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
         </property>
         <property name="text">
-         <string>S&amp;ubtract fee from amount</string>
+         <string>S&amp;ubtract network fee from amount</string>
         </property>
        </widget>
       </item>
@@ -179,7 +179,7 @@
          <string>Enable/Disable future transaction</string>
         </property>
         <property name="text">
-         <string>future</string>
+         <string>Future</string>
         </property>
        </widget>
       </item>

--- a/src/qt/sendfuturesdialog.cpp
+++ b/src/qt/sendfuturesdialog.cpp
@@ -453,7 +453,7 @@ void SendFuturesDialog::send(QList<SendFuturesRecipient> recipients)
         questionString.append("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'><b>No maturity is set. Transaction will mature as normal.</b></span>");
     }
 
-    // Show some additioinal information
+    // Show some additional information
     questionString.append("<hr />");
     // append transaction size
     questionString.append(tr("Transaction size: %1").arg(QString::number((double)currentTransaction.getTransactionSize() / 1000)) + " kB");


### PR DESCRIPTION
I looked at subtracting the future tx fee from the amount, but realized that it is handled separately from the normal network fees.

Instead of changing the model to track two sets of fees, I have updated the checkbox on the dialog to indicate network fees, and it now shows the networks fees and special transaction fee in the confirmation dialog.

## Examples:

### Single transaction:
![image](https://user-images.githubusercontent.com/88252561/181934049-a3d7d69e-cd70-4649-b164-72ad95399ad6.png)
![image](https://user-images.githubusercontent.com/88252561/181934062-8fce6892-369b-4b0a-8ae8-eeaa4ee11bf1.png)

### Multiple transactions:
![image](https://user-images.githubusercontent.com/88252561/181934088-41128d90-0f08-48ba-9301-16f231251964.png)
![image](https://user-images.githubusercontent.com/88252561/181934100-ba5e4bd1-1bc4-4b37-9edb-e82a3f51d4e8.png)

This resolves #150 