### PR TITLE
Fixed bug causing unnecessary transaction refreshes

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -447,8 +447,18 @@ void TransactionRecord::updateStatus(const interfaces::WalletTx& wtx, const inte
 
 bool TransactionRecord::statusUpdateNeeded(int numBlocks, int chainLockHeight) const
 {
-    return status.cur_num_blocks != numBlocks || status.needsUpdate
-        || (!status.lockedByChainLocks && status.cachedChainLockHeight != chainLockHeight);
+    bool numBlocksChanged = status.cur_num_blocks != numBlocks;
+
+    // Block height changes do not matter for final states:
+    bool completed =
+        status.status == TransactionStatus::Confirmed ||
+        status.status == TransactionStatus::Abandoned ||
+        status.status == TransactionStatus::NotAccepted;
+
+    return
+        status.needsUpdate ||
+        (numBlocksChanged && !completed) ||
+        (!status.lockedByChainLocks && status.cachedChainLockHeight != chainLockHeight);
 }
 
 void TransactionRecord::updateLabel(interfaces::Wallet& wallet)


### PR DESCRIPTION
Tracked down a performance issue where every new block would trigger a complete refresh of the transactions in the wallet(s).  I was testing with a wallet with 127K transactions and the UI would hang for about 90 seconds every block.  This was because it thought it needed to refresh the transaction when the block height changed - even for confirmed transactions.

With the update, the initial update is still required, but subsequent updates are very quick.