### PR TITLE
Auto lock smartnode collaterals after sync completes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Raptoreum Core Latest v1.3.17.02
+Raptoreum Core Latest v1.3.17.03
 ===========================
 
 |CI|master|develop|

--- a/build.properties
+++ b/build.properties
@@ -1,3 +1,3 @@
-snapshot-version=1.3.17.02-SNAPSHOT
-release-version=1.3.17.02
-candidate-version=1.3.17.02-candidate
+snapshot-version=1.3.17.03-SNAPSHOT
+release-version=1.3.17.03
+candidate-version=1.3.17.03-candidate


### PR DESCRIPTION
When performing a full sync, smartnode collateral transactions are not locked when the sync completes.  The problem is that during initialization, those transactions are locked - but we have not synced the transactions, yet, so they are not locked.

I have added a one-time re-lock of collateral transactions when the sync completes.