### PR TITLE
Add pose penalty to smartnode list

### DIFF
--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -667,6 +667,7 @@ UniValue smartnodelist(const JSONRPCRequest& request)
             objMN.pushKV("votingaddress", EncodeDestination(dmn->pdmnState->keyIDVoting));
             objMN.pushKV("collateraladdress", collateralAddressStr);
             objMN.pushKV("pubkeyoperator", dmn->pdmnState->pubKeyOperator.Get().ToString());
+            objMN.pushKV("posepenalty", dmn->pdmnState->nPoSePenalty);
             obj.pushKV(strOutpoint, objMN);
         } else if (strMode == "lastpaidblock") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;


### PR DESCRIPTION
Added posepenalty to the RPC `smartnode list` call.  I find it very useful to monitor the network and quorums.

For example, you can get the sum of all PoSe penaltieis like this (the Network PoSe Penalty):
`raptoreum-cli smartnode list | grep -i posepenalty | awk '{ sum += $2 } END { print sum }'`
