### PR TITLE
Fixed bug when smartnode list changes during request

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -288,7 +288,9 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int
         return CompareByLastPaid(a, b);
     });
 
-    result.resize(nCount);
+    if (result.size() > nCount) {
+        result.resize(nCount);
+    }
 
     return result;
 }


### PR DESCRIPTION
During certain time sensitive updates, retrieving the smartnode list could change during the call, possibly causing a crash.  Protected from the possible crash.