### PR TITLE
Add icon future transaction

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -55,8 +55,8 @@ static const char *validateFutureCoin(const Coin& coin, int nSpendHeight) {
 			CFutureTx futureTx;
 			if(GetTxPayload(coin.vExtraPayload, futureTx)) {
                 		bool isBlockMature = futureTx.maturity > 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
-               			bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
-                		bool canSpend = isBlockMature || isTimeMature;
+				bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
+				bool canSpend = isBlockMature || isTimeMature;
 				if(!canSpend) {
 					return "bad-txns-premature-spend-of-future";
 				}

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -54,9 +54,9 @@ static const char *validateFutureCoin(const Coin& coin, int nSpendHeight) {
 			uint32_t confirmedTime = confirmedBlockIndex->GetBlockTime();
 			CFutureTx futureTx;
 			if(GetTxPayload(coin.vExtraPayload, futureTx)) {
-                		bool isBlockMature = futureTx.maturity > 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
-				bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
-				bool canSpend = isBlockMature || isTimeMature;
+                bool isBlockMature = futureTx.maturity > 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
+                bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
+                bool canSpend = isBlockMature || isTimeMature;
 				if(!canSpend) {
 					return "bad-txns-premature-spend-of-future";
 				}

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -54,9 +54,9 @@ static const char *validateFutureCoin(const Coin& coin, int nSpendHeight) {
 			uint32_t confirmedTime = confirmedBlockIndex->GetBlockTime();
 			CFutureTx futureTx;
 			if(GetTxPayload(coin.vExtraPayload, futureTx)) {
-				bool isBlockMature = futureTx.maturity > 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
-				bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
-				bool canSpend = isBlockMature || isTimeMature;
+                		bool isBlockMature = futureTx.maturity > 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
+               			bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
+                		bool canSpend = isBlockMature || isTimeMature;
 				if(!canSpend) {
 					return "bad-txns-premature-spend-of-future";
 				}

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -54,8 +54,8 @@ static const char *validateFutureCoin(const Coin& coin, int nSpendHeight) {
 			uint32_t confirmedTime = confirmedBlockIndex->GetBlockTime();
 			CFutureTx futureTx;
 			if(GetTxPayload(coin.vExtraPayload, futureTx)) {
-                bool isBlockMature = futureTx.maturity > 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
-                bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
+                bool isBlockMature = futureTx.maturity >= 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
+                bool isTimeMature = futureTx.lockTime >= 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
                 bool canSpend = isBlockMature || isTimeMature;
 				if(!canSpend) {
 					return "bad-txns-premature-spend-of-future";

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -366,7 +366,7 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients)
                 } else {
                     recipientElement.append("This transaction will likely mature based on time.");
                 }
-            } else if(recipients[0].maturity <= 0 && recipients[0].locktime <= 0){
+            else if(recipients[0].maturity < 0 && recipients[0].locktime < 0){
                 recipientElement.append("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'><b>No maturity is set. Transaction will mature as normal.</b></span>");
             }
         }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -352,14 +352,14 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients)
         //std::cout << rcp.amount << " is future output " << rcp.isFutureOutput << "\n";
         if(rcp.isFutureOutput) {
             hasFuture = true;
-            if(recipients[0].maturity > 0) {
+            if(recipients[0].maturity >= 0) {
                 recipientElement.append(tr("<br>Confirmations in: <b>%1 blocks</b><br />").arg(recipients[0].maturity));
             }
-            if(recipients[0].locktime > 0) {
+            if(recipients[0].locktime >= 0) {
                 recipientElement.append(tr("Time in: <b>%1 seconds from first confirmed</b><br />")
                                                 .arg(recipients[0].locktime));
             }
-            if(recipients[0].maturity > 0 && recipients[0].locktime > 0) {
+            if(recipients[0].maturity >= 0 && recipients[0].locktime >= 0) {
                 int calcBlock = (recipients[0].maturity * 2 * 60);
                 if(calcBlock < recipients[0].locktime) {
                     recipientElement.append("This transaction will likely mature based on confirmations.");

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -366,7 +366,7 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients)
                 } else {
                     recipientElement.append("This transaction will likely mature based on time.");
                 }
-            else if(recipients[0].maturity < 0 && recipients[0].locktime < 0){
+            } else if(recipients[0].maturity < 0 && recipients[0].locktime < 0){
                 recipientElement.append("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'><b>No maturity is set. Transaction will mature as normal.</b></span>");
             }
         }

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -84,7 +84,7 @@ QString TransactionDesc::FutureTxDescToHTML(const interfaces::WalletTx& wtx, con
         strHTML += "<b>Future Amount:</b> " + BitcoinUnits::formatHtmlWithUnit(unit, ftxValue) + "<br>";
         if (status.is_in_main_chain)
         {
-        	if(ftx.maturity > 0) {
+        	if(ftx.maturity >= 0) {
 				strHTML += tr("<b>Maturity Block:</b> %1").arg(maturityBlock);
 				if(maturityBlock >= currentHeight)
 				{
@@ -101,7 +101,7 @@ QString TransactionDesc::FutureTxDescToHTML(const interfaces::WalletTx& wtx, con
         	}
         }
 	    
-        if(ftx.lockTime > 0){
+        if(ftx.lockTime >= 0){
             strHTML += "<b>Maturity Time:</b> " + GUIUtil::dateTimeStr(maturityTime) + "<br>";
             strHTML += tr("<b>Locked Time:</b><em> %1 seconds</em><br>").arg(ftx.lockTime);
         }else{

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -84,7 +84,7 @@ QString TransactionDesc::FutureTxDescToHTML(const interfaces::WalletTx& wtx, con
         strHTML += "<b>Future Amount:</b> " + BitcoinUnits::formatHtmlWithUnit(unit, ftxValue) + "<br>";
         if (status.is_in_main_chain)
         {
-        	if(ftx.maturity >= 0) {
+        	if(ftx.maturity > 0) {
 				strHTML += tr("<b>Maturity Block:</b> %1").arg(maturityBlock);
 				if(maturityBlock >= currentHeight)
 				{
@@ -100,9 +100,13 @@ QString TransactionDesc::FutureTxDescToHTML(const interfaces::WalletTx& wtx, con
         		strHTML += tr("<b>Maturity Block:</b> Never<br>");
         	}
         }
-
-        strHTML += "<b>Maturity Time:</b> " + (ftx.lockTime >=0 ? GUIUtil::dateTimeStr(maturityTime) : "Never") + "<br>";
-        strHTML += tr("<b>Locked Time:</b><em> %1 seconds</em><br>").arg(ftx.lockTime);
+	    
+        if(ftx.lockTime > 0){
+            strHTML += "<b>Maturity Time:</b> " + GUIUtil::dateTimeStr(maturityTime) + "<br>";
+            strHTML += tr("<b>Locked Time:</b><em> %1 seconds</em><br>").arg(ftx.lockTime);
+        }else{
+            strHTML += "<b>Maturity Time:</b> Never <br>";
+        }
         strHTML += tr("<b>Locked Output Index:</b> %1<br>").arg(ftx.lockOutputIndex);
         
     }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -83,27 +83,17 @@ void TransactionRecord::getFutureTxStatus(const interfaces::WalletTx& wtx, const
         //transaction depth in chain against maturity OR relative seconds of transaction against lockTime
         if(status.depth == 0)
         {
-                status.status = TransactionStatus::Unconfirmed;
+            status.status = TransactionStatus::Unconfirmed;
         }
         else
         if ((currentHeight >= maturityBlock && ftx.maturity > 0) || (GetAdjustedTime() >= maturityTime && ftx.lockTime > 0)) {
             status.status = TransactionStatus::Confirmed;
         } else {
             status.countsForBalance = false;
-           //display transaction is mature in x blocks or transaction is mature in days hh:mm:ss
-            if(ftx.lockTime <= 0)
-            {
-                status.status = TransactionStatus::OpenUntilBlock;
-                status.open_for = maturityBlock - chainActive.Height(); 
-            }
-            else
-            if(ftx.maturity <= 0)
-            {
-                status.status = TransactionStatus::OpenUntilDate;
-                status.open_for = maturityTime;
-            }
-            else
-            if(((maturityBlock - chainActive.Height()) * 2 * 60) < (maturityTime - GetAdjustedTime()))
+            //display transaction is mature in x blocks or transaction is mature in days hh:mm:ss
+            int64_t blockTimeleft = (maturityBlock - chainActive.Height()) * 2 * 60;
+            int64_t Timeleft = maturityTime - GetAdjustedTime();
+            if((blockTimeleft < Timeleft && ftx.maturity > 0) || ftx.lockTime <= 0)
             {
                 status.status = TransactionStatus::OpenUntilBlock;
                 status.open_for = maturityBlock - chainActive.Height();

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -86,14 +86,14 @@ void TransactionRecord::getFutureTxStatus(const interfaces::WalletTx& wtx, const
             status.status = TransactionStatus::Unconfirmed;
         }
         else
-        if ((currentHeight >= maturityBlock && ftx.maturity > 0) || (GetAdjustedTime() >= maturityTime && ftx.lockTime > 0)) {
+        if ((currentHeight >= maturityBlock && ftx.maturity >= 0) || (GetAdjustedTime() >= maturityTime && ftx.lockTime >= 0)) {
             status.status = TransactionStatus::Confirmed;
         } else {
             status.countsForBalance = false;
             //display transaction is mature in x blocks or transaction is mature in days hh:mm:ss
             int64_t blockTimeleft = (maturityBlock - chainActive.Height()) * 2 * 60;
             int64_t Timeleft = maturityTime - GetAdjustedTime();
-            if((blockTimeleft < Timeleft && ftx.maturity > 0) || ftx.lockTime <= 0)
+            if((blockTimeleft < Timeleft && ftx.maturity >= 0) || ftx.lockTime < 0)
             {
                 status.status = TransactionStatus::OpenUntilBlock;
                 status.open_for = maturityBlock - chainActive.Height();

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -523,8 +523,9 @@ QVariant TransactionTableModel::txStatusDecoration(const TransactionRecord *wtx)
     switch(wtx->status.status)
     {
     case TransactionStatus::OpenUntilBlock:
+        return GUIUtil::getIcon("transaction_locked", GUIUtil::ThemedColor::TX_STATUS_OPENUNTILDATE);
     case TransactionStatus::OpenUntilDate:
-        return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::TX_STATUS_OPENUNTILDATE);
+        return GUIUtil::getIcon("transaction_locked", GUIUtil::ThemedColor::TX_STATUS_OPENUNTILDATE);
     case TransactionStatus::Unconfirmed:
         return GUIUtil::getIcon("transaction_0");
     case TransactionStatus::Abandoned:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2059,8 +2059,8 @@ bool CWalletTx::isFutureSpendable(unsigned int outputIndex) const
         // confirmedTime = currentTime if it is not confirmed so that time maturity math does not need special case
         if(confirmedTime < 0) confirmedTime = adjustCurrentTime;
         if(futureTx.lockOutputIndex == outputIndex) {
-            bool isBlockMature = futureTx.maturity > 0 && maturity >= futureTx.maturity;
-            bool isTimeMature = futureTx.lockTime > 0 && adjustCurrentTime - confirmedTime >= futureTx.lockTime;
+            bool isBlockMature = futureTx.maturity >= 0 && maturity >= futureTx.maturity;
+            bool isTimeMature = futureTx.lockTime >= 0 && adjustCurrentTime - confirmedTime >= futureTx.lockTime;
             isCoinSpendable = isBlockMature || isTimeMature;
         }
         else {


### PR DESCRIPTION
Add icon for future transaction. should solve #40 
fix incorrect selection of future transaction maturity type. always showed as based on time
fix future transaction show as confirmed while still on mempool

![image](https://user-images.githubusercontent.com/28742969/182302824-3e87d020-55d3-40e0-8857-43eec827ed04.png)
![image](https://user-images.githubusercontent.com/28742969/182302933-6c208aff-5b45-4c1a-b41b-d157400cfac0.png)
![image](https://user-images.githubusercontent.com/28742969/182303040-25af3165-17d2-4f1b-be3f-c85e71394506.png)
