### PR TITLE
Add minrefresh option

### DIFF
--- a/src/qt/raptoreum.cpp
+++ b/src/qt/raptoreum.cpp
@@ -569,6 +569,7 @@ static void SetupUIArgs()
     gArgs.AddArg("-uiplatform", strprintf("Select platform to customize UI for (one of windows, macosx, other; default: %s)", BitcoinGUI::DEFAULT_UIPLATFORM), true, OptionsCategory::GUI);
     gArgs.AddArg("-debug-ui", "Updates the UI's stylesheets in realtime with changes made to the css files in -custom-css-dir and forces some widgets to show up which are usually only visible under certain circumstances. (default: 0)", true, OptionsCategory::GUI);
     gArgs.AddArg("-windowtitle=<name>", _("Sets a window title which is appended to \"Raptoreum Core - \""), false, OptionsCategory::GUI);
+    gArgs.AddArg("-minrefresh", "Minimize UI refreshes.  Fully confirmed transactions will not update with each new block (default: false)", false, OptionsCategory::GUI);
 }
 
 #ifndef BITCOIN_QT_TEST

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -327,6 +327,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     if (wtx->value_map.count("comment") && !wtx->value_map["comment"].empty())
         strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx->value_map["comment"], true) + "<br>";
 
+    strHTML += "<b>" + tr("Height") + ":</b> " + QString::number(status.block_height) + "<br>"; 
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx->tx->GetTotalSize()) + " bytes<br>";

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -443,9 +443,10 @@ void TransactionRecord::updateStatus(const std::shared_ptr<const interfaces::Wal
 
 bool TransactionRecord::statusUpdateNeeded(int numBlocks, int chainLockHeight) const
 {
+    static bool minRefresh = gArgs.GetBoolArg("-minrefresh", false);
     bool numBlocksChanged = status.cur_num_blocks != numBlocks;
 
-    // Block height changes do not matter for final states:
+    // Block height changes do not matter for final states, except to update confirmations:
     bool completed =
         status.status == TransactionStatus::Confirmed ||
         status.status == TransactionStatus::Abandoned ||
@@ -453,7 +454,8 @@ bool TransactionRecord::statusUpdateNeeded(int numBlocks, int chainLockHeight) c
 
     return
         status.needsUpdate ||
-        (numBlocksChanged && !completed) ||
+        (!minRefresh && numBlocksChanged) ||
+        (!completed) ||
         (!status.lockedByChainLocks && status.cachedChainLockHeight != chainLockHeight);
 }
 


### PR DESCRIPTION
I had added an option (`minrefresh=1`) for the Qt wallet to minimize UI refreshes every transaction after each new block.  For wallets with a large number of transactions, this refresh can be problematic.  This refresh is bypassed only for fully confirmed transactions.

The default (`minrefresh=0`) is to refresh after each block, so the confirmation count will rise as expected.

I also added block height to the transaction details in the tooltip.  I find myself looking for that regularly.