### PR TITLE
add protocol version transistion and increase fork block to 420420

### DIFF
--- a/doc/release-notes/dash/release-notes-0.11.0.md
+++ b/doc/release-notes/dash/release-notes-0.11.0.md
@@ -146,7 +146,7 @@ Protocol and network code:
 - Remove CENT-output free transaction rule when relaying
 - Lower maximum size for free transaction creation
 - Send multiple inv messages if mempool.size > MAX_INV_SZ
-- Split MIN_PROTO_VERSION into INIT_PROTO_VERSION and MIN_PEER_PROTO_VERSION
+- Split MIN_PROTO_VERSION into INIT_PROTO_VERSION and OLD_MIN_PEER_PROTO_VERSION
 - Do not treat fFromMe transaction differently when broadcasting
 - Process received messages one at a time without sleeping between messages
 - Improve logging of failed connections

--- a/doc/release-notes/dash/release-notes-0.12.2.2.md
+++ b/doc/release-notes/dash/release-notes-0.12.2.2.md
@@ -173,7 +173,7 @@ See detailed [change log](https://github.com/raptoreum/raptoreum/compare/v0.12.2
 ### Network/Sync:
 - [`5d58dd90c`](https://github.com/raptoreum/raptoreum/commit/5d58dd90c) Make sure to clear setAskFor in Raptoreum submodules (#1730)
 - [`328009749`](https://github.com/raptoreum/raptoreum/commit/328009749) fine-tune sync conditions in getblocktemplate (#1739)
-- [`362becbcc`](https://github.com/raptoreum/raptoreum/commit/362becbcc) Bump MIN_PEER_PROTO_VERSION to 70208 (#1772)
+- [`362becbcc`](https://github.com/raptoreum/raptoreum/commit/362becbcc) Bump OLD_MIN_PEER_PROTO_VERSION to 70208 (#1772)
 - [`930afd7df`](https://github.com/raptoreum/raptoreum/commit/930afd7df) Fix mnp and mnv invs (#1775)
 - [`63e306148`](https://github.com/raptoreum/raptoreum/commit/63e306148) Improve sync (#1779)
 - [`a79c97248`](https://github.com/raptoreum/raptoreum/commit/a79c97248) Fix ProcessVerifyBroadcast (#1780)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -527,7 +527,7 @@ public:
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.smartnodePaymentFixedBlock = 6800;
-        consensus.nFutureForkBlock = 410000;
+        consensus.nFutureForkBlock = 420420;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
@@ -638,14 +638,17 @@ public:
         checkpointData = {
           {  {5145, uint256S("0x64c9cc82f05f4326e49fd4b21a48494b02b12a707de67a47c7e8e1102b0f1d9b")},
              {35000, uint256S("0xb4fb191f3ef4141557aef8aafa700d312e5499cbde4a3079faa78cf58c0c414f")},
-             {61900, uint256S("0xc146fc6244fe4d71559f4fef16a386f1fceda6e5efa3da3ca1ebe9806cc8f25c")} }
+             {61900, uint256S("0xc146fc6244fe4d71559f4fef16a386f1fceda6e5efa3da3ca1ebe9806cc8f25c")},
+             {394273, uint256S("0dc274a28864a01a9539e60afdbc38fcdb0f000fbc52553cd31651c97557dc04")}
+
+          }
         };
 
         chainTxData = ChainTxData{
-          1621916553,   // * UNIX timestamp of last known number of transactions (Block 0)
-              170026,   // * total number of transactions between genesis and that timestamp
+            1662608883,   // * UNIX timestamp of last known number of transactions (Block 0)
+            2091922,   // * total number of transactions between genesis and that timestamp
                         //   (the tx=... number in the SetBestChain debug.log lines)
-                 0.1    // * estimated number of transactions per second after that timestamp
+            0.06    // * estimated number of transactions per second after that timestamp
         };
     }
 };

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -473,6 +473,7 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions()
     });
 
     bool fShouldAllMembersBeConnected = CLLMQUtils::IsAllMembersConnectedEnabled(params.type);
+    int minSmartnodeProtoVersion =  Params().IsFutureActive(chainActive.Tip()) ? MIN_SMARTNODE_PROTO_VERSION : OLD_MIN_SMARTNODE_PROTO_VERSION;
     for (auto& m : members) {
         if (m->dmn->proTxHash == myProTxHash) {
             continue;
@@ -482,9 +483,9 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions()
         if (it == protoMap.end()) {
             m->badConnection = fShouldAllMembersBeConnected;
             logger.Batch("%s is not connected to us, badConnection=%b", m->dmn->proTxHash.ToString(), m->badConnection);
-        } else if (it != protoMap.end() && it->second < MIN_SMARTNODE_PROTO_VERSION) {
+        } else if (it != protoMap.end() && it->second < minSmartnodeProtoVersion) {
             m->badConnection = true;
-            logger.Batch("%s does not have min proto version %d (has %d)", m->dmn->proTxHash.ToString(), MIN_SMARTNODE_PROTO_VERSION, it->second);
+            logger.Batch("%s does not have min proto version %d (has %d)", m->dmn->proTxHash.ToString(), minSmartnodeProtoVersion, it->second);
         }
 
         auto lastOutbound = mmetaman.GetMetaInfo(m->dmn->proTxHash)->GetLastOutboundSuccess();

--- a/src/net.h
+++ b/src/net.h
@@ -367,10 +367,10 @@ public:
     void ReleaseNodeVector(const std::vector<CNode*>& vecNodes);
 
     void RelayTransaction(const CTransaction& tx);
-    void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
-    void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
+    void RelayInv(CInv &inv, const int minProtoVersion = OLD_MIN_PEER_PROTO_VERSION);
+    void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = OLD_MIN_PEER_PROTO_VERSION);
     // This overload will not update node filters,  so use it only for the cases when other messages will update related transaction data in filters
-    void RelayInvFiltered(CInv &inv, const uint256 &relatedTxHash, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
+    void RelayInvFiltered(CInv &inv, const uint256 &relatedTxHash, const int minProtoVersion = OLD_MIN_PEER_PROTO_VERSION);
 
     // Addrman functions
     size_t GetAddressCount() const;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2177,13 +2177,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             pfrom->fDisconnect = true;
             return false;
         }
-
-        if (nVersion < MIN_PEER_PROTO_VERSION) {
+        int minPeerProtoVersion = Params().IsFutureActive(chainActive.Tip()) ? MIN_PEER_PROTO_VERSION : OLD_MIN_PEER_PROTO_VERSION;
+        if (nVersion < minPeerProtoVersion) {
             // disconnect from peers older than this proto version
             LogPrint(BCLog::NET, "peer=%d using obsolete version %i; disconnecting\n", pfrom->GetId(), nVersion);
             if (enable_bip61) {
                 connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE,
-                                   strprintf("Version must be %d or greater", MIN_PEER_PROTO_VERSION)));
+                                   strprintf("Version must be %d or greater", minPeerProtoVersion)));
             }
             pfrom->fDisconnect = true;
             return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2098,7 +2098,6 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                   CCoinsViewCache& view, const CChainParams& chainparams, bool fJustCheck)
 {
     boost::posix_time::ptime start = boost::posix_time::microsec_clock::local_time();
-
     AssertLockHeld(cs_main);
     assert(pindex);
     assert(*pindex->phashBlock == block.GetHash());

--- a/src/version.h
+++ b/src/version.h
@@ -17,9 +17,12 @@ static const int PROTOCOL_VERSION = 70219;
 static const int INIT_PROTO_VERSION = 209;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70213;
+static const int OLD_MIN_PEER_PROTO_VERSION = 70213;
+
+static const int MIN_PEER_PROTO_VERSION = 70219;
 
 //! minimum proto version of masternode to accept in DKGs
+static const int OLD_MIN_SMARTNODE_PROTO_VERSION = 70218;
 static const int MIN_SMARTNODE_PROTO_VERSION = 70219;
 
 //! minimum proto version for governance sync and messages


### PR DESCRIPTION
protocol version on dev is 70219 while protocol version on dev is 70218 and since we want to d/c old peers after hard fork we want to increase min protocol version to 70219 after the hardfork and add min protocol version switching logic

min smartnode protocol version is current set at 70219 this would cause smartnode run on dev version reject dkg message from older version so adding similar min protocol switching logic here as well

increase hardfork block to 420420