### PR TITLE
Qt: UX improvement on POW cache first time initialization.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2112,6 +2112,11 @@ bool AppInitMain()
 
         // Always load the powcache if available:
         uiInterface.InitMessage(_("Loading POW cache..."));
+        fs::path powCacheFile = pathDB / strDBName;
+        if (!fs::exists(powCacheFile)) {
+          uiInterface.InitMessage("Loading POW cache for the first time. This could take a minute...");
+        }
+
         CFlatDB<CPowCache> flatdb7(strDBName, "powCache");
         if(!flatdb7.Load(CPowCache::Instance())) {
             return InitError(_("Failed to load POW cache from") + "\n" + (pathDB / strDBName).string());


### PR DESCRIPTION
If the `powcache.dat` file is not present, show a user message while that is recreated / initialized.