### PR TITLE
update macos version action build to 11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,7 +174,7 @@ jobs:
   build-macos:
     name: macos build
     needs: checking-build-version
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -196,7 +196,7 @@ jobs:
       - name: configure
         run: |
           ./autogen.sh
-          ./configure --prefix=`pwd`/depends/x86_64-apple-darwin19.6.0
+          ./configure --prefix=`pwd`/depends/x86_64-apple-darwin20.6.0
       - name: build binary
         run: |
           make -j8


### PR DESCRIPTION
macos version 10.15 no longer work for github actions so updated it to version 11