### PR TITLE
Fixed logic in Qt transaction list when watched address is one of many outputs

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -183,7 +183,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
         sub.idx = vOutIdx;
         sub.credit = txout.nValue;
         sub.strAddress = validDestination ? EncodeDestination(address) : mapValue["from"];
-        //TODO: sub.address.SetString(sub.strAddress);
         sub.txDest = address;
         sub.updateLabel(wallet);
 
@@ -330,7 +329,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
             continue;
         }
 
-        // I/J: xxx SendToAddress, SendToOther, watched: ReceiveWithAddress, RecvFromOther + FutureSend, FutureReceive
+        // I/J: SendToAddress, SendToOther, watched: RecvWithAddress, RecvFromOther + FutureSend, FutureReceive
         // This handles watched addresses going to unmonitored addresses
         // I: watched  -> other   Send from watched address to other
         // J: other    -> watched Send from other address to watched
@@ -349,10 +348,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
             }
 
             // If received by Watch, add a receive transaction on the watched side:
-            if (outputInvolvesWatchAddress)
+            if (outputInvolvesWatchAddress && mine)
             {
                 sub.involvesWatchAddress = true;
-                sub.type = isFuture ? TransactionRecord::FutureReceive : TransactionRecord::RecvFromOther;
+                sub.type = isFuture ? TransactionRecord::FutureReceive : TransactionRecord::RecvWithAddress;
                 sub.debit = 0;
                 sub.credit = txout.nValue;
                 parts.append(sub);
@@ -360,7 +359,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
             continue;
         }
 
-        LogPrintf("TransactionRecord::%s TxId: %s, vOutIdx: %d, Unhandled\n", __func__, hash.ToString(), vOutIdx);
+        // LogPrintf("TransactionRecord::%s TxId: %s, vOutIdx: %d, Unhandled\n", __func__, hash.ToString(), vOutIdx);
     }
     return parts;}
 


### PR DESCRIPTION
In transactions where there are large distributions of coins (e.g., mining payments) and the watched addresses is one of the recipients, the Qt wallet would show every output in the transaction as a watched transaction (usually 100s of transactions).  I corrected this so that is only shows the vout for the watched address(es).