### PR TITLE
Disable unnecessary warning

### DIFF
--- a/src/smartnode/smartnode-payments.cpp
+++ b/src/smartnode/smartnode-payments.cpp
@@ -170,7 +170,7 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
         // NOTE: old budget system is disabled since 12.1 and we should never enter this branch
         // anymore when sync is finished (on mainnet). We have no old budget data but these blocks
         // have tons of confirmations and can be safely accepted without payee verification
-        LogPrintf("%s -- WARNING: Client synced but old budget system is disabled, accepting any payee\n", __func__);
+        // LogPrintf("%s -- WARNING: Client synced but old budget system is disabled, accepting any payee\n", __func__);
         return true;
     }
 

--- a/src/smartnode/smartnode-payments.cpp
+++ b/src/smartnode/smartnode-payments.cpp
@@ -170,7 +170,7 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
         // NOTE: old budget system is disabled since 12.1 and we should never enter this branch
         // anymore when sync is finished (on mainnet). We have no old budget data but these blocks
         // have tons of confirmations and can be safely accepted without payee verification
-        // LogPrintf("%s -- WARNING: Client synced but old budget system is disabled, accepting any payee\n", __func__);
+        LogPrint(BCLog::GOBJECT, "%s -- WARNING: Client synced but old budget system is disabled, accepting any payee\n", __func__);
         return true;
     }
 


### PR DESCRIPTION
While syncing my node from scratch this warning first scared me:
`IsBlockPayeeValid -- WARNING: Client synced but old budget system is disabled, accepting any payee`
Then I read on discord that someone else had the same question before and Bigpiggy answered:  "just means were are not running the dash system for budget" 

So I figured why not disable this warning, since WARNING sounds kind of serious.

Maybe this change will help prevents others having the same question about this warning in the future.