### PR TITLE
Large wallet performance improvements

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -56,41 +56,41 @@ public:
 };
 
 //! Construct wallet tx struct.
-WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
+shared_ptr<WalletTx> MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
 {
-    WalletTx result;
+    shared_ptr<WalletTx> result(new WalletTx);
     bool fInputDenomFound{false}, fOutputDenomFound{false};
-    result.tx = wtx.tx;
-    result.txin_is_mine.reserve(wtx.tx->vin.size());
+    result->tx = wtx.tx;
+    result->txin_is_mine.reserve(wtx.tx->vin.size());
     for (const auto& txin : wtx.tx->vin) {
-        result.txin_is_mine.emplace_back(wallet.IsMine(txin));
-        if (!fInputDenomFound && result.txin_is_mine.back() && wallet.IsDenominated(txin.prevout)) {
+        result->txin_is_mine.emplace_back(wallet.IsMine(txin));
+        if (!fInputDenomFound && result->txin_is_mine.back() && wallet.IsDenominated(txin.prevout)) {
             fInputDenomFound = true;
         }
     }
-    result.txout_is_mine.reserve(wtx.tx->vout.size());
-    result.txout_address.reserve(wtx.tx->vout.size());
-    result.txout_address_is_mine.reserve(wtx.tx->vout.size());
+    result->txout_is_mine.reserve(wtx.tx->vout.size());
+    result->txout_address.reserve(wtx.tx->vout.size());
+    result->txout_address_is_mine.reserve(wtx.tx->vout.size());
     for (const auto& txout : wtx.tx->vout) {
-        result.txout_is_mine.emplace_back(wallet.IsMine(txout));
-        result.txout_address.emplace_back();
-        result.txout_address_is_mine.emplace_back(ExtractDestination(txout.scriptPubKey, result.txout_address.back()) ?
-                                                      IsMine(wallet, result.txout_address.back()) :
+        result->txout_is_mine.emplace_back(wallet.IsMine(txout));
+        result->txout_address.emplace_back();
+        result->txout_address_is_mine.emplace_back(ExtractDestination(txout.scriptPubKey, result->txout_address.back()) ?
+                                                      IsMine(wallet, result->txout_address.back()) :
                                                       ISMINE_NO);
-        if (!fOutputDenomFound && result.txout_address_is_mine.back() && CCoinJoin::IsDenominatedAmount(txout.nValue)) {
+        if (!fOutputDenomFound && result->txout_address_is_mine.back() && CCoinJoin::IsDenominatedAmount(txout.nValue)) {
             fOutputDenomFound = true;
         }
     }
-    result.credit = wtx.GetCredit(ISMINE_ALL);
-    result.debit = wtx.GetDebit(ISMINE_ALL);
-    result.change = wtx.GetChange();
-    result.time = wtx.GetTxTime();
-    result.value_map = wtx.mapValue;
-    result.is_coinbase = wtx.IsCoinBase();
+    result->credit = wtx.GetCredit(ISMINE_ALL);
+    result->debit = wtx.GetDebit(ISMINE_ALL);
+    result->change = wtx.GetChange();
+    result->time = wtx.GetTxTime();
+    result->value_map = wtx.mapValue;
+    result->is_coinbase = wtx.IsCoinBase();
     // The determination of is_denominate is based on simplified checks here because in this part of the code
     // we only want to know about mixing transactions belonging to this specific wallet.
-    result.is_denominate = wtx.tx->vin.size() == wtx.tx->vout.size() && // Number of inputs is same as number of outputs
-                           (result.credit - result.debit) == 0 && // Transaction pays no tx fee
+    result->is_denominate = wtx.tx->vin.size() == wtx.tx->vout.size() && // Number of inputs is same as number of outputs
+                           (result->credit - result->debit) == 0 && // Transaction pays no tx fee
                            fInputDenomFound && fOutputDenomFound; // At least 1 input and 1 output are denominated belonging to the provided wallet
     return result;
 }
@@ -173,6 +173,7 @@ public:
 class WalletImpl : public Wallet
 {
 public:
+    unordered_lru_cache<uint256, shared_ptr<WalletTx>, std::hash<uint256>, 10000> m_WalletTxCache;
     CoinJoinImpl m_coinjoin;
 
     WalletImpl(const std::shared_ptr<CWallet>& wallet) : m_shared_wallet(wallet), m_wallet(*wallet.get()), m_coinjoin(*wallet.get()) {}
@@ -315,23 +316,35 @@ public:
         }
         return {};
     }
-    WalletTx getWalletTx(const uint256& txid) override
+    shared_ptr<WalletTx> getWalletTx(const uint256& txid) override
     {
         LOCK2(::cs_main, m_wallet.cs_wallet);
         auto mi = m_wallet.mapWallet.find(txid);
         if (mi != m_wallet.mapWallet.end()) {
-            return MakeWalletTx(m_wallet, mi->second);
+            shared_ptr<WalletTx> tx;
+            if (!m_WalletTxCache.get(mi->first, tx)) {
+               tx = MakeWalletTx(m_wallet, mi->second);
+               m_WalletTxCache.insert(mi->first, tx);
+            }
+            return tx;
         }
         return {};
     }
-    std::vector<WalletTx> getWalletTxs() override
+    std::vector<shared_ptr<WalletTx>> getWalletTxs() override
     {
+        LogPrintf("%s:%d: getWalletTxs Starting\n", __FILE__, __LINE__);
         LOCK2(::cs_main, m_wallet.cs_wallet);
-        std::vector<WalletTx> result;
+        std::vector<shared_ptr<WalletTx>> result;
         result.reserve(m_wallet.mapWallet.size());
         for (const auto& entry : m_wallet.mapWallet) {
-            result.emplace_back(MakeWalletTx(m_wallet, entry.second));
+            shared_ptr<WalletTx> tx;
+            if (!m_WalletTxCache.get(entry.first, tx)) {
+               tx = MakeWalletTx(m_wallet, entry.second);
+               m_WalletTxCache.insert(entry.first, tx);
+            }
+            result.emplace_back(tx);
         }
+        LogPrintf("%s:%d: getWalletTxs Complete: Total WalletTxs: %ld\n", __FILE__, __LINE__, result.size());
         return result;
     }
     bool tryGetTxStatus(const uint256& txid,
@@ -354,7 +367,7 @@ public:
         tx_status = MakeWalletTxStatus(mi->second);
         return true;
     }
-    WalletTx getWalletTxDetails(const uint256& txid,
+    shared_ptr<WalletTx> getWalletTxDetails(const uint256& txid,
         WalletTxStatus& tx_status,
         WalletOrderForm& order_form,
         bool& in_mempool,

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -332,7 +332,6 @@ public:
     }
     std::vector<shared_ptr<WalletTx>> getWalletTxs() override
     {
-        LogPrintf("%s:%d: getWalletTxs Starting\n", __FILE__, __LINE__);
         LOCK2(::cs_main, m_wallet.cs_wallet);
         std::vector<shared_ptr<WalletTx>> result;
         result.reserve(m_wallet.mapWallet.size());
@@ -344,7 +343,6 @@ public:
             }
             result.emplace_back(tx);
         }
-        LogPrintf("%s:%d: getWalletTxs Complete: Total WalletTxs: %ld\n", __FILE__, __LINE__, result.size());
         return result;
     }
     bool tryGetTxStatus(const uint256& txid,

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -175,10 +175,10 @@ public:
     virtual CTransactionRef getTx(const uint256& txid) = 0;
 
     //! Get transaction information.
-    virtual WalletTx getWalletTx(const uint256& txid) = 0;
+    virtual std::shared_ptr<WalletTx> getWalletTx(const uint256& txid) = 0;
 
     //! Get list of all wallet transactions.
-    virtual std::vector<WalletTx> getWalletTxs() = 0;
+    virtual std::vector<std::shared_ptr<WalletTx>> getWalletTxs() = 0;
 
     //! Try to get updated status for a particular transaction, if possible without blocking.
     virtual bool tryGetTxStatus(const uint256& txid,
@@ -186,7 +186,7 @@ public:
         int64_t& adjusted_time) = 0;
 
     //! Get transaction details.
-    virtual WalletTx getWalletTxDetails(const uint256& txid,
+    virtual std::shared_ptr<WalletTx> getWalletTxDetails(const uint256& txid,
         WalletTxStatus& tx_status,
         WalletOrderForm& order_form,
         bool& in_mempool,

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -25,14 +25,14 @@
 #include <stdint.h>
 #include <string>
 
-QString TransactionDesc::FormatTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks, int64_t adjustedTime)
+QString TransactionDesc::FormatTxStatus(shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks, int64_t adjustedTime)
 {
     if (!status.is_final)
     {
-        if (wtx.tx->nLockTime < LOCKTIME_THRESHOLD)
-            return tr("Open for %n more block(s)", "", wtx.tx->nLockTime - numBlocks);
+        if (wtx->tx->nLockTime < LOCKTIME_THRESHOLD)
+            return tr("Open for %n more block(s)", "", wtx->tx->nLockTime - numBlocks);
         else
-            return tr("Open until %1").arg(GUIUtil::dateTimeStr(wtx.tx->nLockTime));
+            return tr("Open until %1").arg(GUIUtil::dateTimeStr(wtx->tx->nLockTime));
     }
     else
     {
@@ -62,7 +62,7 @@ QString TransactionDesc::FormatTxStatus(const interfaces::WalletTx& wtx, const i
     }
 }
 
-QString TransactionDesc::FutureTxDescToHTML(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, CFutureTx& ftx, int unit)
+QString TransactionDesc::FutureTxDescToHTML(shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& status, CFutureTx& ftx, int unit)
 {
     //
     // Future Transaction HTML Description
@@ -72,12 +72,12 @@ QString TransactionDesc::FutureTxDescToHTML(const interfaces::WalletTx& wtx, con
 
     strHTML += "<hr><b>"+tr("Future Transaction")+":</b><br><br>";
 
-    if (GetTxPayload(wtx.tx->vExtraPayload, ftx)) {
+    if (GetTxPayload(wtx->tx->vExtraPayload, ftx)) {
 
-        CAmount ftxValue = wtx.tx->vout[ftx.lockOutputIndex].nValue;
+        CAmount ftxValue = wtx->tx->vout[ftx.lockOutputIndex].nValue;
         int txBlock = status.block_height;
         int currentHeight = chainActive.Height();
-        int64_t nTime = wtx.time;
+        int64_t nTime = wtx->time;
         int maturityBlock = (txBlock + ftx.maturity);
         int64_t maturityTime = (nTime + ftx.lockTime);
 
@@ -128,15 +128,15 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     interfaces::WalletTxStatus status;
     interfaces::WalletOrderForm orderForm;
     bool inMempool;
-    interfaces::WalletTx wtx = wallet.getWalletTxDetails(rec->hash, status, orderForm, inMempool, numBlocks, adjustedTime);
+    shared_ptr<interfaces::WalletTx> wtx = wallet.getWalletTxDetails(rec->hash, status, orderForm, inMempool, numBlocks, adjustedTime);
     QString strHTML;
 
     strHTML.reserve(4000);
     strHTML += "<html>";
 
-    int64_t nTime = wtx.time;
-    CAmount nCredit = wtx.credit;
-    CAmount nDebit = wtx.debit;
+    int64_t nTime = wtx->time;
+    CAmount nCredit = wtx->credit;
+    CAmount nDebit = wtx->debit;
     CAmount nNet = nCredit - nDebit;
 
     strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(wtx, status, inMempool, numBlocks, adjustedTime);
@@ -147,7 +147,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Future Transaction
     //
-    if (wtx.tx->nType == TRANSACTION_FUTURE)
+    if (wtx->tx->nType == TRANSACTION_FUTURE)
     {
         CFutureTx ftx;
         strHTML += FutureTxDescToHTML(wtx, status, ftx, unit);
@@ -155,14 +155,14 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // From
     //
-    if (wtx.is_coinbase)
+    if (wtx->is_coinbase)
     {
         strHTML += "<b>" + tr("Source") + ":</b> " + tr("Generated") + "<br>";
     }
-    else if (wtx.value_map.count("from") && !wtx.value_map["from"].empty())
+    else if (wtx->value_map.count("from") && !wtx->value_map["from"].empty())
     {
         // Online transaction
-        strHTML += "<b>" + tr("From") + ":</b> " + GUIUtil::HtmlEscape(wtx.value_map["from"]) + "<br>";
+        strHTML += "<b>" + tr("From") + ":</b> " + GUIUtil::HtmlEscape(wtx->value_map["from"]) + "<br>";
     }
     else
     {
@@ -193,10 +193,10 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // To
     //
-    if (wtx.value_map.count("to") && !wtx.value_map["to"].empty())
+    if (wtx->value_map.count("to") && !wtx->value_map["to"].empty())
     {
         // Online transaction
-        std::string strAddress = wtx.value_map["to"];
+        std::string strAddress = wtx->value_map["to"];
         strHTML += "<b>" + tr("To") + ":</b> ";
         CTxDestination dest = DecodeDestination(strAddress);
         std::string name;
@@ -208,13 +208,13 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Amount
     //
-    if (wtx.is_coinbase && nCredit == 0)
+    if (wtx->is_coinbase && nCredit == 0)
     {
         //
         // Coinbase
         //
         CAmount nUnmatured = 0;
-        for (const CTxOut& txout : wtx.tx->vout)
+        for (const CTxOut& txout : wtx->tx->vout)
             nUnmatured += wallet.getCredit(txout, ISMINE_ALL);
         strHTML += "<b>" + tr("Credit") + ":</b> ";
         if (status.is_in_main_chain)
@@ -233,13 +233,13 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     else
     {
         isminetype fAllFromMe = ISMINE_SPENDABLE;
-        for (isminetype mine : wtx.txin_is_mine)
+        for (isminetype mine : wtx->txin_is_mine)
         {
             if(fAllFromMe > mine) fAllFromMe = mine;
         }
 
         isminetype fAllToMe = ISMINE_SPENDABLE;
-        for (isminetype mine : wtx.txout_is_mine)
+        for (isminetype mine : wtx->txout_is_mine)
         {
             if(fAllToMe > mine) fAllToMe = mine;
         }
@@ -252,15 +252,15 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             //
             // Debit
             //
-            auto mine = wtx.txout_is_mine.begin();
-            for (const CTxOut& txout : wtx.tx->vout)
+            auto mine = wtx->txout_is_mine.begin();
+            for (const CTxOut& txout : wtx->tx->vout)
             {
                 // Ignore change
                 isminetype toSelf = *(mine++);
                 if ((toSelf == ISMINE_SPENDABLE) && (fAllFromMe == ISMINE_SPENDABLE))
                     continue;
 
-                if (!wtx.value_map.count("to") || wtx.value_map["to"].empty())
+                if (!wtx->value_map.count("to") || wtx->value_map["to"].empty())
                 {
                     // Offline transaction
                     CTxDestination address;
@@ -287,13 +287,13 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             if (fAllToMe)
             {
                 // Payment to self
-                CAmount nChange = wtx.change;
+                CAmount nChange = wtx->change;
                 CAmount nValue = nCredit - nChange;
                 strHTML += "<b>" + tr("Total debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nValue) + "<br>";
                 strHTML += "<b>" + tr("Total credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nValue) + "<br>";
             }
 
-            CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
+            CAmount nTxFee = nDebit - wtx->tx->GetValueOut();
             if (nTxFee > 0)
                 strHTML += "<b>" + tr("Transaction fee") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nTxFee) + "<br>";
         }
@@ -302,14 +302,14 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
             //
             // Mixed debit transaction
             //
-            auto mine = wtx.txin_is_mine.begin();
-            for (const CTxIn& txin : wtx.tx->vin) {
+            auto mine = wtx->txin_is_mine.begin();
+            for (const CTxIn& txin : wtx->tx->vin) {
                 if (*(mine++)) {
                     strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet.getDebit(txin, ISMINE_ALL)) + "<br>";
                 }
             }
-            mine = wtx.txout_is_mine.begin();
-            for (const CTxOut& txout : wtx.tx->vout) {
+            mine = wtx->txout_is_mine.begin();
+            for (const CTxOut& txout : wtx->tx->vout) {
                 if (*(mine++)) {
                     strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet.getCredit(txout, ISMINE_ALL)) + "<br>";
                 }
@@ -322,14 +322,14 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Message
     //
-    if (wtx.value_map.count("message") && !wtx.value_map["message"].empty())
-        strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.value_map["message"], true) + "<br>";
-    if (wtx.value_map.count("comment") && !wtx.value_map["comment"].empty())
-        strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.value_map["comment"], true) + "<br>";
+    if (wtx->value_map.count("message") && !wtx->value_map["message"].empty())
+        strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(wtx->value_map["message"], true) + "<br>";
+    if (wtx->value_map.count("comment") && !wtx->value_map["comment"].empty())
+        strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx->value_map["comment"], true) + "<br>";
 
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
-    strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.tx->GetTotalSize()) + " bytes<br>";
+    strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx->tx->GetTotalSize()) + " bytes<br>";
 
     // Message from normal raptoreum:URI (raptoreum:XyZ...?message=example)
     for (const std::pair<std::string, std::string>& r : orderForm)
@@ -351,7 +351,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         }
     }
 
-    if (wtx.is_coinbase)
+    if (wtx->is_coinbase)
     {
         quint32 numBlocksToMaturity = COINBASE_MATURITY +  1;
         strHTML += "<br>" + tr("Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to \"not accepted\" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.").arg(QString::number(numBlocksToMaturity)) + "<br>";
@@ -365,20 +365,20 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     if (node.getLogCategories() != BCLog::NONE)
     {
         strHTML += "<hr><br>" + tr("Debug information") + "<br><br>";
-        for (const CTxIn& txin : wtx.tx->vin)
+        for (const CTxIn& txin : wtx->tx->vin)
             if(wallet.txinIsMine(txin))
                 strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet.getDebit(txin, ISMINE_ALL)) + "<br>";
-        for (const CTxOut& txout : wtx.tx->vout)
+        for (const CTxOut& txout : wtx->tx->vout)
             if(wallet.txoutIsMine(txout))
                 strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet.getCredit(txout, ISMINE_ALL)) + "<br>";
 
         strHTML += "<br><b>" + tr("Transaction") + ":</b><br>";
-        strHTML += GUIUtil::HtmlEscape(wtx.tx->ToString(), true);
+        strHTML += GUIUtil::HtmlEscape(wtx->tx->ToString(), true);
 
         strHTML += "<br><b>" + tr("Inputs") + ":</b>";
         strHTML += "<ul>";
 
-        for (const CTxIn& txin : wtx.tx->vin)
+        for (const CTxIn& txin : wtx->tx->vin)
         {
             COutPoint prevout = txin.prevout;
 

--- a/src/qt/transactiondesc.h
+++ b/src/qt/transactiondesc.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_QT_TRANSACTIONDESC_H
 #define BITCOIN_QT_TRANSACTIONDESC_H
 
+#include <memory>
+
 #include <QObject>
 #include <QString>
 
@@ -32,8 +34,8 @@ public:
 private:
     TransactionDesc() {}
 
-    static QString FormatTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks, int64_t adjustedTime);
-    static QString FutureTxDescToHTML(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, CFutureTx& ftx, int unit);
+    static QString FormatTxStatus(std::shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks, int64_t adjustedTime);
+    static QString FutureTxDescToHTML(std::shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& status, CFutureTx& ftx, int unit);
 
 };
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -18,7 +18,6 @@
 #include <utilmoneystr.h>
 
 #include <stdint.h>
-#include <QDebug>
 
 
 /* Return positive answer if transaction should be shown in list.

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -18,6 +18,7 @@
 #include <utilmoneystr.h>
 
 #include <stdint.h>
+#include <QDebug>
 
 
 /* Return positive answer if transaction should be shown in list.
@@ -71,12 +72,10 @@ bool TransactionRecord::isFutureTxMatured(const CWalletTx &wtx, CFutureTx &ftx)
     }
 }
 
-void TransactionRecord::getFutureTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& wtxStatus, CFutureTx &ftx)
+void TransactionRecord::getFutureTxStatus(const std::shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& wtxStatus, CFutureTx &ftx)
 {
-
-    if (GetTxPayload(wtx.tx->vExtraPayload, ftx))
+    if (GetTxPayload(wtx->tx->vExtraPayload, ftx))
     {
-
         int maturityBlock = wtxStatus.block_height + ftx.maturity;
         int64_t maturityTime = wtxStatus.time_received + ftx.lockTime;
         int currentHeight = chainActive.Height();
@@ -110,37 +109,36 @@ void TransactionRecord::getFutureTxStatus(const interfaces::WalletTx& wtx, const
         //not in main chain - new transaction
         status.status = TransactionStatus::NotAccepted;
     }
-
 }
 
 /*
  * Decompose CWallet transaction to model transaction records.
  */
-QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wallet& wallet, const interfaces::WalletTx& wtx)
+QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wallet& wallet, const std::shared_ptr<const interfaces::WalletTx> wtx)
 {
     QList<TransactionRecord> parts;
     isminefilter creditMineTypes = 0;
     isminefilter debitMineTypes = 0;
 
-    int64_t nTime = wtx.time; // TODO: Should this be GetConfirmationTime?
-    CAmount nCredit = wtx.credit;
-    CAmount nDebit = wtx.debit;
+    int64_t nTime = wtx->time; // TODO: Should this be GetConfirmationTime?
+    CAmount nCredit = wtx->credit;
+    CAmount nDebit = wtx->debit;
     CAmount nNet = nCredit - nDebit;
-    CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
-    uint256 hash = wtx.tx->GetHash();
-    bool isFuture = wtx.tx->nType == TRANSACTION_FUTURE;
+    CAmount nTxFee = nDebit - wtx->tx->GetValueOut();
+    uint256 hash = wtx->tx->GetHash();
+    bool isFuture = wtx->tx->nType == TRANSACTION_FUTURE;
 
-    for (isminetype mine : wtx.txout_is_mine)
+    for (isminetype mine : wtx->txout_is_mine)
     {
         creditMineTypes |= mine;
     }
 
-    for (isminetype mine : wtx.txin_is_mine)
+    for (isminetype mine : wtx->txin_is_mine)
     {
         debitMineTypes |= mine;
     }
 
-    std::map<std::string, std::string> mapValue = wtx.value_map;
+    std::map<std::string, std::string> mapValue = wtx->value_map;
 
     // Combinations of transactions:
     // NB: This treats all watched addresses like a single, other wallet
@@ -169,13 +167,13 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
     // J: other    -> watched Send from other address to watched
 
     // LogPrintf("TransactionRecord::%s TxId: %s debitMineTypes: %02X, creditMineTypes: %02X, debit: %s, credit: %s, ValueOut: %s, TxFee: %s, nType: %d\n",
-    //         __func__, hash.ToString(), debitMineTypes, creditMineTypes, FormatMoney(nDebit), FormatMoney(nCredit), FormatMoney(wtx.tx->GetValueOut()), FormatMoney(nTxFee), wtx.tx->nType);
+    //         __func__, hash.ToString(), debitMineTypes, creditMineTypes, FormatMoney(nDebit), FormatMoney(nCredit), FormatMoney(wtx->tx->GetValueOut()), FormatMoney(nTxFee), wtx->tx->nType);
 
-    for (unsigned int vOutIdx = 0; vOutIdx < wtx.tx->vout.size(); ++vOutIdx)
+    for (unsigned int vOutIdx = 0; vOutIdx < wtx->tx->vout.size(); ++vOutIdx)
     {
-        const CTxOut& txout = wtx.tx->vout[vOutIdx];
+        const CTxOut& txout = wtx->tx->vout[vOutIdx];
 
-        isminetype mine = wtx.txout_is_mine[vOutIdx];
+        isminetype mine = wtx->txout_is_mine[vOutIdx];
 
         TransactionRecord sub(hash, nTime);
         CTxDestination address;
@@ -192,26 +190,26 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
         bool inputInvolvesWatchAddress = false;
         bool outputInvolvesWatchAddress = false;
         isminetype fAllFromMe = ISMINE_SPENDABLE;
-        for (isminetype mine : wtx.txin_is_mine)
+        for (isminetype mine : wtx->txin_is_mine)
         {
             if (mine & ISMINE_WATCH_ONLY) inputInvolvesWatchAddress = true;
             if (fAllFromMe > mine) fAllFromMe = mine;
         }
 
         isminetype fAllToMe = ISMINE_SPENDABLE;
-        for (isminetype mine : wtx.txout_is_mine)
+        for (isminetype mine : wtx->txout_is_mine)
         {
             if (mine & ISMINE_WATCH_ONLY) outputInvolvesWatchAddress = true;
             if (fAllToMe > mine) fAllToMe = mine;
         }
 
         // LogPrintf("TransactionRecord::%s TxId: %s vOutIdx: %d, CoinBase: %d, AllFromMe: %d, AllToMe: %d, inputWatch: %d, outputWatch: %d\n",
-        //         __func__, hash.ToString(), vOutIdx, wtx.is_coinbase, fAllFromMe, fAllToMe, inputInvolvesWatchAddress, outputInvolvesWatchAddress);
+        //         __func__, hash.ToString(), vOutIdx, wtx->is_coinbase, fAllFromMe, fAllToMe, inputInvolvesWatchAddress, outputInvolvesWatchAddress);
 
         // A/B Generated:
         // A: coinbase -> self    Generated
         // B: coinbase -> watched Generated (watched)
-        if (wtx.is_coinbase && mine)
+        if (wtx->is_coinbase && mine)
         {
             sub.type = TransactionRecord::Generated;
             sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
@@ -224,12 +222,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
         // D: watched -> watched  Send to self (watched)
         if (fAllFromMe && fAllToMe && (debitMineTypes == creditMineTypes))
         {
-            CAmount nChange = wtx.change;
+            CAmount nChange = wtx->change;
             sub.debit = -(nDebit - nChange);
             sub.credit = nCredit - nChange;
             sub.involvesWatchAddress = inputInvolvesWatchAddress;
 
-            if (wtx.is_denominate)
+            if (wtx->is_denominate)
             {
                 sub.type = TransactionRecord::CoinJoinCreateDenominations;
                 sub.debit = -nDebit;
@@ -241,7 +239,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
             if (mapValue["DS"] == "1")
             {
                 sub.type = TransactionRecord::CoinJoinSend;
-                CAmount nChange = wtx.change;
+                CAmount nChange = wtx->change;
                 parts.append(sub);
                 break; // Only report first of the batch
             } 
@@ -250,7 +248,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
             sub.type = TransactionRecord::SendToSelf;
 
             sub.idx = parts.size();
-            if (wtx.tx->vin.size() == 1 && wtx.tx->vout.size() == 1
+            if (wtx->tx->vin.size() == 1 && wtx->tx->vout.size() == 1
                 && CCoinJoin::IsCollateralAmount(nDebit)
                 && CCoinJoin::IsCollateralAmount(nCredit)
                 && CCoinJoin::IsCollateralAmount(-nNet))
@@ -259,7 +257,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
             } 
             else 
             {
-                for (const auto& txout : wtx.tx->vout)
+                for (const auto& txout : wtx->tx->vout)
                 {
                     if (txout.nValue == CCoinJoin::GetMaxCollateralAmount()) {
                         sub.type = TransactionRecord::CoinJoinMakeCollaterals;
@@ -363,7 +361,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wal
     }
     return parts;}
 
-void TransactionRecord::updateStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& wtxStatus, int numBlocks, int64_t adjustedTime, int chainLockHeight)
+void TransactionRecord::updateStatus(const std::shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& wtxStatus, int numBlocks, int64_t adjustedTime, int chainLockHeight)
 {
     // Determine transaction status
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -132,7 +132,7 @@ public:
     /** Decompose CWallet transaction to model transaction records.
      */
     static bool showTransaction();
-    static QList<TransactionRecord> decomposeTransaction(interfaces::Wallet& wallet, const interfaces::WalletTx& wtx);
+    static QList<TransactionRecord> decomposeTransaction(interfaces::Wallet& wallet, const std::shared_ptr<const interfaces::WalletTx> wtx);
 
     /** @name Immutable transaction attributes
       @{*/
@@ -166,7 +166,7 @@ public:
 
     /** Update status from core wallet tx.
      */
-    void updateStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& wtxStatus, int numBlocks, int64_t adjustedTime, int chainLockHeight);
+    void updateStatus(const std::shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& wtxStatus, int numBlocks, int64_t adjustedTime, int chainLockHeight);
 
     /** Return whether a status update is needed.
      */
@@ -189,7 +189,7 @@ public:
     bool isFutureTxMatured(const CWalletTx &wtx, CFutureTx &ftx);
 
     /** Return the Future TX Status based on maturity */
-    void getFutureTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& wtxStatus, CFutureTx &ftx);
+    void getFutureTxStatus(const std::shared_ptr<const interfaces::WalletTx> wtx, const interfaces::WalletTxStatus& wtxStatus, CFutureTx &ftx);
 
 };
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -132,8 +132,8 @@ public:
             if(showTransaction)
             {
                 // Find transaction in wallet
-                interfaces::WalletTx wtx = wallet.getWalletTx(hash);
-                if(!wtx.tx)
+                std::shared_ptr<const interfaces::WalletTx> wtx = wallet.getWalletTx(hash);
+                if(!wtx->tx)
                 {
                     qWarning() << "TransactionTablePriv::updateWallet: Warning: Got CT_NEW, but transaction is not in wallet";
                     break;
@@ -211,7 +211,7 @@ public:
             interfaces::WalletTxStatus wtxStatus;
             int64_t adjustedTime;
             if (rec->statusUpdateNeeded(numBlocks, parent->getChainLockHeight()) && wallet.tryGetTxStatus(rec->hash, wtxStatus, adjustedTime)) {
-                interfaces::WalletTx wtx = wallet.getWalletTx(rec->hash);
+                std::shared_ptr<const interfaces::WalletTx> wtx = wallet.getWalletTx(rec->hash);
                 rec->updateStatus(wtx, wtxStatus, numBlocks, adjustedTime, parent->getChainLockHeight());
             }
             return rec;


### PR DESCRIPTION
Performance improvements for large wallets (particularly transactions with many inputs or outputs).  Added caching of WalletTx and used shared_ptr to minimize excessive copying.  Performance for this logic for smaller wallets is ~20x faster, for larger wallets, well over 100x faster.