### PR TITLE
fix compiling with --disable-wallet and --enable-miner=no

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -543,10 +543,11 @@ void static RaptoreumMiner(const CChainParams& chainparams)
 
     #ifdef ENABLE_WALLET
         pWallet = GetFirstWallet();
+
+        if (!EnsureWalletIsAvailable(pWallet, false)) {
+            LogPrintf("RaptoreumMiner -- Wallet not available\n");
+        }
     #endif
-    if (!EnsureWalletIsAvailable(pWallet, false)) {
-        LogPrintf("RaptoreumMiner -- Wallet not available\n");
-    }
 
     if (pWallet == NULL)
     {

--- a/src/rpc/specialtx_utilities.h
+++ b/src/rpc/specialtx_utilities.h
@@ -100,11 +100,15 @@ static void FundSpecialTx(CWallet* pwallet, CMutableTransaction& tx, const Speci
     }
 }
 
+#endif//ENABLE_WALLET
+
 template<typename SpecialTxPayload>
 static void UpdateSpecialTxInputsHash(const CMutableTransaction& tx, SpecialTxPayload& payload)
 {
     payload.inputsHash = CalcTxInputsHash(tx);
 }
+
+#ifdef ENABLE_WALLET
 
 template<typename SpecialTxPayload>
 static void SignSpecialTxPayloadByHash(const CMutableTransaction& tx, SpecialTxPayload& payload, const CKey& key)


### PR DESCRIPTION
-Compile with --disable-wallet give the following error
`rpc/rawtransaction.cpp:557:9: error: 'UpdateSpecialTxInputsHash' was not declared in this scope
  557 |         UpdateSpecialTxInputsHash(rawTx, ftx);`
  
 -Compile with --enable-miner=no give the following error
`/miner.cpp:547: undefined reference to 'EnsureWalletIsAvailable(CWallet*, bool)'`

This pr fix both issue and should solve #229

changes tested under Ubuntu 20.04