### PR TITLE
Fix vout shuffling in FundTransaction.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3381,7 +3381,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
     // Copy output sizes from new transaction; they may have had the fee
     // subtracted from them.
     for (unsigned int idx = 0; idx < tx.vout.size(); idx++) {
-        tx.vout[idx].nValue = tx_new->vout[idx].nValue;
+        tx.vout[idx] = tx_new->vout[idx];
     }
 
     // Add new txins while keeping original txin scriptSig/order.


### PR DESCRIPTION
This should fix the reordering of vout transactions while using FundTransaction.

The current code can reorder vout amount that is sent while keeping not corresponding script/address
example transaction (WALLET: AMOUNT)
X: 20.0
Y: 30.0
Z: 10.0
After FundTransaction (fundrawtransaction in a wallet)
X: 10.0
Y: 20.0
Z: 30.0

Amounts are sorted according to BIP69 but the addresses are not changed with it right now.
This results in a completely broken send which can go through, but the recipients will get completely different amounts in most cases.

New code fixes that issue.