### PR TITLE
add spendableHeight and spendableTime to getaddressutxos output

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -662,6 +662,8 @@ UniValue getaddressutxos(const JSONRPCRequest& request)
         output.pushKV("script", HexStr(it->second.script.begin(), it->second.script.end()));
         output.pushKV("satoshis", it->second.satoshis);
         output.pushKV("height", it->second.blockHeight);
+        output.pushKV("spendableHeight", it->second.fSpendableHeight);
+        output.pushKV("spendableTime", it->second.fSpendableTime);
         result.push_back(output);
     }
 


### PR DESCRIPTION
they were missing from getaddressutxos so client currently would not able to determine whether an unspent is being locked