### PR TITLE
Fixed txvalidationcache tests

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -113,10 +113,10 @@ void CChainParams::UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64
 //    consensus.DIP0003EnforcementHeight = nEnforcementHeight;
 //}
 
-void CChainParams::UpdateBIP66Parameters(bool nactive)
+void CChainParams::UpdateBIP66Parameters(bool active)
 {
     if (strcmp(Params().NetworkIDString().c_str(),"regtest") == 0){
-        consensus.BIP66Enabled = nactive;
+        consensus.BIP66Enabled = active;
     }
 }
 
@@ -1126,9 +1126,9 @@ void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime,
 //    globalChainParams->UpdateDIP3Parameters(nActivationHeight, nEnforcementHeight);
 //}
 
-void UpdateBIP66Parameters(bool nactive)
+void UpdateBIP66Parameters(bool active)
 {
-    globalChainParams->UpdateBIP66Parameters(nactive);
+    globalChainParams->UpdateBIP66Parameters(active);
 }
 
 void UpdateBudgetParameters(int nSmartnodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -113,6 +113,13 @@ void CChainParams::UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64
 //    consensus.DIP0003EnforcementHeight = nEnforcementHeight;
 //}
 
+void CChainParams::UpdateBIP66Parameters(bool nactive)
+{
+    if (strcmp(Params().NetworkIDString().c_str(),"regtest") == 0){
+        consensus.BIP66Enabled = nactive;
+    }
+}
+
 void CChainParams::UpdateBudgetParameters(int nSmartnodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock)
 {
     consensus.nSmartnodePaymentsStartBlock = nSmartnodePaymentsStartBlock;
@@ -1118,6 +1125,11 @@ void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime,
 //{
 //    globalChainParams->UpdateDIP3Parameters(nActivationHeight, nEnforcementHeight);
 //}
+
+void UpdateBIP66Parameters(bool nactive)
+{
+    globalChainParams->UpdateBIP66Parameters(nactive);
+}
 
 void UpdateBudgetParameters(int nSmartnodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock)
 {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -91,7 +91,7 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
     void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout, int64_t nWindowSize, int64_t nThresholdStart, int64_t nThresholdMin, int64_t nFalloffCoeff);
     void UpdateDIP3Parameters(int nActivationHeight, int nEnforcementHeight);
-    void UpdateBIP66Parameters(bool nactive);
+    void UpdateBIP66Parameters(bool active);
     void UpdateBudgetParameters(int nSmartnodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock);
     void UpdateSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor);
     void UpdateLLMQChainLocks(Consensus::LLMQType llmqType);
@@ -176,7 +176,7 @@ void UpdateDIP3Parameters(int nActivationHeight, int nEnforcementHeight);
 /**
  * Allows modifying the BIP66 regtest parameters.
  */
-void UpdateBIP66Parameters(bool nactive);
+void UpdateBIP66Parameters(bool active);
 
 /**
  * Allows modifying the budget regtest parameters.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -91,6 +91,7 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
     void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout, int64_t nWindowSize, int64_t nThresholdStart, int64_t nThresholdMin, int64_t nFalloffCoeff);
     void UpdateDIP3Parameters(int nActivationHeight, int nEnforcementHeight);
+    void UpdateBIP66Parameters(bool nactive);
     void UpdateBudgetParameters(int nSmartnodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock);
     void UpdateSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor);
     void UpdateLLMQChainLocks(Consensus::LLMQType llmqType);
@@ -171,6 +172,11 @@ void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime,
  * Allows modifying the DIP3 activation and enforcement height
  */
 void UpdateDIP3Parameters(int nActivationHeight, int nEnforcementHeight);
+
+/**
+ * Allows modifying the BIP66 regtest parameters.
+ */
+void UpdateBIP66Parameters(bool nactive);
 
 /**
  * Allows modifying the budget regtest parameters.

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -16,6 +16,7 @@
 #include <core_io.h>
 #include <keystore.h>
 #include <policy/policy.h>
+#include <chainparams.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -220,6 +221,9 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
         // successes.
         ValidateCheckInputsForAllFlags(spend_tx, SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S | SCRIPT_VERIFY_STRICTENC, false);
     }
+
+    //turn off BIP66 (DERSIG is enabled by default)
+    UpdateBIP66Parameters(false);
 
     // And if we produce a block with this tx, it should be valid (DERSIG not
     // enabled yet), even though there's no cache entry.


### PR DESCRIPTION
txvalidationcache_tests require BIP66 to be off in order to run (default is on).
Added logic to turn on/off BIP66, usage only allowed on regtest