### PR TITLE
Removed extraneous lock causing deadlock during Quorums

### DIFF
--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -613,24 +613,20 @@ void CSigSharesManager::CollectPendingSigSharesToVerify(
         }
     }
 
-    {
-        LOCK(cs_main);
+    // For the convenience of the caller, also build a map of quorumHash -> quorum
 
-        // For the convenience of the caller, also build a map of quorumHash -> quorum
+    for (auto& p : retSigShares) {
+        for (auto& sigShare : p.second) {
+            auto llmqType = (Consensus::LLMQType) sigShare.llmqType;
 
-        for (auto& p : retSigShares) {
-            for (auto& sigShare : p.second) {
-                auto llmqType = (Consensus::LLMQType) sigShare.llmqType;
-
-                auto k = std::make_pair(llmqType, sigShare.quorumHash);
-                if (retQuorums.count(k)) {
-                    continue;
-                }
-
-                CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, sigShare.quorumHash);
-                assert(quorum != nullptr);
-                retQuorums.emplace(k, quorum);
+            auto k = std::make_pair(llmqType, sigShare.quorumHash);
+            if (retQuorums.count(k)) {
+                continue;
             }
+
+            CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, sigShare.quorumHash);
+            assert(quorum != nullptr);
+            retQuorums.emplace(k, quorum);
         }
     }
 }


### PR DESCRIPTION
The following deadlock occurred between these two threads:
```
Thread 18 (Thread 0x7f081dffb700 (LWP 36)):
#0  __lll_lock_wait (futex=futex@entry=0x557ec8eb1d78, private=0) at lowlevellock.c:52
#1  0x00007f08823b7131 in __GI___pthread_mutex_lock (mutex=0x557ec8eb1d78) at ../nptl/pthread_mutex_lock.c:115
#2  0x0000557ec61fb8b1 in __gthread_mutex_lock () at /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:749
#3  __gthread_recursive_mutex_lock () at /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:811
#4  std::recursive_mutex::lock () at /usr/include/c++/9/mutex:106
#5  AnnotatedMixin<std::recursive_mutex>::lock () at ./sync.h:59
#6  std::unique_lock<CCriticalSection>::lock () at /usr/include/c++/9/bits/unique_lock.h:141
#7  CCriticalBlock::Enter () at ./sync.h:128
#8  CCriticalBlock::CCriticalBlock () at ./sync.h:149
#9  llmq::CQuorumManager::GetQuorum () at llmq/quorums.cpp:507
#10 0x0000557ec61fd45f in llmq::CQuorumManager::GetQuorum () at llmq/quorums.cpp:492
#11 0x0000557ec5f0e67d in llmq::CSigSharesManager::CollectPendingSigSharesToVerify () at llmq/quorums_signing_shares.cpp:630
#12 0x0000557ec5f15f90 in llmq::CSigSharesManager::ProcessPendingSigShares () at llmq/quorums_signing_shares.cpp:644
#13 0x0000557ec5f20ab6 in llmq::CSigSharesManager::WorkThreadMain () at llmq/quorums_signing_shares.cpp:1518
#14 0x0000557ec5e399aa in std::function<void ()>::operator()() const () at /usr/include/c++/9/bits/std_function.h:688
#15 TraceThread<std::function<void ()> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>) () at ./util.h:346
#16 0x0000557ec5ee8a91 in std::__invoke_impl<void, void (*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*, std::function<void ()> >(std::__invoke_other, void (*&&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*&&, std::function<void ()>&&) () at /usr/include/c++/9/bits/invoke.h:60
#17 std::__invoke<void (*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*, std::function<void ()> >(void (*&&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*&&, std::function<void ()>&&) () at /usr/include/c++/9/bits/invoke.h:95
#18 std::thread::_Invoker<std::tuple<void (*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*, std::function<void ()> > >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) () at /usr/include/c++/9/thread:244
#19 std::thread::_Invoker<std::tuple<void (*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*, std::function<void ()> > >::operator()() () at /usr/include/c++/9/thread:251
#20 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*, std::function<void ()> > > >::_M_run() () at /usr/include/c++/9/thread:195
#21 0x0000557ec68ab954 in execute_native_thread_routine ()
#22 0x00007f08823b4609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#23 0x00007f088216f133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
and

```
Thread 6 (Thread 0x7f087f636700 (LWP 15)):
#0  __lll_lock_wait (futex=futex@entry=0x557ec6c86360 <cs_main>, private=0) at lowlevellock.c:52
#1  0x00007f08823b7131 in __GI___pthread_mutex_lock (mutex=0x557ec6c86360 <cs_main>) at ../nptl/pthread_mutex_lock.c:115
#2  0x0000557ec60c7776 in __gthread_mutex_lock () at /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:749
#3  __gthread_recursive_mutex_lock () at /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:811
#4  std::recursive_mutex::lock () at /usr/include/c++/9/mutex:106
#5  AnnotatedMixin<std::recursive_mutex>::lock () at ./sync.h:59
#6  std::unique_lock<CCriticalSection>::lock () at /usr/include/c++/9/bits/unique_lock.h:141
#7  CCriticalBlock::Enter () at ./sync.h:128
#8  CCriticalBlock::CCriticalBlock () at ./sync.h:149
#9  GetUTXOCoin () at validation.cpp:446
#10 0x0000557ec61a0449 in CDeterministicMNList::IsMNValid () at evo/deterministicmns.cpp:134
#11 0x0000557ec61a1afa in ForEachMN<CDeterministicMNList::CalculateScores(const uint256&) const::<lambda(const CDeterministicMNCPtr&)> >(void) () at ./evo/deterministicmns.h:398
#12 0x0000557ec61a21b4 in CDeterministicMNList::CalculateScores () at evo/deterministicmns.cpp:324
#13 0x0000557ec61a231a in CDeterministicMNList::CalculateQuorum () at evo/deterministicmns.cpp:300
#14 0x0000557ec5f37291 in llmq::CLLMQUtils::GetAllQuorumMembers () at llmq/quorums_utils.cpp:44
#15 0x0000557ec61fac14 in llmq::CQuorumManager::BuildQuorumFromCommitment () at llmq/quorums.cpp:304
#16 0x0000557ec61fb943 in llmq::CQuorumManager::GetQuorum () at llmq/quorums.cpp:513
#17 0x0000557ec61ff589 in llmq::CQuorumManager::ScanQuorums () at llmq/quorums.cpp:461
#18 0x0000557ec620040b in llmq::CQuorumManager::EnsureQuorumConnections () at llmq/quorums.cpp:269
#19 0x0000557ec62012c9 in llmq::CQuorumManager::UpdatedBlockTip () at llmq/quorums.cpp:245
#20 0x0000557ec619bf0c in CDSNotificationInterface::UpdatedBlockTip () at dsnotificationinterface.cpp:74
#21 CDSNotificationInterface::UpdatedBlockTip () at dsnotificationinterface.cpp:51
#22 0x0000557ec6159118 in boost::function3<void, CBlockIndex const*, CBlockIndex const*, bool>::operator() () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/function/function_template.hpp:763
#23 boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::m_invoke<boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)>, 0u, 1u, 2u, CBlockIndex const*&, CBlockIndex const*&, bool&>(boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)>&, boost::signals2::detail::unsigned_meta_array<0u, 1u, 2u>, std::tuple<CBlockIndex const*&, CBlockIndex const*&, bool&> const&, boost::enable_if<boost::is_void<boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)>::result_type>, void>::type*) const () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/signals2/detail/variadic_slot_invoker.hpp:105
#24 boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::operator()<boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)>, CBlockIndex const*&, CBlockIndex const*&, bool&, 3ul>(boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)>&, std::tuple<CBlockIndex const*&, CBlockIndex const*&, bool&> const&, mpl_::size_t<3ul>) const () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/signals2/detail/variadic_slot_invoker.hpp:90
#25 boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >(boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > const&) const () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/signals2/detail/variadic_slot_invoker.hpp:133
#26 boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> >::dereference() const () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/signals2/detail/slot_call_iterator.hpp:110
#27 boost::iterators::iterator_core_access::dereference<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > const&) () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/iterator/iterator_facade.hpp:550
#28 boost::iterators::detail::iterator_facade_base<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> >, boost::signals2::detail::void_type, boost::iterators::single_pass_traversal_tag, boost::signals2::detail::void_type const&, long, false, false>::operator*() const () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/iterator/iterator_facade.hpp:656
#29 boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> >, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> >) const () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/signals2/optional_last_value.hpp:57
#30 boost::signals2::detail::combiner_invoker<void>::operator()<boost::signals2::optional_last_value<void>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >(boost::signals2::optional_last_value<void>&, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> >, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, CBlockIndex const*, CBlockIndex const*, bool>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (CBlockIndex const*, CBlockIndex const*, bool), boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)> >, boost::signals2::mutex> >) const () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/signals2/detail/result_type_wrapper.hpp:64
#31 boost::signals2::detail::signal_impl<void (CBlockIndex const*, CBlockIndex const*, bool), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (CBlockIndex const*, CBlockIndex const*, bool)>, boost::function<void (boost::signals2::connection const&, CBlockIndex const*, CBlockIndex const*, bool)>, boost::signals2::mutex>::operator()(CBlockIndex const*, CBlockIndex const*, bool) () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/signals2/detail/signal_template.hpp:243
#32 0x0000557ec6391ebd in std::function<void ()>::operator()() const () at /usr/include/c++/9/bits/std_function.h:688
#33 SingleThreadedSchedulerClient::ProcessQueue () at scheduler.cpp:186
#34 0x0000557ec6390830 in std::function<void ()>::operator()() const () at /usr/include/c++/9/bits/std_function.h:688
#35 CScheduler::serviceQueue () at scheduler.cpp:82
#36 0x0000557ec5e399aa in std::function<void ()>::operator()() const () at /usr/include/c++/9/bits/std_function.h:688
#37 TraceThread<std::function<void ()> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>) () at ./util.h:346
#38 0x0000557ec5e3b341 in std::__invoke_impl<void, void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*&, std::function<void ()>&>(std::__invoke_other, void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*&, std::function<void ()>&) () at /usr/include/c++/9/bits/invoke.h:60
#39 std::__invoke<void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*&, std::function<void ()>&>(void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>), char const*&, std::function<void ()>&) () at /usr/include/c++/9/bits/invoke.h:95
#40 std::_Bind<void (*(char const*, std::function<void ()>))(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) () at /usr/include/c++/9/functional:400
#41 std::_Bind<void (*(char const*, std::function<void ()>))(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>)>::operator()<, void>() () at /usr/include/c++/9/functional:484
#42 boost::detail::thread_data<std::_Bind<void (*(char const*, std::function<void ()>))(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::function<void ()>)> >::run() () at /raptoreum/depends/x86_64-pc-linux-gnu/share/../include/boost/thread/detail/thread.hpp:120
#43 0x0000557ec6543486 in thread_proxy ()
#44 0x00007f08823b4609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#45 0x00007f088216f133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
