### PR TITLE
[Assets] unique assets, consensus, qt send asset

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -36,6 +36,7 @@ QT_FORMS_UI = \
   qt/forms/appearancewidget.ui \
   qt/forms/askpassphrasedialog.ui \
   qt/forms/coincontroldialog.ui \
+  qt/forms/assetcontroldialog.ui \
   qt/forms/editaddressdialog.ui \
   qt/forms/helpmessagedialog.ui \
   qt/forms/intro.ui \
@@ -50,6 +51,8 @@ QT_FORMS_UI = \
   qt/forms/debugwindow.ui \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
+  qt/forms/sendassetsdialog.ui \
+  qt/forms/sendassetsentry.ui \
   qt/forms/signverifymessagedialog.ui \
   qt/forms/transactiondescdialog.ui
 
@@ -67,6 +70,8 @@ QT_MOC_CPP = \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
+  qt/moc_assetcontroldialog.cpp \
+  qt/moc_assetcontroltreewidget.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
   qt/moc_guiutil.cpp \
@@ -91,6 +96,8 @@ QT_MOC_CPP = \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sendcoinsentry.cpp \
+  qt/moc_sendassetsdialog.cpp \
+  qt/moc_sendassetsentry.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
   qt/moc_trafficgraphwidget.cpp \
@@ -140,6 +147,8 @@ BITCOIN_QT_H = \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \
+  qt/assetcontroldialog.h \
+  qt/assetcontroltreewidget.h \
   qt/csvmodelwriter.h \
   qt/editaddressdialog.h \
   qt/guiconstants.h \
@@ -168,6 +177,8 @@ BITCOIN_QT_H = \
   qt/rpcconsole.h \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
+  qt/sendassesdialog.h \
+  qt/sendassetsentry.h \
   qt/signverifymessagedialog.h \
   qt/splashscreen.h \
   qt/trafficgraphdata.h \
@@ -272,6 +283,8 @@ BITCOIN_QT_WALLET_CPP = \
   qt/askpassphrasedialog.cpp \
   qt/coincontroldialog.cpp \
   qt/coincontroltreewidget.cpp \
+  qt/assetcontroldialog.cpp \
+  qt/assetcontroltreewidget.cpp \
   qt/editaddressdialog.cpp \
   qt/smartnodelist.cpp \
   qt/openuridialog.cpp \
@@ -284,6 +297,8 @@ BITCOIN_QT_WALLET_CPP = \
   qt/recentrequeststablemodel.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
+  qt/sendassetsdialog.cpp \
+  qt/sendassetsentry.cpp \
   qt/signverifymessagedialog.cpp \
   qt/transactiondesc.cpp \
   qt/transactiondescdialog.cpp \

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -40,7 +40,7 @@ bool GetAssetId(const CScript& script, std::string& assetId)
 {
     CAssetTransfer assetTransfer;
     if (GetTransferAsset(script, assetTransfer)) {
-        assetId = assetTransfer.AssetId;
+        assetId = assetTransfer.assetId;
         return true;
     }
     return false;
@@ -48,168 +48,168 @@ bool GetAssetId(const CScript& script, std::string& assetId)
 
 CAssetMetaData::CAssetMetaData(const std::string txid, const CNewAssetTx assetTx)
 {
-    this->assetId = txid;
-    this->circulatingSupply = 0;
-    this->mintCount = 0;
-    this->Name = assetTx.Name;
-    this->updatable = assetTx.updatable;
-    this->isunique = assetTx.isUnique;
-    this->Decimalpoint = assetTx.decimalPoint;
-    this->referenceHash = assetTx.referenceHash;
-    this->maxMintCount = assetTx.maxMintCount;
-    this->fee = assetTx.fee;
-    this->type = assetTx.type;
-    this->targetAddress = assetTx.targetAddress;
-    this->issueFrequency = assetTx.issueFrequency;
-    this->Amount = assetTx.Amount;
-    this->ownerAddress = assetTx.ownerAddress;
-    this->collateralAddress = assetTx.collateralAddress;
+    assetId = txid;
+    circulatingSupply = 0;
+    mintCount = 0;
+    name = assetTx.name;
+    updatable = assetTx.updatable;
+    isUnique = assetTx.isUnique;
+    decimalPoint = assetTx.decimalPoint;
+    referenceHash = assetTx.referenceHash;
+    maxMintCount = assetTx.maxMintCount;
+    fee = assetTx.fee;
+    type = assetTx.type;
+    targetAddress = assetTx.targetAddress;
+    issueFrequency = assetTx.issueFrequency;
+    amount = assetTx.amount;
+    ownerAddress = assetTx.ownerAddress;
+    collateralAddress = assetTx.collateralAddress;
 }
 
-CDatabasedAssetData::CDatabasedAssetData(const CAssetMetaData& asset, const int& nHeight, const uint256& blockHash)
+CDatabaseAssetData::CDatabaseAssetData(const CAssetMetaData& asset, const int& nHeight, const uint256& blockHash)
 {
-    this->SetNull();
+    SetNull();
     this->asset = asset;
     this->blockHeight = nHeight;
     this->blockHash = blockHash;
 }
 
-CDatabasedAssetData::CDatabasedAssetData()
+CDatabaseAssetData::CDatabaseAssetData()
 {
-    this->SetNull();
+    SetNull();
 }
 
-bool CAssetsCache::InsertAsset(CNewAssetTx newasset, std::string assetid, int nheigth)
+bool CAssetsCache::InsertAsset(CNewAssetTx newAsset, std::string assetId, int nHeight)
 {
-    if (CheckIfAssetExists(assetid))
-        return error("%s: Tried adding new asset, but it already existed in the map of assets: %s", __func__, assetid);
-    CAssetMetaData test(assetid, newasset);
-    CDatabasedAssetData newAsset(test, nheigth, uint256());
+    if (CheckIfAssetExists(assetId))
+        return error("%s: Tried adding new asset, but it already existed in the map of assets: %s", __func__, assetId);
+    CAssetMetaData test(assetId, newAsset);
+    CDatabaseAssetData newAssetData(test, nHeight, uint256());
 
-    if (NewAssetsToRemove.count(newAsset))
-        NewAssetsToRemove.erase(newAsset);
+    if (NewAssetsToRemove.count(newAssetData))
+        NewAssetsToRemove.erase(newAssetData);
 
-    NewAssetsToAdd.insert(newAsset);
+    NewAssetsToAdd.insert(newAssetData);
 
-    mapAsset.insert(std::make_pair(assetid, newAsset));
-    mapAssetid.insert(std::make_pair(newAsset.asset.Name, assetid));
+    mapAsset.insert(std::make_pair(assetId, newAssetData));
+    mapAssetId.insert(std::make_pair(newAssetData.asset.name, assetId));
 
     return true;
 }
 
-bool CAssetsCache::UpdateAsset(CUpdateAssetTx upasset)
+bool CAssetsCache::UpdateAsset(CUpdateAssetTx upAsset)
 {
-    CAssetMetaData assetdata;
-    if (!GetAssetMetaData(upasset.AssetId, assetdata)) {
+    CAssetMetaData assetData;
+    if (!GetAssetMetaData(upAsset.assetId, assetData)) {
         return false;
     }
 
-    if (NewAssetsToAdd.count(mapAsset[upasset.AssetId]))
-        NewAssetsToAdd.erase(mapAsset[upasset.AssetId]);
+    if (NewAssetsToAdd.count(mapAsset[upAsset.assetId]))
+        NewAssetsToAdd.erase(mapAsset[upAsset.assetId]);
 
-    NewAssetsToRemove.insert(mapAsset[upasset.AssetId]);
+    NewAssetsToRemove.insert(mapAsset[upAsset.assetId]);
 
-    assetdata.updatable = upasset.updatable;
-    assetdata.referenceHash = upasset.referenceHash;
-    assetdata.type = upasset.type;
-    assetdata.targetAddress = upasset.targetAddress;
-    assetdata.issueFrequency = upasset.issueFrequency;
-    assetdata.Amount = upasset.Amount;
-    assetdata.ownerAddress = upasset.ownerAddress;
-    assetdata.collateralAddress = upasset.collateralAddress;
+    assetData.updatable = upAsset.updatable;
+    assetData.referenceHash = upAsset.referenceHash;
+    assetData.type = upAsset.type;
+    assetData.targetAddress = upAsset.targetAddress;
+    assetData.issueFrequency = upAsset.issueFrequency;
+    assetData.amount = upAsset.amount;
+    assetData.ownerAddress = upAsset.ownerAddress;
+    assetData.collateralAddress = upAsset.collateralAddress;
     //update cache
-    mapAsset[upasset.AssetId].asset = assetdata;
+    mapAsset[upAsset.assetId].asset = assetData;
     //update db
-    NewAssetsToAdd.insert(mapAsset[upasset.AssetId]);
+    NewAssetsToAdd.insert(mapAsset[upAsset.assetId]);
     return true;
 }
 
-bool CAssetsCache::UpdateAsset(std::string assetid, CAmount amount)
+bool CAssetsCache::UpdateAsset(std::string assetId, CAmount amount)
 {
-    if (mapAsset.count(assetid) > 0) {
-        if (NewAssetsToAdd.count(mapAsset[assetid]))
-            NewAssetsToAdd.erase(mapAsset[assetid]);
+    if (mapAsset.count(assetId) > 0) {
+        if (NewAssetsToAdd.count(mapAsset[assetId]))
+            NewAssetsToAdd.erase(mapAsset[assetId]);
 
-        NewAssetsToRemove.insert(mapAsset[assetid]);
-        mapAsset[assetid].asset.circulatingSupply += amount;
-        mapAsset[assetid].asset.mintCount += 1;
-        NewAssetsToAdd.insert(mapAsset[assetid]);
+        NewAssetsToRemove.insert(mapAsset[assetId]);
+        mapAsset[assetId].asset.circulatingSupply += amount;
+        mapAsset[assetId].asset.mintCount += 1;
+        NewAssetsToAdd.insert(mapAsset[assetId]);
         return true;
     }
     return false;
 }
 
-bool CAssetsCache::RemoveAsset(std::string asetId)
+bool CAssetsCache::RemoveAsset(std::string assetId)
 {
-    if (mapAsset.count(asetId) > 0) {
-        if (NewAssetsToAdd.count(mapAsset[asetId]))
-            NewAssetsToAdd.erase(mapAsset[asetId]);
+    if (mapAsset.count(assetId) > 0) {
+        if (NewAssetsToAdd.count(mapAsset[assetId]))
+            NewAssetsToAdd.erase(mapAsset[assetId]);
 
-        NewAssetsToRemove.insert(mapAsset[asetId]);
+        NewAssetsToRemove.insert(mapAsset[assetId]);
         return true;
     }
     return false;
 }
 
-bool CAssetsCache::UndoUpdateAsset(const CUpdateAssetTx upasset, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData)
+bool CAssetsCache::UndoUpdateAsset(const CUpdateAssetTx upAsset, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData)
 {
-    if (mapAsset.count(upasset.AssetId) > 0) {
-        CAssetMetaData assetdata;
-        if (!GetAssetMetaData(upasset.AssetId, assetdata)) {
+    if (mapAsset.count(upAsset.assetId) > 0) {
+        CAssetMetaData assetData;
+        if (!GetAssetMetaData(upAsset.assetId, assetData)) {
             return false;
         }
 
-        if (NewAssetsToAdd.count(mapAsset[upasset.AssetId]))
-            NewAssetsToAdd.erase(mapAsset[upasset.AssetId]);
+        if (NewAssetsToAdd.count(mapAsset[upAsset.assetId]))
+            NewAssetsToAdd.erase(mapAsset[upAsset.assetId]);
 
-        NewAssetsToRemove.insert(mapAsset[upasset.AssetId]);
+        NewAssetsToRemove.insert(mapAsset[upAsset.assetId]);
 
         for (auto item : vUndoData) {
-            if (item.first == upasset.AssetId) {
-                assetdata.updatable = item.second.updatable;
-                assetdata.referenceHash = item.second.referenceHash;
-                assetdata.type = item.second.type;
-                assetdata.targetAddress = item.second.targetAddress;
-                assetdata.issueFrequency = item.second.issueFrequency;
-                assetdata.Amount = item.second.Amount;
-                assetdata.ownerAddress = item.second.ownerAddress;
-                assetdata.collateralAddress = item.second.collateralAddress;
+            if (item.first == upAsset.assetId) {
+                assetData.updatable = item.second.updatable;
+                assetData.referenceHash = item.second.referenceHash;
+                assetData.type = item.second.type;
+                assetData.targetAddress = item.second.targetAddress;
+                assetData.issueFrequency = item.second.issueFrequency;
+                assetData.amount = item.second.amount;
+                assetData.ownerAddress = item.second.ownerAddress;
+                assetData.collateralAddress = item.second.collateralAddress;
             }
         }
 
         //update cache
-        mapAsset[upasset.AssetId].asset = assetdata;
+        mapAsset[upAsset.assetId].asset = assetData;
         //update db
-        NewAssetsToAdd.insert(mapAsset[upasset.AssetId]);
+        NewAssetsToAdd.insert(mapAsset[upAsset.assetId]);
         return true;
     }
     return false;
 }
 
-bool CAssetsCache::UndoMintAsset(const CMintAssetTx assettx, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData)
+bool CAssetsCache::UndoMintAsset(const CMintAssetTx assetTx, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData)
 {
-    if (mapAsset.count(assettx.AssetId) > 0) {
-        CAssetMetaData assetdata;
-        if (!GetAssetMetaData(assettx.AssetId, assetdata)) {
+    if (mapAsset.count(assetTx.assetId) > 0) {
+        CAssetMetaData assetData;
+        if (!GetAssetMetaData(assetTx.assetId, assetData)) {
             return false;
         }
 
-        if (NewAssetsToAdd.count(mapAsset[assettx.AssetId]))
-            NewAssetsToAdd.erase(mapAsset[assettx.AssetId]);
+        if (NewAssetsToAdd.count(mapAsset[assetTx.assetId]))
+            NewAssetsToAdd.erase(mapAsset[assetTx.assetId]);
 
-        NewAssetsToRemove.insert(mapAsset[assettx.AssetId]);
+        NewAssetsToRemove.insert(mapAsset[assetTx.assetId]);
 
         for (auto item : vUndoData) {
-            if (item.first == assettx.AssetId) {
-                assetdata.circulatingSupply = item.second.circulatingSupply;
-                assetdata.mintCount = item.second.mintCount;
+            if (item.first == assetTx.assetId) {
+                assetData.circulatingSupply = item.second.circulatingSupply;
+                assetData.mintCount = item.second.mintCount;
             }
         }
 
         //update cache
-        mapAsset[assettx.AssetId].asset = assetdata;
+        mapAsset[assetTx.assetId].asset = assetData;
         //update db
-        NewAssetsToAdd.insert(mapAsset[assettx.AssetId]);
+        NewAssetsToAdd.insert(mapAsset[assetTx.assetId]);
         return true;
     }
     return false;
@@ -220,7 +220,7 @@ bool CAssetsCache::CheckIfAssetExists(std::string assetId)
     //check if the asset is removed
     CAssetMetaData tempAsset;
     tempAsset.assetId = assetId;
-    CDatabasedAssetData cachedAsset(tempAsset, 0, uint256());
+    CDatabaseAssetData cachedAsset(tempAsset, 0, uint256());
     if (NewAssetsToRemove.count(cachedAsset)) {
         return false;
     }
@@ -234,7 +234,7 @@ bool CAssetsCache::CheckIfAssetExists(std::string assetId)
     uint256 blockHash;
     CAssetMetaData asset;
     if (passetsdb->ReadAssetData(assetId, asset, nHeight, blockHash)) {
-        CDatabasedAssetData newAsset(asset, nHeight, blockHash);
+        CDatabaseAssetData newAsset(asset, nHeight, blockHash);
         mapAsset.insert(std::make_pair(assetId, newAsset));
         return true;
     }
@@ -243,15 +243,15 @@ bool CAssetsCache::CheckIfAssetExists(std::string assetId)
 
 bool CAssetsCache::GetAssetId(std::string name, std::string& assetId)
 {
-    //try to get assetid by asset name
-    auto it = mapAssetid.find(name);
-    if (it != mapAssetid.end()) {
+    //try to get assetId by asset name
+    auto it = mapAssetId.find(name);
+    if (it != mapAssetId.end()) {
         assetId = it->second;
         return true;
     }
     //try to get asset id from the db
     if (passetsdb->ReadAssetId(name, assetId)) {
-        mapAssetid.insert(std::make_pair(name, assetId));
+        mapAssetId.insert(std::make_pair(name, assetId));
         return true;
     }
     return false;
@@ -275,7 +275,7 @@ bool CAssetsCache::GetAssetMetaData(std::string assetId, CAssetMetaData& asset)
     int nHeight;
     uint256 blockHash;
     if (passetsdb->ReadAssetData(assetId, asset, nHeight, blockHash)) {
-        CDatabasedAssetData newAsset(asset, nHeight, blockHash);
+        CDatabaseAssetData newAsset(asset, nHeight, blockHash);
         mapAsset.insert(std::make_pair(assetId, newAsset));
         return true;
     }
@@ -290,7 +290,7 @@ bool CAssetsCache::DumpCacheToDatabase()
             if (!passetsdb->EraseAssetData(newAsset.asset.assetId)) {
                 return error("%s : %s", __func__, "_Failed Erasing Asset Data from database");
             }
-            if (!passetsdb->EraseAssetId(newAsset.asset.Name)) {
+            if (!passetsdb->EraseAssetId(newAsset.asset.name)) {
                 return error("%s : %s", __func__, "_Failed Erasing Asset Data from database");
             }
         }
@@ -299,7 +299,7 @@ bool CAssetsCache::DumpCacheToDatabase()
             if (!passetsdb->WriteAssetData(newAsset.asset, newAsset.blockHeight, newAsset.blockHash)) {
                 return error("%s : %s", __func__, "_Failed Writing New Asset Data to database");
             }
-            if (!passetsdb->WriteAssetId(newAsset.asset.Name, newAsset.asset.assetId)) {
+            if (!passetsdb->WriteAssetId(newAsset.asset.name, newAsset.asset.assetId)) {
                 return error("%s : %s", __func__, "_Failed Writing New Asset Data to database");
             }
         }
@@ -331,8 +331,8 @@ bool CAssetsCache::Flush()
         for (auto& item : mapAsset)
             passetsCache->mapAsset[item.first] = item.second;
 
-        for (auto& item : mapAssetid)
-            passetsCache->mapAssetid[item.first] = item.second;
+        for (auto& item : mapAssetId)
+            passetsCache->mapAssetId[item.first] = item.second;
 
         return true;
 
@@ -345,18 +345,18 @@ void AddAssets(const CTransaction& tx, int nHeight, CAssetsCache* assetCache, st
 {
     if (Params().IsAssetsActive(chainActive.Tip()) && assetCache) {
         if (tx.nType == TRANSACTION_NEW_ASSET) {
-            CNewAssetTx assettx;
-            if (GetTxPayload(tx, assettx)) {
-                assetCache->InsertAsset(assettx, tx.GetHash().ToString(), nHeight);
+            CNewAssetTx assetTx;
+            if (GetTxPayload(tx, assetTx)) {
+                assetCache->InsertAsset(assetTx, tx.GetHash().ToString(), nHeight);
             }
         } else if (tx.nType == TRANSACTION_UPDATE_ASSET) {
-            CUpdateAssetTx assettx;
-            if (GetTxPayload(tx, assettx)) {
+            CUpdateAssetTx assetTx;
+            if (GetTxPayload(tx, assetTx)) {
                 CAssetMetaData asset;
-                if (!assetCache->GetAssetMetaData(assettx.AssetId, asset))
+                if (!assetCache->GetAssetMetaData(assetTx.assetId, asset))
                     return;
-                assetCache->UpdateAsset(assettx);
-                undoAssetData->first = assettx.AssetId; // Asset Name
+                assetCache->UpdateAsset(assetTx);
+                undoAssetData->first = assetTx.assetId; // Asset Name
                 undoAssetData->second = CBlockAssetUndo{false, asset.circulatingSupply,
                     asset.mintCount,
                     asset.updatable,
@@ -364,13 +364,13 @@ void AddAssets(const CTransaction& tx, int nHeight, CAssetsCache* assetCache, st
                     asset.type,
                     asset.targetAddress,
                     asset.issueFrequency,
-                    asset.Amount,
+                    asset.amount,
                     asset.ownerAddress,
                     asset.collateralAddress};
             }
         } else if (tx.nType == TRANSACTION_MINT_ASSET) {
-            CMintAssetTx assettx;
-            if (GetTxPayload(tx, assettx)) {
+            CMintAssetTx assetTx;
+            if (GetTxPayload(tx, assetTx)) {
                 CAmount amount = 0;
                 for (auto out : tx.vout) {
                     if (out.scriptPubKey.IsAssetScript()) {
@@ -380,10 +380,10 @@ void AddAssets(const CTransaction& tx, int nHeight, CAssetsCache* assetCache, st
                     }
                 }
                 CAssetMetaData asset;
-                if (!assetCache->GetAssetMetaData(assettx.AssetId, asset))
+                if (!assetCache->GetAssetMetaData(assetTx.assetId, asset))
                     return;
-                assetCache->UpdateAsset(assettx.AssetId, amount); //update circulating suply
-                undoAssetData->first = assettx.AssetId;           // Asset Name
+                assetCache->UpdateAsset(assetTx.assetId, amount); // Update circulating supply
+                undoAssetData->first = assetTx.assetId;           // Asset Name
                 undoAssetData->second = CBlockAssetUndo{true, asset.circulatingSupply,
                     asset.mintCount,
                     asset.updatable,
@@ -391,7 +391,7 @@ void AddAssets(const CTransaction& tx, int nHeight, CAssetsCache* assetCache, st
                     asset.type,
                     asset.targetAddress,
                     asset.issueFrequency,
-                    asset.Amount,
+                    asset.amount,
                     asset.ownerAddress,
                     asset.collateralAddress};
             }
@@ -408,7 +408,7 @@ bool GetAssetData(const CScript& script, CAssetOutputEntry& data)
     if (GetTransferAsset(script, transfer)) {
         data.nAmount = transfer.nAmount;
         ExtractDestination(script, data.destination);
-        data.assetId = transfer.AssetId;
+        data.assetId = transfer.assetId;
         return true;
     }
     return false;
@@ -428,5 +428,5 @@ bool validateAmount(const std::string& assetId, const CAmount nAmount)
     if (!passetsCache->GetAssetMetaData(assetId, asset))
         return false; //this should never happen
 
-    return validateAmount(nAmount, asset.Decimalpoint);
+    return validateAmount(nAmount, asset.decimalPoint);
 }

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -3,33 +3,33 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <assets/assets.h>
-#include <assets/assetstype.h>
 #include <assets/assetsdb.h>
-#include <wallet/wallet.h>
-#include <spork.h>
-#include <evo/specialtx.h>
-#include <evo/providertx.h>
+#include <assets/assetstype.h>
 #include <chainparams.h>
-#include <validation.h>
+#include <evo/providertx.h>
+#include <evo/specialtx.h>
 #include <regex>
+#include <spork.h>
+#include <validation.h>
+#include <wallet/wallet.h>
 
 static const std::regex name_characters("^[a-zA-Z0-9 ]{3,}$");
 static const std::regex rtm_names("^RTM$|^RAPTOREUM$|^wRTM$|^WRTM$|^RTMcoin$|^RTMCOIN$");
 
 bool IsAssetNameValid(std::string name)
-{ 
+{
     if (name.length() < 3 || name.length() > 128) return false;
     return std::regex_match(name, name_characters) && !std::regex_match(name, rtm_names);
 }
 
-CAmount getAssetsFeesCoin() 
+CAmount getAssetsFeesCoin()
 {
-	return getAssetsFees() * COIN;
+    return getAssetsFees() * COIN;
 }
 
-uint16_t getAssetsFees() 
+uint16_t getAssetsFees()
 {
-    if(!sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE)) {
+    if (!sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE)) {
         return 0;
     }
     int64_t specialTxValue = sporkManager.GetSporkValue(SPORK_22_SPECIAL_TX_FEE);
@@ -39,7 +39,7 @@ uint16_t getAssetsFees()
 bool GetAssetId(const CScript& script, std::string& assetId)
 {
     CAssetTransfer assetTransfer;
-    if(GetTransferAsset(script,assetTransfer)){
+    if (GetTransferAsset(script, assetTransfer)) {
         assetId = assetTransfer.AssetId;
         return true;
     }
@@ -81,32 +81,31 @@ CDatabasedAssetData::CDatabasedAssetData()
 
 bool CAssetsCache::InsertAsset(CNewAssetTx newasset, std::string assetid, int nheigth)
 {
-
     if (CheckIfAssetExists(assetid))
         return error("%s: Tried adding new asset, but it already existed in the map of assets: %s", __func__, assetid);
     CAssetMetaData test(assetid, newasset);
     CDatabasedAssetData newAsset(test, nheigth, uint256());
 
-    if(NewAssetsToRemove.count(newAsset))
+    if (NewAssetsToRemove.count(newAsset))
         NewAssetsToRemove.erase(newAsset);
 
     NewAssetsToAdd.insert(newAsset);
 
     mapAsset.insert(std::make_pair(assetid, newAsset));
     mapAssetid.insert(std::make_pair(newAsset.asset.Name, assetid));
-    
-    return true;    
+
+    return true;
 }
 
 bool CAssetsCache::UpdateAsset(CUpdateAssetTx upasset)
 {
     CAssetMetaData assetdata;
-    if(!GetAssetMetaData(upasset.AssetId, assetdata)){
+    if (!GetAssetMetaData(upasset.AssetId, assetdata)) {
         return false;
     }
 
     if (NewAssetsToAdd.count(mapAsset[upasset.AssetId]))
-            NewAssetsToAdd.erase(mapAsset[upasset.AssetId]);
+        NewAssetsToAdd.erase(mapAsset[upasset.AssetId]);
 
     NewAssetsToRemove.insert(mapAsset[upasset.AssetId]);
 
@@ -127,10 +126,10 @@ bool CAssetsCache::UpdateAsset(CUpdateAssetTx upasset)
 
 bool CAssetsCache::UpdateAsset(std::string assetid, CAmount amount)
 {
-    if(mapAsset.count(assetid) > 0 ){
+    if (mapAsset.count(assetid) > 0) {
         if (NewAssetsToAdd.count(mapAsset[assetid]))
             NewAssetsToAdd.erase(mapAsset[assetid]);
-    
+
         NewAssetsToRemove.insert(mapAsset[assetid]);
         mapAsset[assetid].asset.circulatingSupply += amount;
         mapAsset[assetid].asset.mintCount += 1;
@@ -142,31 +141,31 @@ bool CAssetsCache::UpdateAsset(std::string assetid, CAmount amount)
 
 bool CAssetsCache::RemoveAsset(std::string asetId)
 {
-    if(mapAsset.count(asetId) > 0 ){
+    if (mapAsset.count(asetId) > 0) {
         if (NewAssetsToAdd.count(mapAsset[asetId]))
             NewAssetsToAdd.erase(mapAsset[asetId]);
-        
+
         NewAssetsToRemove.insert(mapAsset[asetId]);
         return true;
     }
     return false;
 }
 
-bool CAssetsCache::UndoUpdateAsset(const CUpdateAssetTx upasset, const std::vector<std::pair<std::string, CBlockAssetUndo> >& vUndoData)
+bool CAssetsCache::UndoUpdateAsset(const CUpdateAssetTx upasset, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData)
 {
-    if(mapAsset.count(upasset.AssetId) > 0 ){
+    if (mapAsset.count(upasset.AssetId) > 0) {
         CAssetMetaData assetdata;
-        if(!GetAssetMetaData(upasset.AssetId, assetdata)){
+        if (!GetAssetMetaData(upasset.AssetId, assetdata)) {
             return false;
         }
 
         if (NewAssetsToAdd.count(mapAsset[upasset.AssetId]))
-                NewAssetsToAdd.erase(mapAsset[upasset.AssetId]);
+            NewAssetsToAdd.erase(mapAsset[upasset.AssetId]);
 
         NewAssetsToRemove.insert(mapAsset[upasset.AssetId]);
 
-        for (auto item : vUndoData){
-            if (item.first == upasset.AssetId){
+        for (auto item : vUndoData) {
+            if (item.first == upasset.AssetId) {
                 assetdata.updatable = item.second.updatable;
                 assetdata.referenceHash = item.second.referenceHash;
                 assetdata.type = item.second.type;
@@ -187,26 +186,26 @@ bool CAssetsCache::UndoUpdateAsset(const CUpdateAssetTx upasset, const std::vect
     return false;
 }
 
-bool CAssetsCache::UndoMintAsset(const CMintAssetTx assettx, const std::vector<std::pair<std::string, CBlockAssetUndo> >& vUndoData)
+bool CAssetsCache::UndoMintAsset(const CMintAssetTx assettx, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData)
 {
-    if(mapAsset.count(assettx.AssetId) > 0 ){
+    if (mapAsset.count(assettx.AssetId) > 0) {
         CAssetMetaData assetdata;
-        if(!GetAssetMetaData(assettx.AssetId, assetdata)){
+        if (!GetAssetMetaData(assettx.AssetId, assetdata)) {
             return false;
         }
 
         if (NewAssetsToAdd.count(mapAsset[assettx.AssetId]))
-                NewAssetsToAdd.erase(mapAsset[assettx.AssetId]);
+            NewAssetsToAdd.erase(mapAsset[assettx.AssetId]);
 
         NewAssetsToRemove.insert(mapAsset[assettx.AssetId]);
 
-        for (auto item : vUndoData){
-            if (item.first == assettx.AssetId){
+        for (auto item : vUndoData) {
+            if (item.first == assettx.AssetId) {
                 assetdata.circulatingSupply = item.second.circulatingSupply;
                 assetdata.mintCount = item.second.mintCount;
             }
         }
-        
+
         //update cache
         mapAsset[assettx.AssetId].asset = assetdata;
         //update db
@@ -222,19 +221,19 @@ bool CAssetsCache::CheckIfAssetExists(std::string assetId)
     CAssetMetaData tempAsset;
     tempAsset.assetId = assetId;
     CDatabasedAssetData cachedAsset(tempAsset, 0, uint256());
-    if (NewAssetsToRemove.count(cachedAsset)){
+    if (NewAssetsToRemove.count(cachedAsset)) {
         return false;
     }
 
-    if(mapAsset.count(assetId) > 0 ){
+    if (mapAsset.count(assetId) > 0) {
         return true;
     }
 
     //check if the asset exist on the db
-    int nHeight; 
+    int nHeight;
     uint256 blockHash;
     CAssetMetaData asset;
-    if (passetsdb->ReadAssetData(assetId, asset, nHeight, blockHash)){
+    if (passetsdb->ReadAssetData(assetId, asset, nHeight, blockHash)) {
         CDatabasedAssetData newAsset(asset, nHeight, blockHash);
         mapAsset.insert(std::make_pair(assetId, newAsset));
         return true;
@@ -246,12 +245,12 @@ bool CAssetsCache::GetAssetId(std::string name, std::string& assetId)
 {
     //try to get assetid by asset name
     auto it = mapAssetid.find(name);
-    if( it != mapAssetid.end() ) {
+    if (it != mapAssetid.end()) {
         assetId = it->second;
         return true;
     }
     //try to get asset id from the db
-    if (passetsdb->ReadAssetId(name, assetId)){
+    if (passetsdb->ReadAssetId(name, assetId)) {
         mapAssetid.insert(std::make_pair(name, assetId));
         return true;
     }
@@ -261,21 +260,21 @@ bool CAssetsCache::GetAssetId(std::string name, std::string& assetId)
 bool CAssetsCache::GetAssetMetaData(std::string assetId, CAssetMetaData& asset)
 {
     auto it = mapAsset.find(assetId);
-    if (it != mapAsset.end() ) {
+    if (it != mapAsset.end()) {
         asset = it->second.asset;
         return true;
     }
 
     auto it2 = passetsCache->mapAsset.find(assetId);
-    if (it2 != passetsCache->mapAsset.end() ) {
+    if (it2 != passetsCache->mapAsset.end()) {
         mapAsset.insert(std::make_pair(assetId, it2->second));
         asset = it2->second.asset;
         return true;
     }
 
-    int nHeight; 
+    int nHeight;
     uint256 blockHash;
-    if (passetsdb->ReadAssetData(assetId, asset, nHeight, blockHash)){
+    if (passetsdb->ReadAssetData(assetId, asset, nHeight, blockHash)) {
         CDatabasedAssetData newAsset(asset, nHeight, blockHash);
         mapAsset.insert(std::make_pair(assetId, newAsset));
         return true;
@@ -287,21 +286,21 @@ bool CAssetsCache::DumpCacheToDatabase()
 {
     try {
         //remove assets from db
-        for (auto newAsset : NewAssetsToRemove){
-            if (!passetsdb->EraseAssetData(newAsset.asset.assetId)){
+        for (auto newAsset : NewAssetsToRemove) {
+            if (!passetsdb->EraseAssetData(newAsset.asset.assetId)) {
                 return error("%s : %s", __func__, "_Failed Erasing Asset Data from database");
             }
-            if (!passetsdb->EraseAssetId(newAsset.asset.Name)){
+            if (!passetsdb->EraseAssetId(newAsset.asset.Name)) {
                 return error("%s : %s", __func__, "_Failed Erasing Asset Data from database");
             }
         }
         //add assets to db
-        for (auto newAsset : NewAssetsToAdd){
+        for (auto newAsset : NewAssetsToAdd) {
             if (!passetsdb->WriteAssetData(newAsset.asset, newAsset.blockHeight, newAsset.blockHash)) {
-               return error("%s : %s", __func__, "_Failed Writing New Asset Data to database");
+                return error("%s : %s", __func__, "_Failed Writing New Asset Data to database");
             }
             if (!passetsdb->WriteAssetId(newAsset.asset.Name, newAsset.asset.assetId)) {
-               return error("%s : %s", __func__, "_Failed Writing New Asset Data to database");
+                return error("%s : %s", __func__, "_Failed Writing New Asset Data to database");
             }
         }
         ClearDirtyCache();
@@ -313,28 +312,26 @@ bool CAssetsCache::DumpCacheToDatabase()
 
 bool CAssetsCache::Flush()
 {
-
     if (!passetsCache)
         return error("%s: Couldn't find passetsCache pointer while trying to flush assets cache", __func__);
 
     try {
-
-        for (auto &item : NewAssetsToRemove) {
+        for (auto& item : NewAssetsToRemove) {
             if (passetsCache->NewAssetsToAdd.count(item))
                 passetsCache->NewAssetsToAdd.erase(item);
             passetsCache->NewAssetsToRemove.insert(item);
         }
 
-        for (auto &item : NewAssetsToAdd) {
+        for (auto& item : NewAssetsToAdd) {
             if (passetsCache->NewAssetsToRemove.count(item))
                 passetsCache->NewAssetsToRemove.erase(item);
             passetsCache->NewAssetsToAdd.insert(item);
         }
 
-        for (auto &item : mapAsset)
+        for (auto& item : mapAsset)
             passetsCache->mapAsset[item.first] = item.second;
 
-        for (auto &item : mapAssetid)
+        for (auto& item : mapAssetid)
             passetsCache->mapAssetid[item.first] = item.second;
 
         return true;
@@ -347,56 +344,56 @@ bool CAssetsCache::Flush()
 void AddAssets(const CTransaction& tx, int nHeight, CAssetsCache* assetCache, std::pair<std::string, CBlockAssetUndo>* undoAssetData)
 {
     if (Params().IsAssetsActive(chainActive.Tip()) && assetCache) {
-        if (tx.nType == TRANSACTION_NEW_ASSET){
+        if (tx.nType == TRANSACTION_NEW_ASSET) {
             CNewAssetTx assettx;
             if (GetTxPayload(tx, assettx)) {
                 assetCache->InsertAsset(assettx, tx.GetHash().ToString(), nHeight);
             }
-        } else if (tx.nType == TRANSACTION_UPDATE_ASSET){
+        } else if (tx.nType == TRANSACTION_UPDATE_ASSET) {
             CUpdateAssetTx assettx;
             if (GetTxPayload(tx, assettx)) {
                 CAssetMetaData asset;
-                if(!assetCache->GetAssetMetaData(assettx.AssetId, asset))
-                return;
+                if (!assetCache->GetAssetMetaData(assettx.AssetId, asset))
+                    return;
                 assetCache->UpdateAsset(assettx);
                 undoAssetData->first = assettx.AssetId; // Asset Name
-                undoAssetData->second = CBlockAssetUndo {false, asset.circulatingSupply,
-                                                                asset.mintCount,
-                                                                asset.updatable,
-                                                                asset.referenceHash,
-                                                                asset.type,
-                                                                asset.targetAddress,
-                                                                asset.issueFrequency,
-                                                                asset.Amount,
-                                                                asset.ownerAddress,
-                                                                asset.collateralAddress};       
+                undoAssetData->second = CBlockAssetUndo{false, asset.circulatingSupply,
+                    asset.mintCount,
+                    asset.updatable,
+                    asset.referenceHash,
+                    asset.type,
+                    asset.targetAddress,
+                    asset.issueFrequency,
+                    asset.Amount,
+                    asset.ownerAddress,
+                    asset.collateralAddress};
             }
-        } else if (tx.nType == TRANSACTION_MINT_ASSET){
+        } else if (tx.nType == TRANSACTION_MINT_ASSET) {
             CMintAssetTx assettx;
             if (GetTxPayload(tx, assettx)) {
                 CAmount amount = 0;
-                for (auto out : tx.vout){
-                    if (out.scriptPubKey.IsAssetScript()){
+                for (auto out : tx.vout) {
+                    if (out.scriptPubKey.IsAssetScript()) {
                         CAssetTransfer assetTransfer;
-                        if(GetTransferAsset(out.scriptPubKey, assetTransfer))
-                            amount += assetTransfer.nAmount;                
+                        if (GetTransferAsset(out.scriptPubKey, assetTransfer))
+                            amount += assetTransfer.nAmount;
                     }
                 }
                 CAssetMetaData asset;
-                if(!assetCache->GetAssetMetaData(assettx.AssetId, asset))
-                return;
+                if (!assetCache->GetAssetMetaData(assettx.AssetId, asset))
+                    return;
                 assetCache->UpdateAsset(assettx.AssetId, amount); //update circulating suply
-                undoAssetData->first = assettx.AssetId; // Asset Name
-                undoAssetData->second = CBlockAssetUndo {true,  asset.circulatingSupply,
-                                                                asset.mintCount,
-                                                                asset.updatable,
-                                                                asset.referenceHash,
-                                                                asset.type,
-                                                                asset.targetAddress,
-                                                                asset.issueFrequency,
-                                                                asset.Amount,
-                                                                asset.ownerAddress,
-                                                                asset.collateralAddress};
+                undoAssetData->first = assettx.AssetId;           // Asset Name
+                undoAssetData->second = CBlockAssetUndo{true, asset.circulatingSupply,
+                    asset.mintCount,
+                    asset.updatable,
+                    asset.referenceHash,
+                    asset.type,
+                    asset.targetAddress,
+                    asset.issueFrequency,
+                    asset.Amount,
+                    asset.ownerAddress,
+                    asset.collateralAddress};
             }
         }
     }
@@ -419,7 +416,7 @@ bool GetAssetData(const CScript& script, CAssetOutputEntry& data)
 
 bool validateAmount(const CAmount nAmount, const uint16_t decimalPoint)
 {
-    if(nAmount % int64_t(pow(10, (8 - decimalPoint))) != 0){
+    if (nAmount % int64_t(pow(10, (8 - decimalPoint))) != 0) {
         return false;
     }
     return true;
@@ -428,9 +425,8 @@ bool validateAmount(const CAmount nAmount, const uint16_t decimalPoint)
 bool validateAmount(const std::string& assetId, const CAmount nAmount)
 {
     CAssetMetaData asset;
-    if(!passetsCache->GetAssetMetaData(assetId, asset))
+    if (!passetsCache->GetAssetMetaData(assetId, asset))
         return false; //this should never happen
-    
+
     return validateAmount(nAmount, asset.Decimalpoint);
-    
 }

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -25,25 +25,26 @@ bool GetAssetId(const CScript& script, std::string& assetId);
 bool validateAmount(const CAmount nAmount, const uint16_t decimalPoint);
 bool validateAmount(const std::string& assetId, const CAmount nAmount);
 
-class CAssetMetaData {
+class CAssetMetaData
+{
 public:
-    std::string assetId; //Transaction hash of asset creation
+    std::string assetId;       //Transaction hash of asset creation
     CAmount circulatingSupply; //update every mint transaction.
     uint16_t mintCount;
     std::string Name;
-    bool updatable = false;//if true this asset meta can be modify using assetTx update process. 
-    bool isunique = false;//true if this is asset is unique it has an identity per token (NFT flag)
+    bool updatable = false; //if true this asset meta can be modify using assetTx update process.
+    bool isunique = false;  //true if this is asset is unique it has an identity per token (NFT flag)
     uint8_t Decimalpoint = 0;
-    uint16_t maxMintCount; 
+    uint16_t maxMintCount;
     std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
-    uint16_t fee; // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
+    uint16_t fee;              // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
     //  distribution
-    uint8_t type;//manual, coinbase, address, schedule
+    uint8_t type; //manual, coinbase, address, schedule
     CKeyID targetAddress;
     uint8_t issueFrequency;
     CAmount Amount;
     CKeyID ownerAddress;
-    CKeyID collateralAddress;  
+    CKeyID collateralAddress;
 
     CAssetMetaData()
     {
@@ -54,8 +55,9 @@ public:
 
     ADD_SERIALIZE_METHODS;
 
-    template<typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(assetId);
         READWRITE(circulatingSupply);
         READWRITE(mintCount);
@@ -74,14 +76,15 @@ public:
         READWRITE(collateralAddress);
     }
 
-    void SetNull(){
+    void SetNull()
+    {
         assetId = "";
-        circulatingSupply= CAmount(-1);
+        circulatingSupply = CAmount(-1);
         mintCount = uint16_t(-1);
         Name = "";
-        updatable = false; 
+        updatable = false;
         isunique = false;
-        Decimalpoint  = uint8_t(-1);
+        Decimalpoint = uint8_t(-1);
         referenceHash = "";
         maxMintCount = uint16_t(-1);
         fee = uint8_t(-1);
@@ -127,27 +130,32 @@ public:
     }
 };
 
-class CAssets {
+class CAssets
+{
 public:
     std::map<std::string, CDatabasedAssetData> mapAsset;
     std::map<std::string, std::string> mapAssetid;
 
-    CAssets(const CAssets& assets) {
+    CAssets(const CAssets& assets)
+    {
         this->mapAsset = assets.mapAsset;
         this->mapAssetid = assets.mapAssetid;
     }
 
-    CAssets& operator=(const CAssets& other) {
+    CAssets& operator=(const CAssets& other)
+    {
         mapAsset = other.mapAsset;
         mapAssetid = other.mapAssetid;
         return *this;
     }
 
-    CAssets() {
+    CAssets()
+    {
         SetNull();
     }
 
-    void SetNull() {
+    void SetNull()
+    {
         mapAsset.clear();
         mapAssetid.clear();
     }
@@ -159,13 +167,15 @@ public:
     std::set<CDatabasedAssetData> NewAssetsToRemove;
     std::set<CDatabasedAssetData> NewAssetsToAdd;
 
-    CAssetsCache() : CAssets()
+    CAssetsCache() :
+        CAssets()
     {
         SetNull();
         ClearDirtyCache();
     }
 
-    CAssetsCache(CAssetsCache& cache) : CAssets(cache)
+    CAssetsCache(CAssetsCache& cache) :
+        CAssets(cache)
     {
         this->NewAssetsToRemove = cache.NewAssetsToRemove;
         this->NewAssetsToAdd = cache.NewAssetsToAdd;
@@ -176,8 +186,8 @@ public:
     bool UpdateAsset(std::string assetid, CAmount amount);
     //undo asset
     bool RemoveAsset(std::string assetid);
-    bool UndoUpdateAsset(const CUpdateAssetTx upasset, const std::vector<std::pair<std::string, CBlockAssetUndo> >& vUndoData);
-    bool UndoMintAsset(const CMintAssetTx assettx, const std::vector<std::pair<std::string, CBlockAssetUndo> >& vUndoData);
+    bool UndoUpdateAsset(const CUpdateAssetTx upasset, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData);
+    bool UndoMintAsset(const CMintAssetTx assettx, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData);
 
     bool CheckIfAssetExists(std::string asestId);
     bool GetAssetMetaData(std::string assetId, CAssetMetaData& asset);
@@ -185,8 +195,9 @@ public:
 
     bool Flush();
     bool DumpCacheToDatabase();
-    
-    void ClearDirtyCache() {
+
+    void ClearDirtyCache()
+    {
         NewAssetsToAdd.clear();
         NewAssetsToRemove.clear();
     }

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -31,10 +31,10 @@ public:
     std::string assetId;       //Transaction hash of asset creation
     CAmount circulatingSupply; //update every mint transaction.
     uint16_t mintCount;
-    std::string Name;
+    std::string name;
     bool updatable = false; //if true this asset meta can be modify using assetTx update process.
-    bool isunique = false;  //true if this is asset is unique it has an identity per token (NFT flag)
-    uint8_t Decimalpoint = 0;
+    bool isUnique = false;  //true if this is asset is unique it has an identity per token (NFT flag)
+    uint8_t decimalPoint = 0;
     uint16_t maxMintCount;
     std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
     uint16_t fee;              // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
@@ -42,7 +42,7 @@ public:
     uint8_t type; //manual, coinbase, address, schedule
     CKeyID targetAddress;
     uint8_t issueFrequency;
-    CAmount Amount;
+    CAmount amount;
     CKeyID ownerAddress;
     CKeyID collateralAddress;
 
@@ -61,17 +61,17 @@ public:
         READWRITE(assetId);
         READWRITE(circulatingSupply);
         READWRITE(mintCount);
-        READWRITE(Name);
+        READWRITE(name);
         READWRITE(updatable);
-        READWRITE(isunique);
+        READWRITE(isUnique);
         READWRITE(maxMintCount);
-        READWRITE(Decimalpoint);
+        READWRITE(decimalPoint);
         READWRITE(referenceHash);
         READWRITE(fee);
         READWRITE(type);
         READWRITE(targetAddress);
         READWRITE(issueFrequency);
-        READWRITE(Amount);
+        READWRITE(amount);
         READWRITE(ownerAddress);
         READWRITE(collateralAddress);
     }
@@ -81,31 +81,31 @@ public:
         assetId = "";
         circulatingSupply = CAmount(-1);
         mintCount = uint16_t(-1);
-        Name = "";
+        name = "";
         updatable = false;
-        isunique = false;
-        Decimalpoint = uint8_t(-1);
+        isUnique = false;
+        decimalPoint = uint8_t(-1);
         referenceHash = "";
         maxMintCount = uint16_t(-1);
         fee = uint8_t(-1);
         type = uint8_t(-1);
         targetAddress = CKeyID();
         issueFrequency;
-        Amount = 0;
+        amount = 0;
         ownerAddress = CKeyID();
         collateralAddress = CKeyID();
     }
 };
 
-class CDatabasedAssetData
+class CDatabaseAssetData
 {
 public:
     CAssetMetaData asset;
     int blockHeight;
     uint256 blockHash;
 
-    CDatabasedAssetData(const CAssetMetaData& asset, const int& nHeight, const uint256& blockHash);
-    CDatabasedAssetData();
+    CDatabaseAssetData(const CAssetMetaData& asset, const int& nHeight, const uint256& blockHash);
+    CDatabaseAssetData();
 
     void SetNull()
     {
@@ -114,7 +114,7 @@ public:
         blockHash = uint256();
     }
 
-    bool operator<(const CDatabasedAssetData& rhs) const
+    bool operator<(const CDatabaseAssetData& rhs) const
     {
         return asset.assetId < rhs.asset.assetId;
     }
@@ -133,19 +133,19 @@ public:
 class CAssets
 {
 public:
-    std::map<std::string, CDatabasedAssetData> mapAsset;
-    std::map<std::string, std::string> mapAssetid;
+    std::map<std::string, CDatabaseAssetData> mapAsset;
+    std::map<std::string, std::string> mapAssetId;
 
     CAssets(const CAssets& assets)
     {
         this->mapAsset = assets.mapAsset;
-        this->mapAssetid = assets.mapAssetid;
+        this->mapAssetId = assets.mapAssetId;
     }
 
     CAssets& operator=(const CAssets& other)
     {
         mapAsset = other.mapAsset;
-        mapAssetid = other.mapAssetid;
+        mapAssetId = other.mapAssetId;
         return *this;
     }
 
@@ -157,15 +157,15 @@ public:
     void SetNull()
     {
         mapAsset.clear();
-        mapAssetid.clear();
+        mapAssetId.clear();
     }
 };
 
 class CAssetsCache : public CAssets
 {
 public:
-    std::set<CDatabasedAssetData> NewAssetsToRemove;
-    std::set<CDatabasedAssetData> NewAssetsToAdd;
+    std::set<CDatabaseAssetData> NewAssetsToRemove;
+    std::set<CDatabaseAssetData> NewAssetsToAdd;
 
     CAssetsCache() :
         CAssets()
@@ -181,15 +181,15 @@ public:
         this->NewAssetsToAdd = cache.NewAssetsToAdd;
     }
 
-    bool InsertAsset(CNewAssetTx newasset, std::string assetid, int nheigth);
-    bool UpdateAsset(CUpdateAssetTx upasset);
-    bool UpdateAsset(std::string assetid, CAmount amount);
+    bool InsertAsset(CNewAssetTx newAsset, std::string assetId, int nHeight);
+    bool UpdateAsset(CUpdateAssetTx upAsset);
+    bool UpdateAsset(std::string assetId, CAmount amount);
     //undo asset
-    bool RemoveAsset(std::string assetid);
-    bool UndoUpdateAsset(const CUpdateAssetTx upasset, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData);
-    bool UndoMintAsset(const CMintAssetTx assettx, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData);
+    bool RemoveAsset(std::string assetId);
+    bool UndoUpdateAsset(const CUpdateAssetTx upAsset, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData);
+    bool UndoMintAsset(const CMintAssetTx assetTx, const std::vector<std::pair<std::string, CBlockAssetUndo>>& vUndoData);
 
-    bool CheckIfAssetExists(std::string asestId);
+    bool CheckIfAssetExists(std::string assetId);
     bool GetAssetMetaData(std::string assetId, CAssetMetaData& asset);
     bool GetAssetId(std::string name, std::string& assetId);
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -22,15 +22,19 @@ CAmount getAssetsFeesCoin();
 uint16_t getAssetsFees();
 bool IsAssetNameValid(std::string name);
 bool GetAssetId(const CScript& script, std::string& assetId);
+bool validateAmount(const CAmount nAmount, const uint16_t decimalPoint);
+bool validateAmount(const std::string& assetId, const CAmount nAmount);
 
 class CAssetMetaData {
 public:
     std::string assetId; //Transaction hash of asset creation
     CAmount circulatingSupply; //update every mint transaction.
+    uint16_t mintCount;
     std::string Name;
     bool updatable = false;//if true this asset meta can be modify using assetTx update process. 
     bool isunique = false;//true if this is asset is unique it has an identity per token (NFT flag)
     uint8_t Decimalpoint = 0;
+    uint16_t maxMintCount; 
     std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
     uint16_t fee; // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
     //  distribution
@@ -54,9 +58,11 @@ public:
     inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(assetId);
         READWRITE(circulatingSupply);
+        READWRITE(mintCount);
         READWRITE(Name);
         READWRITE(updatable);
         READWRITE(isunique);
+        READWRITE(maxMintCount);
         READWRITE(Decimalpoint);
         READWRITE(referenceHash);
         READWRITE(fee);
@@ -71,11 +77,13 @@ public:
     void SetNull(){
         assetId = "";
         circulatingSupply= CAmount(-1);
+        mintCount = uint16_t(-1);
         Name = "";
         updatable = false; 
         isunique = false;
         Decimalpoint  = uint8_t(-1);
         referenceHash = "";
+        maxMintCount = uint16_t(-1);
         fee = uint8_t(-1);
         type = uint8_t(-1);
         targetAddress = CKeyID();

--- a/src/assets/assetsdb.cpp
+++ b/src/assets/assetsdb.cpp
@@ -3,13 +3,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util.h>
+#include "validation.h"
+#include <assets/assets.h>
+#include <assets/assetsdb.h>
 #include <consensus/params.h>
 #include <script/ismine.h>
 #include <tinyformat.h>
-#include <assets/assetsdb.h>
-#include <assets/assets.h>
-#include "validation.h"
+#include <util.h>
 
 #include <boost/thread.hpp>
 
@@ -19,10 +19,12 @@ static const char BLOCK_ASSET_UNDO_DATA = 'U';
 
 static size_t MAX_DATABASE_RESULTS = 50000;
 
-CAssetsDB::CAssetsDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetDataDir() / "assets", nCacheSize, fMemory, fWipe) {
+CAssetsDB::CAssetsDB(size_t nCacheSize, bool fMemory, bool fWipe) :
+    CDBWrapper(GetDataDir() / "assets", nCacheSize, fMemory, fWipe)
+{
 }
 
-bool CAssetsDB::WriteAssetData(const CAssetMetaData &asset, const int nHeight, const uint256& blockHash)
+bool CAssetsDB::WriteAssetData(const CAssetMetaData& asset, const int nHeight, const uint256& blockHash)
 {
     CDatabasedAssetData data(asset, nHeight, blockHash);
     return Write(std::make_pair(ASSET_FLAG, asset.assetId), data);
@@ -30,13 +32,13 @@ bool CAssetsDB::WriteAssetData(const CAssetMetaData &asset, const int nHeight, c
 
 bool CAssetsDB::WriteAssetId(const std::string assetName, const std::string Txid)
 {
-    return Write(std::make_pair(ASSET_NAME_TXID_FLAG, assetName), Txid );
+    return Write(std::make_pair(ASSET_NAME_TXID_FLAG, assetName), Txid);
 }
 
 bool CAssetsDB::ReadAssetData(const std::string& txid, CAssetMetaData& asset, int& nHeight, uint256& blockHash)
 {
     CDatabasedAssetData data;
-    bool ret =  Read(std::make_pair(ASSET_FLAG, txid), data);
+    bool ret = Read(std::make_pair(ASSET_FLAG, txid), data);
 
     if (ret) {
         asset = data.asset;
@@ -62,16 +64,16 @@ bool CAssetsDB::EraseAssetId(const std::string& assetName)
     return Erase(std::make_pair(ASSET_NAME_TXID_FLAG, assetName));
 }
 
-bool CAssetsDB::WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, CBlockAssetUndo> >& assetUndoData)
+bool CAssetsDB::WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData)
 {
     return Write(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash), assetUndoData);
 }
 
-bool CAssetsDB::ReadBlockUndoAssetData(const uint256 &blockhash, std::vector<std::pair<std::string, CBlockAssetUndo> > &assetUndoData)
+bool CAssetsDB::ReadBlockUndoAssetData(const uint256& blockhash, std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData)
 {
     // If it exists, return the read value.
     if (Exists(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash)))
-           return Read(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash), assetUndoData);
+        return Read(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash), assetUndoData);
 
     // If it doesn't exist, we just return true because we don't want to fail just because it didn't exist in the db
     return true;
@@ -90,7 +92,7 @@ bool CAssetsDB::LoadAssets()
         if (pcursor->GetKey(key) && key.first == ASSET_FLAG) {
             CDatabasedAssetData data;
             if (pcursor->GetValue(data)) {
-                passetsCache->mapAsset.insert( std::make_pair(data.asset.assetId, data));
+                passetsCache->mapAsset.insert(std::make_pair(data.asset.assetId, data));
                 pcursor->Next();
 
                 // Loaded enough from database to have in memory.
@@ -116,7 +118,7 @@ bool CAssetsDB::LoadAssets()
             std::string value;
             if (pcursor2->GetValue(value)) {
                 passetsCache->mapAssetid.insert(
-                        std::make_pair(key.second, value));
+                    std::make_pair(key.second, value));
                 if (passetsCache->mapAssetid.size() > MAX_CACHE_ASSETS_SIZE)
                     break;
                 pcursor2->Next();

--- a/src/assets/assetsdb.h
+++ b/src/assets/assetsdb.h
@@ -18,10 +18,10 @@
 class CAssetMetaData;
 class uint256;
 class COutPoint;
-class CDatabasedAssetData;
+class CDatabaseAssetData;
 
 struct CBlockAssetUndo {
-    bool onlysuply;
+    bool onlySupply;
     CAmount circulatingSupply;
     uint16_t mintCount;
     bool updatable;
@@ -30,7 +30,7 @@ struct CBlockAssetUndo {
     uint8_t type;
     CKeyID targetAddress;
     uint8_t issueFrequency;
-    CAmount Amount;
+    CAmount amount;
     CKeyID ownerAddress;
     CKeyID collateralAddress;
 
@@ -40,16 +40,16 @@ struct CBlockAssetUndo {
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        READWRITE(onlysuply);
+        READWRITE(onlySupply);
         READWRITE(circulatingSupply);
         READWRITE(mintCount);
-        if (!onlysuply) {
+        if (!onlySupply) {
             READWRITE(updatable);
             READWRITE(referenceHash);
             READWRITE(type);
             READWRITE(targetAddress);
             READWRITE(issueFrequency);
-            READWRITE(Amount);
+            READWRITE(amount);
             READWRITE(ownerAddress);
             READWRITE(collateralAddress);
         }
@@ -68,12 +68,12 @@ public:
     // Write to database
     bool WriteAssetData(const CAssetMetaData& asset, const int nHeight, const uint256& blockHash);
     bool WriteAssetId(const std::string assetName, const std::string Txid);
-    bool WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData);
+    bool WriteBlockUndoAssetData(const uint256& blockHash, const std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData);
 
     // Read from database
     bool ReadAssetData(const std::string& txid, CAssetMetaData& asset, int& nHeight, uint256& blockHash);
     bool ReadAssetId(const std::string& assetName, std::string& Txid);
-    bool ReadBlockUndoAssetData(const uint256& blockhash, std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData);
+    bool ReadBlockUndoAssetData(const uint256& blockHash, std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData);
 
     // Erase from database
     bool EraseAssetData(const std::string& assetName);

--- a/src/assets/assetsdb.h
+++ b/src/assets/assetsdb.h
@@ -9,19 +9,18 @@
 #include "fs.h"
 #include "serialize.h"
 
-#include <string>
-#include <map>
-#include <dbwrapper.h>
 #include <amount.h>
+#include <dbwrapper.h>
+#include <map>
 #include <pubkey.h>
+#include <string>
 
 class CAssetMetaData;
 class uint256;
 class COutPoint;
 class CDatabasedAssetData;
 
-struct CBlockAssetUndo
-{
+struct CBlockAssetUndo {
     bool onlysuply;
     CAmount circulatingSupply;
     uint16_t mintCount;
@@ -39,11 +38,12 @@ struct CBlockAssetUndo
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(onlysuply);
         READWRITE(circulatingSupply);
         READWRITE(mintCount);
-        if(!onlysuply){
+        if (!onlysuply) {
             READWRITE(updatable);
             READWRITE(referenceHash);
             READWRITE(type);
@@ -68,17 +68,17 @@ public:
     // Write to database
     bool WriteAssetData(const CAssetMetaData& asset, const int nHeight, const uint256& blockHash);
     bool WriteAssetId(const std::string assetName, const std::string Txid);
-    bool WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, CBlockAssetUndo> >& assetUndoData);
+    bool WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData);
 
     // Read from database
     bool ReadAssetData(const std::string& txid, CAssetMetaData& asset, int& nHeight, uint256& blockHash);
     bool ReadAssetId(const std::string& assetName, std::string& Txid);
-    bool ReadBlockUndoAssetData(const uint256& blockhash, std::vector<std::pair<std::string, CBlockAssetUndo> >& assetUndoData);
+    bool ReadBlockUndoAssetData(const uint256& blockhash, std::vector<std::pair<std::string, CBlockAssetUndo>>& assetUndoData);
 
     // Erase from database
     bool EraseAssetData(const std::string& assetName);
     bool EraseAssetId(const std::string& assetName);
-    
+
     // Helper functions
     bool LoadAssets();
 };

--- a/src/assets/assetsdb.h
+++ b/src/assets/assetsdb.h
@@ -24,6 +24,7 @@ struct CBlockAssetUndo
 {
     bool onlysuply;
     CAmount circulatingSupply;
+    uint16_t mintCount;
     bool updatable;
     std::string referenceHash;
     //  distribution
@@ -41,6 +42,7 @@ struct CBlockAssetUndo
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(onlysuply);
         READWRITE(circulatingSupply);
+        READWRITE(mintCount);
         if(!onlysuply){
             READWRITE(updatable);
             READWRITE(referenceHash);

--- a/src/assets/assetstype.cpp
+++ b/src/assets/assetstype.cpp
@@ -36,9 +36,20 @@ void CAssetTransfer::BuildAssetTransaction(CScript& script) const{
     script << OP_ASSET_ID << ToByteVector(vchMessage) << OP_DROP;
 }
 
+CAssetTransfer::CAssetTransfer(const std::string& AssetId, const CAmount& nAmount, const uint32_t& uniqueId)
+{
+    SetNull();
+    this->AssetId = AssetId;
+    this->isUnique = true;
+    this->uniqueId = uniqueId;
+    this->nAmount = nAmount;    
+}
+
 CAssetTransfer::CAssetTransfer(const std::string& AssetId, const CAmount& nAmount)
 {
     SetNull();
     this->AssetId = AssetId;
-    this->nAmount = nAmount;
+    this->isUnique = false;
+    this->uniqueId = MAX_UNIQUE_ID;
+    this->nAmount = nAmount;  
 }

--- a/src/assets/assetstype.cpp
+++ b/src/assets/assetstype.cpp
@@ -6,9 +6,10 @@
 #include <streams.h>
 
 
-bool GetTransferAsset(const CScript& script, CAssetTransfer& assetTransfer){
+bool GetTransferAsset(const CScript& script, CAssetTransfer& assetTransfer)
+{
     int nIndex;
-    if (!script.IsAssetScript(nIndex)){
+    if (!script.IsAssetScript(nIndex)) {
         return false;
     }
 
@@ -17,7 +18,7 @@ bool GetTransferAsset(const CScript& script, CAssetTransfer& assetTransfer){
     CDataStream DSAsset(vchAssetId, SER_NETWORK, PROTOCOL_VERSION);
     try {
         DSAsset >> assetTransfer;
-    } catch(std::exception& e) {
+    } catch (std::exception& e) {
         error("Failed to get the transfer asset: %s", e.what());
         return false;
     }
@@ -25,7 +26,8 @@ bool GetTransferAsset(const CScript& script, CAssetTransfer& assetTransfer){
     return true;
 }
 
-void CAssetTransfer::BuildAssetTransaction(CScript& script) const{
+void CAssetTransfer::BuildAssetTransaction(CScript& script) const
+{
     CDataStream AssetTransfer(SER_NETWORK, PROTOCOL_VERSION);
     AssetTransfer << *this;
     std::vector<unsigned char> vchMessage;
@@ -42,7 +44,7 @@ CAssetTransfer::CAssetTransfer(const std::string& AssetId, const CAmount& nAmoun
     this->AssetId = AssetId;
     this->isUnique = true;
     this->uniqueId = uniqueId;
-    this->nAmount = nAmount;    
+    this->nAmount = nAmount;
 }
 
 CAssetTransfer::CAssetTransfer(const std::string& AssetId, const CAmount& nAmount)
@@ -51,5 +53,5 @@ CAssetTransfer::CAssetTransfer(const std::string& AssetId, const CAmount& nAmoun
     this->AssetId = AssetId;
     this->isUnique = false;
     this->uniqueId = MAX_UNIQUE_ID;
-    this->nAmount = nAmount;  
+    this->nAmount = nAmount;
 }

--- a/src/assets/assetstype.cpp
+++ b/src/assets/assetstype.cpp
@@ -38,19 +38,19 @@ void CAssetTransfer::BuildAssetTransaction(CScript& script) const
     script << OP_ASSET_ID << ToByteVector(vchMessage) << OP_DROP;
 }
 
-CAssetTransfer::CAssetTransfer(const std::string& AssetId, const CAmount& nAmount, const uint32_t& uniqueId)
+CAssetTransfer::CAssetTransfer(const std::string& assetId, const CAmount& nAmount, const uint32_t& uniqueId)
 {
     SetNull();
-    this->AssetId = AssetId;
+    this->assetId = assetId;
     this->isUnique = true;
     this->uniqueId = uniqueId;
     this->nAmount = nAmount;
 }
 
-CAssetTransfer::CAssetTransfer(const std::string& AssetId, const CAmount& nAmount)
+CAssetTransfer::CAssetTransfer(const std::string& assetId, const CAmount& nAmount)
 {
     SetNull();
-    this->AssetId = AssetId;
+    this->assetId = assetId;
     this->isUnique = false;
     this->uniqueId = MAX_UNIQUE_ID;
     this->nAmount = nAmount;

--- a/src/assets/assetstype.h
+++ b/src/assets/assetstype.h
@@ -9,9 +9,9 @@
 #include <coins.h>
 #include <key_io.h>
 
-#define RTM_R 0x72  //R
-#define RTM_T 0x74  //T
-#define RTM_M 0x6d  //M
+#define RTM_R 0x72 //R
+#define RTM_T 0x74 //T
+#define RTM_M 0x6d //M
 #define MAX_UNIQUE_ID 0xffffffff
 
 class CAssetTransfer
@@ -19,9 +19,9 @@ class CAssetTransfer
 public:
     std::string AssetId;
     bool isUnique = false;
-    uint32_t uniqueId = MAX_UNIQUE_ID;//default it to MAX_UNIQUE_ID
+    uint32_t uniqueId = MAX_UNIQUE_ID; //default it to MAX_UNIQUE_ID
     CAmount nAmount;
-    
+
     CAssetTransfer()
     {
         SetNull();
@@ -30,7 +30,7 @@ public:
     void SetNull()
     {
         AssetId = "";
-        isUnique= false;
+        isUnique = false;
         uniqueId = MAX_UNIQUE_ID;
         nAmount = 0;
     }
@@ -44,7 +44,7 @@ public:
         READWRITE(isUnique);
         if (isUnique)
             READWRITE(uniqueId);
-        READWRITE(nAmount);      
+        READWRITE(nAmount);
     }
 
     CAssetTransfer(const std::string& AssetId, const CAmount& nAmount, const uint32_t& uniqueId);

--- a/src/assets/assetstype.h
+++ b/src/assets/assetstype.h
@@ -12,13 +12,16 @@
 #define RTM_R 0x72  //R
 #define RTM_T 0x74  //T
 #define RTM_M 0x6d  //M
+#define MAX_UNIQUE_ID 0xffffffff
 
 class CAssetTransfer
 {
 public:
     std::string AssetId;
+    bool isUnique = false;
+    uint32_t uniqueId = MAX_UNIQUE_ID;//default it to MAX_UNIQUE_ID
     CAmount nAmount;
-
+    
     CAssetTransfer()
     {
         SetNull();
@@ -26,8 +29,10 @@ public:
 
     void SetNull()
     {
-        nAmount = 0;
         AssetId = "";
+        isUnique= false;
+        uniqueId = MAX_UNIQUE_ID;
+        nAmount = 0;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -36,9 +41,13 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(AssetId);
-        READWRITE(nAmount);
+        READWRITE(isUnique);
+        if (isUnique)
+            READWRITE(uniqueId);
+        READWRITE(nAmount);      
     }
 
+    CAssetTransfer(const std::string& AssetId, const CAmount& nAmount, const uint32_t& uniqueId);
     CAssetTransfer(const std::string& AssetId, const CAmount& nAmount);
     void BuildAssetTransaction(CScript& script) const;
 };

--- a/src/assets/assetstype.h
+++ b/src/assets/assetstype.h
@@ -17,7 +17,7 @@
 class CAssetTransfer
 {
 public:
-    std::string AssetId;
+    std::string assetId;
     bool isUnique = false;
     uint32_t uniqueId = MAX_UNIQUE_ID; //default it to MAX_UNIQUE_ID
     CAmount nAmount;
@@ -29,7 +29,7 @@ public:
 
     void SetNull()
     {
-        AssetId = "";
+        assetId = "";
         isUnique = false;
         uniqueId = MAX_UNIQUE_ID;
         nAmount = 0;
@@ -40,15 +40,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        READWRITE(AssetId);
+        READWRITE(assetId);
         READWRITE(isUnique);
         if (isUnique)
             READWRITE(uniqueId);
         READWRITE(nAmount);
     }
 
-    CAssetTransfer(const std::string& AssetId, const CAmount& nAmount, const uint32_t& uniqueId);
-    CAssetTransfer(const std::string& AssetId, const CAmount& nAmount);
+    CAssetTransfer(const std::string& assetId, const CAmount& nAmount, const uint32_t& uniqueId);
+    CAssetTransfer(const std::string& assetId, const CAmount& nAmount);
     void BuildAssetTransaction(CScript& script) const;
 };
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -28,15 +28,15 @@ extern CChain& chainActive;
 
 static bool checkSpecialTxFee(const CTransaction &tx, CAmount& nFeeTotal, CAmount& specialTxFee, bool fFeeVerify = false) {
 	if(tx.nVersion >= 3) {
-		switch(tx.nType){
-            case TRANSACTION_FUTURE:{
+            switch (tx.nType) {
+            case TRANSACTION_FUTURE: {
                 CFutureTx ftx;
-                if(GetTxPayload(tx.vExtraPayload, ftx)) {
-                    if(!Params().IsFutureActive(chainActive.Tip())) {
+                if (GetTxPayload(tx.vExtraPayload, ftx)) {
+                    if (!Params().IsFutureActive(chainActive.Tip())) {
                         return false;
                     }
                     bool futureEnabled = sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE);
-                    if(futureEnabled && fFeeVerify && ftx.fee != getFutureFees()) {
+                    if (futureEnabled && fFeeVerify && ftx.fee != getFutureFees()) {
                         return false;
                     }
                     specialTxFee = ftx.fee * COIN;
@@ -44,79 +44,79 @@ static bool checkSpecialTxFee(const CTransaction &tx, CAmount& nFeeTotal, CAmoun
                 }
                 break;
             }
-            case TRANSACTION_NEW_ASSET:{
+            case TRANSACTION_NEW_ASSET: {
                 CNewAssetTx asset;
-                if(GetTxPayload(tx.vExtraPayload, asset)) {
-                    if(!Params().IsAssetsActive(chainActive.Tip())) {
+                if (GetTxPayload(tx.vExtraPayload, asset)) {
+                    if (!Params().IsAssetsActive(chainActive.Tip())) {
                         return false;
                     }
                     bool assetsEnabled = sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE);
-                    if(assetsEnabled && fFeeVerify && asset.fee != getAssetsFees()){
+                    if (assetsEnabled && fFeeVerify && asset.fee != getAssetsFees()) {
                         return false;
                     }
-                    specialTxFee = asset.fee  * COIN;
+                    specialTxFee = asset.fee * COIN;
                     nFeeTotal -= specialTxFee;
                 }
                 break;
             }
-            case TRANSACTION_UPDATE_ASSET:{
+            case TRANSACTION_UPDATE_ASSET: {
                 CUpdateAssetTx asset;
-                if(GetTxPayload(tx.vExtraPayload, asset)) {
-                    if(!Params().IsAssetsActive(chainActive.Tip())) {
+                if (GetTxPayload(tx.vExtraPayload, asset)) {
+                    if (!Params().IsAssetsActive(chainActive.Tip())) {
                         return false;
                     }
                     bool assetsEnabled = sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE);
-                    if(assetsEnabled && fFeeVerify && asset.fee != getAssetsFees()){
+                    if (assetsEnabled && fFeeVerify && asset.fee != getAssetsFees()) {
                         return false;
                     }
-                    specialTxFee = asset.fee  * COIN;
+                    specialTxFee = asset.fee * COIN;
                     nFeeTotal -= specialTxFee;
                 }
                 break;
             }
-            case TRANSACTION_MINT_ASSET:{
+            case TRANSACTION_MINT_ASSET: {
                 CMintAssetTx asset;
-                if(GetTxPayload(tx.vExtraPayload, asset)) {
-                    if(!Params().IsAssetsActive(chainActive.Tip())) {
+                if (GetTxPayload(tx.vExtraPayload, asset)) {
+                    if (!Params().IsAssetsActive(chainActive.Tip())) {
                         return false;
                     }
                     bool assetsEnabled = sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE);
-                    if(assetsEnabled && fFeeVerify && asset.fee != getAssetsFees()){
+                    if (assetsEnabled && fFeeVerify && asset.fee != getAssetsFees()) {
                         return false;
                     }
-                    specialTxFee = asset.fee  * COIN;
+                    specialTxFee = asset.fee * COIN;
                     nFeeTotal -= specialTxFee;
                 }
                 break;
+            } break;
             }
-            break;
         }
-	}
     return true;
 }
 
-static const char *validateFutureCoin(const Coin& coin, int nSpendHeight) {
-	if(coin.nType == TRANSACTION_FUTURE) {
-		CBlockIndex* confirmedBlockIndex = chainActive[coin.nHeight];
-		if(confirmedBlockIndex) {
-			int64_t adjustCurrentTime = GetAdjustedTime();
-			uint32_t confirmedTime = confirmedBlockIndex->GetBlockTime();
-			CFutureTx futureTx;
-			if(GetTxPayload(coin.vExtraPayload, futureTx)) {
+static const char* validateFutureCoin(const Coin& coin, int nSpendHeight)
+{
+    if (coin.nType == TRANSACTION_FUTURE) {
+        CBlockIndex* confirmedBlockIndex = chainActive[coin.nHeight];
+        if (confirmedBlockIndex) {
+            int64_t adjustCurrentTime = GetAdjustedTime();
+            uint32_t confirmedTime = confirmedBlockIndex->GetBlockTime();
+            CFutureTx futureTx;
+            if (GetTxPayload(coin.vExtraPayload, futureTx)) {
                 bool isBlockMature = futureTx.maturity >= 0 && nSpendHeight - coin.nHeight >= futureTx.maturity;
-                bool isTimeMature = futureTx.lockTime >= 0 && adjustCurrentTime - confirmedTime  >= futureTx.lockTime;
+                bool isTimeMature = futureTx.lockTime >= 0 && adjustCurrentTime - confirmedTime >= futureTx.lockTime;
                 bool canSpend = isBlockMature || isTimeMature;
-				if(!canSpend) {
-					return "bad-txns-premature-spend-of-future";
-				}
-				return nullptr;
-			}
-			return "bad-txns-unable-to-parse-future";
-		}
-		// should not get here
-		return "bad-txns-unable-to-block-index-for-future";
-	}
-	return nullptr;
+                if (!canSpend) {
+                    return "bad-txns-premature-spend-of-future";
+                }
+                return nullptr;
+            }
+            return "bad-txns-unable-to-parse-future";
+        }
+        // should not get here
+        return "bad-txns-unable-to-block-index-for-future";
+    }
+    return nullptr;
 }
 
 
@@ -292,22 +292,22 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, int nHeig
         if (!MoneyRange(nValueOut, isV17active))
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-txouttotal-toolarge");
 
-        if(txout.scriptPubKey.IsAssetScript()){
+        if (txout.scriptPubKey.IsAssetScript()) {
             CAssetTransfer assetTransfer;
-            if(!GetTransferAsset(txout.scriptPubKey, assetTransfer))
+            if (!GetTransferAsset(txout.scriptPubKey, assetTransfer))
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-assets-output");
 
-            if(nAssetVout.count(assetTransfer.AssetId))
+            if (nAssetVout.count(assetTransfer.AssetId))
                 nAssetVout[assetTransfer.AssetId] += assetTransfer.nAmount;
             else
                 nAssetVout.insert(std::make_pair(assetTransfer.AssetId, assetTransfer.nAmount));
-            
+
             if (assetTransfer.nAmount < 0)
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-negative");
-            
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-negative");
+
             if (assetTransfer.nAmount > MAX_MONEY)
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-toolarge");
-            
+
             if (!MoneyRange(nAssetVout.at(assetTransfer.AssetId), isV17active)) {
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-outputvalues-outofrange");
             }
@@ -322,8 +322,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, int nHeig
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
     }
 
-    if (tx.IsCoinBase())
-    {
+    if (tx.IsCoinBase()) {
         size_t minCbSize = 2;
         if (tx.nType == TRANSACTION_COINBASE) {
             // With the introduction of CbTx, coinbase scripts are not required anymore to hold a valid block height
@@ -331,15 +330,13 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, int nHeig
         }
         if (tx.vin[0].scriptSig.size() < minCbSize || tx.vin[0].scriptSig.size() > 100)
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-length");
-		FounderPayment founderPayment = Params().GetConsensus().nFounderPayment;
-		CAmount founderReward = founderPayment.getFounderPaymentAmount(nHeight, blockReward);
-		int founderStartHeight = founderPayment.getStartBlock();
-		if(nHeight > founderStartHeight && founderReward && !founderPayment.IsBlockPayeeValid(tx,nHeight,blockReward)) {
-			return state.DoS(100, false, REJECT_INVALID, "bad-cb-founder-payment-not-found");
-		}
-    }
-    else
-    {
+        FounderPayment founderPayment = Params().GetConsensus().nFounderPayment;
+        CAmount founderReward = founderPayment.getFounderPaymentAmount(nHeight, blockReward);
+        int founderStartHeight = founderPayment.getStartBlock();
+        if (nHeight > founderStartHeight && founderReward && !founderPayment.IsBlockPayeeValid(tx, nHeight, blockReward)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-cb-founder-payment-not-found");
+        }
+    } else {
         for (const auto& txin : tx.vin)
             if (txin.prevout.IsNull())
                 return state.DoS(10, false, REJECT_INVALID, "bad-txns-prevout-null");
@@ -356,29 +353,29 @@ inline bool checkOutput(const CTxOut& out, CValidationState& state, CAmount& nVa
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
     }
 
-    if(out.scriptPubKey.IsAssetScript()){
+    if (out.scriptPubKey.IsAssetScript()) {
         if (out.nValue != 0)
             return state.DoS(100, false, REJECT_INVALID, "bad-asset-value-outofrange");
 
         CAssetTransfer assetTransfer;
-        if(!GetTransferAsset(out.scriptPubKey, assetTransfer)){
+        if (!GetTransferAsset(out.scriptPubKey, assetTransfer)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-asset-transfer");
         }
 
-        if (!validateAmount(assetTransfer.AssetId, assetTransfer.nAmount)){
+        if (!validateAmount(assetTransfer.AssetId, assetTransfer.nAmount)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-assets-transfer-amount");
         }
 
         std::pair<std::string, uint16_t> asset(assetTransfer.AssetId, assetTransfer.uniqueId);
-        if(nAssetVin.count(asset))
+        if (nAssetVin.count(asset))
             nAssetVin[asset] += assetTransfer.nAmount;
         else
             nAssetVin.insert(std::make_pair(asset, assetTransfer.nAmount));
-        
+
         //check unique asset amount, should be alway 1 COIN
         if (assetTransfer.isUnique && nAssetVin[asset] != 1 * COIN)
             return state.DoS(100, false, REJECT_INVALID, "bad-asset-inputvalues-outofrange");
-        
+
         if (!MoneyRange(assetTransfer.nAmount) || !MoneyRange(nAssetVin.at(asset))) {
             return state.DoS(100, false, REJECT_INVALID, "bad-asset-inputvalues-outofrange");
         }
@@ -408,32 +405,31 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
                 REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
                 strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
         }
-                
+
         if (!checkOutput(coin.out, state, nValueIn, nAssetVin, isV17active))
             return false;
 
         const char* futureValidationError = validateFutureCoin(coin, nSpendHeight);
-		if(futureValidationError) {
-			return state.DoS(100, false, REJECT_INVALID, futureValidationError);
-
-		}
+        if (futureValidationError) {
+            return state.DoS(100, false, REJECT_INVALID, futureValidationError);
+        }
     }
 
     CAmount value_out = 0;
     std::map<std::pair<std::string, uint16_t>, CAmount> nAssetVout;
-    for (auto out : tx.vout){
+    for (auto out : tx.vout) {
         if (!checkOutput(out, state, value_out, nAssetVout, isV17active))
             return false;
     }
 
-    if(tx.nType != TRANSACTION_MINT_ASSET){
+    if (tx.nType != TRANSACTION_MINT_ASSET) {
         for (const auto& outValue : nAssetVout) {
-            if(!nAssetVin.count(outValue.first) || nAssetVin.at(outValue.first) != outValue.second)
+            if (!nAssetVin.count(outValue.first) || nAssetVin.at(outValue.first) != outValue.second)
                 return state.DoS(100, false, REJECT_INVALID, "bad-asset-inputs-outputs-mismatch");
         }
         //Check for missing outputs
         for (const auto& outValue : nAssetVin) {
-            if(!nAssetVout.count(outValue.first) || nAssetVout.at(outValue.first) != outValue.second)
+            if (!nAssetVout.count(outValue.first) || nAssetVout.at(outValue.first) != outValue.second)
                 return state.DoS(100, false, REJECT_INVALID, "bad-asset-inputs-outputs-mismatch");
         }
     }
@@ -450,14 +446,13 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
     }
     txfee = txfee_aux;
 
-	if(!checkSpecialTxFee(tx, txfee, specialTxFee, fFeeVerify)) {
+    if (!checkSpecialTxFee(tx, txfee, specialTxFee, fFeeVerify)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-wrong-future-fee-or-not-enable");
-
     }
 
-	if(txfee < 0) {
-		return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-too-low", false,
-		            strprintf("fee (%s), special tx fee (%s)", FormatMoney(txfee), FormatMoney(specialTxFee)));
-	}
+    if (txfee < 0) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-too-low", false,
+            strprintf("fee (%s), special tx fee (%s)", FormatMoney(txfee), FormatMoney(specialTxFee)));
+    }
     return true;
 }

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -297,10 +297,10 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, int nHeig
             if (!GetTransferAsset(txout.scriptPubKey, assetTransfer))
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-assets-output");
 
-            if (nAssetVout.count(assetTransfer.AssetId))
-                nAssetVout[assetTransfer.AssetId] += assetTransfer.nAmount;
+            if (nAssetVout.count(assetTransfer.assetId))
+                nAssetVout[assetTransfer.assetId] += assetTransfer.nAmount;
             else
-                nAssetVout.insert(std::make_pair(assetTransfer.AssetId, assetTransfer.nAmount));
+                nAssetVout.insert(std::make_pair(assetTransfer.assetId, assetTransfer.nAmount));
 
             if (assetTransfer.nAmount < 0)
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-negative");
@@ -308,7 +308,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, int nHeig
             if (assetTransfer.nAmount > MAX_MONEY)
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-toolarge");
 
-            if (!MoneyRange(nAssetVout.at(assetTransfer.AssetId), isV17active)) {
+            if (!MoneyRange(nAssetVout.at(assetTransfer.assetId), isV17active)) {
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-outputvalues-outofrange");
             }
         }
@@ -362,11 +362,11 @@ inline bool checkOutput(const CTxOut& out, CValidationState& state, CAmount& nVa
             return state.DoS(100, false, REJECT_INVALID, "bad-asset-transfer");
         }
 
-        if (!validateAmount(assetTransfer.AssetId, assetTransfer.nAmount)) {
+        if (!validateAmount(assetTransfer.assetId, assetTransfer.nAmount)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-assets-transfer-amount");
         }
 
-        std::pair<std::string, uint16_t> asset(assetTransfer.AssetId, assetTransfer.uniqueId);
+        std::pair<std::string, uint16_t> asset(assetTransfer.assetId, assetTransfer.uniqueId);
         if (nAssetVin.count(asset))
             nAssetVin[asset] += assetTransfer.nAmount;
         else

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -170,7 +170,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fInclud
 
         CAssetTransfer data;
         if (GetTransferAsset(scriptPubKey, data)) {
-            std:string assetId = data.AssetId;
+            std::string assetId = data.assetId;
             if (data.isUnique)
                 assetId += "[" + to_string(data.uniqueId) + "]";
             assetInfo.pushKV("asset_id", assetId);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -106,8 +106,8 @@ std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDeco
             // Once we hit an OP_ASSET_ID, all the next data should be considered as hex
             str += GetOpName(opcode);
             str += " ";
-            str += HexStr(vch); 
-        } 
+            str += HexStr(vch);
+        }
         else
         if (0 <= opcode && opcode <= OP_PUSHDATA4) {
             if (vch.size() <= static_cast<std::vector<unsigned char>::size_type>(4)) {
@@ -172,7 +172,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fInclud
         if (GetTransferAsset(scriptPubKey, data)) {
             std:string assetId = data.AssetId;
             if (data.isUnique)
-                assetId +="["+to_string(data.uniqueId)+"]";
+                assetId += "[" + to_string(data.uniqueId) + "]";
             assetInfo.pushKV("asset_id", assetId);
             assetInfo.pushKV("amount", ValueFromAmount(data.nAmount));
         }

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -170,7 +170,10 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fInclud
 
         CAssetTransfer data;
         if (GetTransferAsset(scriptPubKey, data)) {
-            assetInfo.pushKV("asset_id", data.AssetId);
+            std:string assetId = data.AssetId;
+            if (data.isUnique)
+                assetId +="["+to_string(data.uniqueId)+"]";
+            assetInfo.pushKV("asset_id", assetId);
             assetInfo.pushKV("amount", ValueFromAmount(data.nAmount));
         }
 

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -114,15 +114,15 @@ inline bool checkNewUniqueAsset(CNewAssetTx& assettx, CValidationState& state)
     if (!assettx.isUnique)
         return true;
 
-    if (assettx.decimalPoint > 0 ){ // alway 0
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-decimalPoint"); 
+    if (assettx.decimalPoint > 0) { // alway 0
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-decimalPoint");
     }
-    
-    if (assettx.type > 0 ){ // manual mint only?
+
+    if (assettx.type > 0) { // manual mint only?
         return state.DoS(100, false, REJECT_INVALID, "bad-unique-assets-distibution-type");
     }
 
-    if (assettx.updatable){ // manual mint only?
+    if (assettx.updatable) { // manual mint only?
         return state.DoS(100, false, REJECT_INVALID, "bad-unique-assets-distibution-type");
     }
 
@@ -131,8 +131,7 @@ inline bool checkNewUniqueAsset(CNewAssetTx& assettx, CValidationState& state)
 
 bool CheckNewAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state, CAssetsCache* assetsCache)
 {
-
-    if(!Params().IsAssetsActive(chainActive.Tip())) {
+    if (!Params().IsAssetsActive(chainActive.Tip())) {
         return state.DoS(100, false, REJECT_INVALID, "assets-not-enabled");
     }
 
@@ -150,14 +149,14 @@ bool CheckNewAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
     }
 
     //validate asset name
-    if(!IsAssetNameValid(assettx.Name)){
+    if (!IsAssetNameValid(assettx.Name)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-name");
     }
 
     //Check if a asset already exist with give name
     std::string assetid = assettx.Name;
-    if (assetsCache->GetAssetId(assettx.Name, assetid)){
-        if(assetsCache->CheckIfAssetExists(assetid)){
+    if (assetsCache->GetAssetId(assettx.Name, assetid)) {
+        if (assetsCache->CheckIfAssetExists(assetid)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-assets-dup-name");
         }
     }
@@ -166,35 +165,35 @@ bool CheckNewAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
     if (!checkNewUniqueAsset(assettx, state))
         return false;
 
-    if(assettx.decimalPoint < 0 || assettx.decimalPoint > 8){
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-decimalPoint"); 
+    if (assettx.decimalPoint < 0 || assettx.decimalPoint > 8) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-decimalPoint");
     }
 
-    if(assettx.ownerAddress.IsNull()){
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-ownerAddress"); 
+    if (assettx.ownerAddress.IsNull()) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-ownerAddress");
     }
 
-    if(assettx.targetAddress.IsNull()){
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-targetAddress"); 
+    if (assettx.targetAddress.IsNull()) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-targetAddress");
     }
-    
-    if(assettx.type < 0 && assettx.type > 3){
+
+    if (assettx.type < 0 && assettx.type > 3) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-distibution-type");
     }
-    
-    if(assettx.collateralAddress.IsNull() && assettx.type != 0){ //
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-collateralAddress"); 
+
+    if (assettx.collateralAddress.IsNull() && assettx.type != 0) { //
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-collateralAddress");
     }
 
-    
-    if(!validateAmount(assettx.Amount, assettx.decimalPoint)){
+
+    if (!validateAmount(assettx.Amount, assettx.decimalPoint)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-amount");
     }
 
     if (!CheckInputsHash(tx, assettx, state)) {
         return false;
     }
-    
+
     return true;
 }
 
@@ -205,8 +204,8 @@ inline bool checkAssetFeesPayment(const CTransaction& tx, CValidationState& stat
         assert(!coin.IsSpent());
         CTxDestination dest;
         ExtractDestination(coin.out.scriptPubKey, dest);
-        if(EncodeDestination(dest) != EncodeDestination(asset.ownerAddress)){
-           return state.DoS(100, false, REJECT_INVALID, "bad-assets-invalid-input");    
+        if (EncodeDestination(dest) != EncodeDestination(asset.ownerAddress)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-assets-invalid-input");
         }
     }
 
@@ -215,8 +214,7 @@ inline bool checkAssetFeesPayment(const CTransaction& tx, CValidationState& stat
 
 bool CheckUpdateAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state, const CCoinsViewCache& view, CAssetsCache* assetsCache)
 {
-
-    if(!Params().IsAssetsActive(chainActive.Tip())) {
+    if (!Params().IsAssetsActive(chainActive.Tip())) {
         return state.DoS(100, false, REJECT_INVALID, "assets-not-enabled");
     }
 
@@ -235,30 +233,30 @@ bool CheckUpdateAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, C
 
     //Check if the provide asset id is valid
     CAssetMetaData asset;
-    if(!assetsCache->GetAssetMetaData(assettx.AssetId, asset)){
+    if (!assetsCache->GetAssetMetaData(assettx.AssetId, asset)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-invalid-id");
     }
 
     //Check if fees is paid by the owner address
-    if(!checkAssetFeesPayment(tx, state, view, asset))
+    if (!checkAssetFeesPayment(tx, state, view, asset))
         return false;
 
-    if(assettx.ownerAddress.IsNull()){
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-ownerAddress"); 
+    if (assettx.ownerAddress.IsNull()) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-ownerAddress");
     }
 
-    if(assettx.targetAddress.IsNull()){
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-targetAddress"); 
+    if (assettx.targetAddress.IsNull()) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-targetAddress");
     }
-    
-    if(assettx.type < 0 && assettx.type > 3){
+
+    if (assettx.type < 0 && assettx.type > 3) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-distibution-type");
     }
-    
-    if(assettx.collateralAddress.IsNull() && assettx.type != 0){ //
-        return state.DoS(100, false, REJECT_INVALID, "bad-assets-collateralAddress"); 
+
+    if (assettx.collateralAddress.IsNull() && assettx.type != 0) { //
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-collateralAddress");
     }
-    
+
     if (!CheckInputsHash(tx, assettx, state)) {
         return false;
     }
@@ -271,33 +269,33 @@ inline bool checkAssetMintAmount(const CTransaction& tx, CValidationState& state
     CAmount nAmount = 0;
     std::set<uint16_t> setUniqueId;
     uint16_t minUniqueId = asset.circulatingSupply / COIN;
-    for (auto out : tx.vout){
-        if (out.scriptPubKey.IsAssetScript()){
+    for (auto out : tx.vout) {
+        if (out.scriptPubKey.IsAssetScript()) {
             CAssetTransfer assetTransfer;
-            if(!GetTransferAsset(out.scriptPubKey, assetTransfer)){
+            if (!GetTransferAsset(out.scriptPubKey, assetTransfer)) {
                 return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-transfer");
             }
-            if(assetTransfer.AssetId != asset.assetId){ //check asset id
-                return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-transfer"); 
+            if (assetTransfer.AssetId != asset.assetId) { //check asset id
+                return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-transfer");
             }
-            if (asset.isunique){
+            if (asset.isunique) {
                 //check validate uniqueId and amount
-                if (assetTransfer.uniqueId < minUniqueId || setUniqueId.count(assetTransfer.uniqueId)){
-                    return state.DoS(100, false, REJECT_INVALID, "bad-mint-dup-uniqueid"); 
+                if (assetTransfer.uniqueId < minUniqueId || setUniqueId.count(assetTransfer.uniqueId)) {
+                    return state.DoS(100, false, REJECT_INVALID, "bad-mint-dup-uniqueid");
                 }
                 setUniqueId.insert(assetTransfer.uniqueId);
-                if (assetTransfer.nAmount != 1 * COIN){
-                    return state.DoS(100, false, REJECT_INVALID, "bad-mint-unique-amount"); 
+                if (assetTransfer.nAmount != 1 * COIN) {
+                    return state.DoS(100, false, REJECT_INVALID, "bad-mint-unique-amount");
                 }
             }
-            if (!validateAmount(assetTransfer.nAmount, asset.Decimalpoint)){
+            if (!validateAmount(assetTransfer.nAmount, asset.Decimalpoint)) {
                 return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-amount");
             }
-            nAmount += assetTransfer.nAmount;                
+            nAmount += assetTransfer.nAmount;
         }
     }
 
-    if (asset.Amount != nAmount){
+    if (asset.Amount != nAmount) {
         return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-amount");
     }
 
@@ -306,8 +304,7 @@ inline bool checkAssetMintAmount(const CTransaction& tx, CValidationState& state
 
 bool CheckMintAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state, const CCoinsViewCache& view, CAssetsCache* assetsCache)
 {
-
-    if(!Params().IsAssetsActive(chainActive.Tip())) {
+    if (!Params().IsAssetsActive(chainActive.Tip())) {
         return state.DoS(100, false, REJECT_INVALID, "assets-not-enabled");
     }
 
@@ -326,19 +323,19 @@ bool CheckMintAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
 
     //Check if the provide asset id is valid
     CAssetMetaData asset;
-    if(!assetsCache->GetAssetMetaData(assettx.AssetId, asset)){
+    if (!assetsCache->GetAssetMetaData(assettx.AssetId, asset)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-invalid-asset-id");
     }
 
-    if (asset.type == 0 || asset.isunique){ // manual mint or unique
+    if (asset.type == 0 || asset.isunique) { // manual mint or unique
         //Check if fees is paid by the owner address
-        if(!checkAssetFeesPayment( tx, state, view, asset))
+        if (!checkAssetFeesPayment(tx, state, view, asset))
             return false;
 
-        if(!checkAssetMintAmount( tx, state, asset))
+        if (!checkAssetMintAmount(tx, state, asset))
             return false;
 
-        if(asset.mintCount >= asset.maxMintCount){
+        if (asset.mintCount >= asset.maxMintCount) {
             return state.DoS(100, false, REJECT_INVALID, "bad-max-mint-count");
         }
 

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -109,20 +109,20 @@ bool CheckFutureTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
     return true;
 }
 
-inline bool checkNewUniqueAsset(CNewAssetTx& assettx, CValidationState& state)
+inline bool checkNewUniqueAsset(CNewAssetTx& assetTx, CValidationState& state)
 {
-    if (!assettx.isUnique)
+    if (!assetTx.isUnique)
         return true;
 
-    if (assettx.decimalPoint > 0) { // alway 0
+    if (assetTx.decimalPoint > 0) { // alway 0
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-decimalPoint");
     }
 
-    if (assettx.type > 0) { // manual mint only?
+    if (assetTx.type > 0) { // manual mint only?
         return state.DoS(100, false, REJECT_INVALID, "bad-unique-assets-distibution-type");
     }
 
-    if (assettx.updatable) { // manual mint only?
+    if (assetTx.updatable) { // manual mint only?
         return state.DoS(100, false, REJECT_INVALID, "bad-unique-assets-distibution-type");
     }
 
@@ -139,58 +139,58 @@ bool CheckNewAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-type");
     }
 
-    CNewAssetTx assettx;
-    if (!GetTxPayload(tx, assettx)) {
+    CNewAssetTx assetTx;
+    if (!GetTxPayload(tx, assetTx)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-payload");
     }
 
-    if (assettx.nVersion == 0 || assettx.nVersion > CNewAssetTx::CURRENT_VERSION) {
+    if (assetTx.nVersion == 0 || assetTx.nVersion > CNewAssetTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-version");
     }
 
     //validate asset name
-    if (!IsAssetNameValid(assettx.Name)) {
+    if (!IsAssetNameValid(assetTx.name)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-name");
     }
 
     //Check if a asset already exist with give name
-    std::string assetid = assettx.Name;
-    if (assetsCache->GetAssetId(assettx.Name, assetid)) {
-        if (assetsCache->CheckIfAssetExists(assetid)) {
+    std::string assetId = assetTx.name;
+    if (assetsCache->GetAssetId(assetTx.name, assetId)) {
+        if (assetsCache->CheckIfAssetExists(assetId)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-assets-dup-name");
         }
     }
 
     //check unique asset
-    if (!checkNewUniqueAsset(assettx, state))
+    if (!checkNewUniqueAsset(assetTx, state))
         return false;
 
-    if (assettx.decimalPoint < 0 || assettx.decimalPoint > 8) {
+    if (assetTx.decimalPoint < 0 || assetTx.decimalPoint > 8) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-decimalPoint");
     }
 
-    if (assettx.ownerAddress.IsNull()) {
+    if (assetTx.ownerAddress.IsNull()) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-ownerAddress");
     }
 
-    if (assettx.targetAddress.IsNull()) {
+    if (assetTx.targetAddress.IsNull()) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-targetAddress");
     }
 
-    if (assettx.type < 0 && assettx.type > 3) {
+    if (assetTx.type < 0 && assetTx.type > 3) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-distibution-type");
     }
 
-    if (assettx.collateralAddress.IsNull() && assettx.type != 0) { //
+    if (assetTx.collateralAddress.IsNull() && assetTx.type != 0) { //
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-collateralAddress");
     }
 
 
-    if (!validateAmount(assettx.Amount, assettx.decimalPoint)) {
+    if (!validateAmount(assetTx.amount, assetTx.decimalPoint)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-amount");
     }
 
-    if (!CheckInputsHash(tx, assettx, state)) {
+    if (!CheckInputsHash(tx, assetTx, state)) {
         return false;
     }
 
@@ -222,18 +222,18 @@ bool CheckUpdateAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, C
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-type");
     }
 
-    CUpdateAssetTx assettx;
-    if (!GetTxPayload(tx, assettx)) {
+    CUpdateAssetTx assetTx;
+    if (!GetTxPayload(tx, assetTx)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-update-payload");
     }
 
-    if (assettx.nVersion == 0 || assettx.nVersion > CUpdateAssetTx::CURRENT_VERSION) {
+    if (assetTx.nVersion == 0 || assetTx.nVersion > CUpdateAssetTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-version");
     }
 
     //Check if the provide asset id is valid
     CAssetMetaData asset;
-    if (!assetsCache->GetAssetMetaData(assettx.AssetId, asset)) {
+    if (!assetsCache->GetAssetMetaData(assetTx.assetId, asset)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-invalid-id");
     }
 
@@ -241,23 +241,23 @@ bool CheckUpdateAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, C
     if (!checkAssetFeesPayment(tx, state, view, asset))
         return false;
 
-    if (assettx.ownerAddress.IsNull()) {
+    if (assetTx.ownerAddress.IsNull()) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-ownerAddress");
     }
 
-    if (assettx.targetAddress.IsNull()) {
+    if (assetTx.targetAddress.IsNull()) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-targetAddress");
     }
 
-    if (assettx.type < 0 && assettx.type > 3) {
+    if (assetTx.type < 0 && assetTx.type > 3) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-distibution-type");
     }
 
-    if (assettx.collateralAddress.IsNull() && assettx.type != 0) { //
+    if (assetTx.collateralAddress.IsNull() && assetTx.type != 0) { //
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-collateralAddress");
     }
 
-    if (!CheckInputsHash(tx, assettx, state)) {
+    if (!CheckInputsHash(tx, assetTx, state)) {
         return false;
     }
 
@@ -275,10 +275,10 @@ inline bool checkAssetMintAmount(const CTransaction& tx, CValidationState& state
             if (!GetTransferAsset(out.scriptPubKey, assetTransfer)) {
                 return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-transfer");
             }
-            if (assetTransfer.AssetId != asset.assetId) { //check asset id
+            if (assetTransfer.assetId != asset.assetId) { //check asset id
                 return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-transfer");
             }
-            if (asset.isunique) {
+            if (asset.isUnique) {
                 //check validate uniqueId and amount
                 if (assetTransfer.uniqueId < minUniqueId || setUniqueId.count(assetTransfer.uniqueId)) {
                     return state.DoS(100, false, REJECT_INVALID, "bad-mint-dup-uniqueid");
@@ -288,14 +288,14 @@ inline bool checkAssetMintAmount(const CTransaction& tx, CValidationState& state
                     return state.DoS(100, false, REJECT_INVALID, "bad-mint-unique-amount");
                 }
             }
-            if (!validateAmount(assetTransfer.nAmount, asset.Decimalpoint)) {
+            if (!validateAmount(assetTransfer.nAmount, asset.decimalPoint)) {
                 return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-amount");
             }
             nAmount += assetTransfer.nAmount;
         }
     }
 
-    if (asset.Amount != nAmount) {
+    if (asset.amount != nAmount) {
         return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-amount");
     }
 
@@ -312,22 +312,22 @@ bool CheckMintAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
         return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-type");
     }
 
-    CMintAssetTx assettx;
-    if (!GetTxPayload(tx, assettx)) {
+    CMintAssetTx assetTx;
+    if (!GetTxPayload(tx, assetTx)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-payload");
     }
 
-    if (assettx.nVersion == 0 || assettx.nVersion > CMintAssetTx::CURRENT_VERSION) {
+    if (assetTx.nVersion == 0 || assetTx.nVersion > CMintAssetTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-mint-assets-version");
     }
 
     //Check if the provide asset id is valid
     CAssetMetaData asset;
-    if (!assetsCache->GetAssetMetaData(assettx.AssetId, asset)) {
+    if (!assetsCache->GetAssetMetaData(assetTx.assetId, asset)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-invalid-asset-id");
     }
 
-    if (asset.type == 0 || asset.isunique) { // manual mint or unique
+    if (asset.type == 0 || asset.isUnique) { // manual mint or unique
         //Check if fees is paid by the owner address
         if (!checkAssetFeesPayment(tx, state, view, asset))
             return false;
@@ -344,7 +344,7 @@ bool CheckMintAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
     }
 
 
-    if (!CheckInputsHash(tx, assettx, state)) {
+    if (!CheckInputsHash(tx, assetTx, state)) {
         return false;
     }
 

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -298,22 +298,22 @@ public:
     static const uint16_t CURRENT_VERSION = 1;
 
     uint16_t nVersion{CURRENT_VERSION}; // message version
-    std::string Name;
-    bool updatable = true; //if true this asset meta can be modify using assetTx update process.
-    bool isUnique = false; //true if this is asset is unique it has an identity per token (NFT flag)
+    std::string name;
+    bool updatable = true; // If true this asset metadata can be modified using assetTx update process.
+    bool isUnique = false; // If true this asset is unique it has an identity per token (NFT flag)
     uint16_t maxMintCount = 0;
     uint8_t decimalPoint = 0;
-    std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
-    uint16_t fee;              // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
+    std::string referenceHash; // Hash of the underlying physical or digital assets, IPFS hash can be used here.
+    uint16_t fee;              // Fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
     //  distribution
-    uint8_t type; //manual, coinbase, address, schedule
+    uint8_t type; // manual, coinbase, address, schedule
     CKeyID targetAddress;
     uint8_t issueFrequency;
-    CAmount Amount;
+    CAmount amount;
     CKeyID ownerAddress;
     CKeyID collateralAddress;
 
-    uint16_t exChainType = 0; // external chain type. each 15 bit unsign number will be map to a external chain. i.e 0 for btc
+    uint16_t exChainType = 0; // External chain type. each 15 bit unsigned number will be map to a external chain. i.e. 0 for btc
     CScript externalPayoutScript;
     uint256 externalTxid;
     uint16_t externalConfirmations = 0;
@@ -325,7 +325,7 @@ public:
     template<typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(nVersion);
-        READWRITE(Name);
+        READWRITE(name);
         READWRITE(updatable);
         READWRITE(isUnique);
         READWRITE(maxMintCount);
@@ -335,7 +335,7 @@ public:
         READWRITE(type);
         READWRITE(targetAddress);
         READWRITE(issueFrequency);
-        READWRITE(Amount);
+        READWRITE(amount);
         READWRITE(ownerAddress);
         READWRITE(collateralAddress);
         READWRITE(exChainType);
@@ -351,23 +351,23 @@ public:
         obj.clear();
         obj.setObject();
         obj.pushKV("version", nVersion);
-        obj.pushKV("Name", Name);
-        obj.pushKV("Isunique", isUnique);
-        obj.pushKV("MaxMintCount", maxMintCount);
-        obj.pushKV("Updatable", updatable);
-        obj.pushKV("Decimalpoint", (int) decimalPoint);
-        obj.pushKV("ReferenceHash", referenceHash);
+        obj.pushKV("name", name);
+        obj.pushKV("isUnique", isUnique);
+        obj.pushKV("maxMintCount", maxMintCount);
+        obj.pushKV("updatable", updatable);
+        obj.pushKV("decimalPoint", (int) decimalPoint);
+        obj.pushKV("referenceHash", referenceHash);
         obj.pushKV("fee", fee);
-        obj.pushKV("Type", type);
-        obj.pushKV("TargetAddress", EncodeDestination(targetAddress));
+        obj.pushKV("type", type);
+        obj.pushKV("targetAddress", EncodeDestination(targetAddress));
         obj.pushKV("ownerAddress", EncodeDestination(ownerAddress));
         if( collateralAddress.IsNull()){
             obj.pushKV("collateralAddress", "N/A");
         }else{
             obj.pushKV("collateralAddress", EncodeDestination(collateralAddress));
         }
-        obj.pushKV("IssueFrequency", issueFrequency);
-        obj.pushKV("Amount", Amount);
+        obj.pushKV("issueFrequency", issueFrequency);
+        obj.pushKV("amount", amount);
         obj.pushKV("exChainType", exChainType);
         CTxDestination dest;
         if (ExtractDestination(externalPayoutScript, dest)) {
@@ -387,19 +387,19 @@ public:
     static const uint16_t CURRENT_VERSION = 1;
 
     uint16_t nVersion{CURRENT_VERSION}; // message version
-    std::string AssetId;
-    bool updatable = true;     //if true this asset meta can be modify using assetTx update process.
-    std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
-    uint16_t fee;              // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
+    std::string assetId;
+    bool updatable = true;     // If true this asset meta can be modified using assetTx update process.
+    std::string referenceHash; // Hash of the underlying physical or digital assets, IPFS hash can be used here.
+    uint16_t fee;              // Fee was paid for this asset creation in addition to miner fee. It is a whole non-decimal point value.
     //  distribution
     uint8_t type; //manual, coinbase, address, schedule
     CKeyID targetAddress;
     uint8_t issueFrequency;
-    CAmount Amount;
+    CAmount amount;
     CKeyID ownerAddress;
     CKeyID collateralAddress;
 
-    uint16_t exChainType = 0; // external chain type. each 15 bit unsign number will be map to a external chain. i.e 0 for btc
+    uint16_t exChainType = 0; // External chain type. Each 15 bit unsigned number will be map to a external chain. i.e. 0 for btc
     CScript externalPayoutScript;
     uint256 externalTxid;
     uint16_t externalConfirmations = 0;
@@ -412,14 +412,14 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(nVersion);
-        READWRITE(AssetId);
+        READWRITE(assetId);
         READWRITE(updatable);
         READWRITE(referenceHash);
         READWRITE(fee);
         READWRITE(type);
         READWRITE(targetAddress);
         READWRITE(issueFrequency);
-        READWRITE(Amount);
+        READWRITE(amount);
         READWRITE(ownerAddress);
         READWRITE(collateralAddress);
         READWRITE(exChainType);
@@ -436,20 +436,20 @@ public:
         obj.clear();
         obj.setObject();
         obj.pushKV("version", nVersion);
-        obj.pushKV("Id", AssetId);
-        obj.pushKV("Updatable", updatable);
-        obj.pushKV("ReferenceHash", referenceHash);
+        obj.pushKV("assetId", assetId);
+        obj.pushKV("updatable", updatable);
+        obj.pushKV("referenceHash", referenceHash);
         obj.pushKV("fee", fee);
-        obj.pushKV("Type", type);
-        obj.pushKV("TargetAddress", EncodeDestination(targetAddress));
+        obj.pushKV("type", type);
+        obj.pushKV("targetAddress", EncodeDestination(targetAddress));
         obj.pushKV("ownerAddress", EncodeDestination(ownerAddress));
         if (collateralAddress.IsNull()) {
             obj.pushKV("collateralAddress", "N/A");
         } else {
             obj.pushKV("collateralAddress", EncodeDestination(collateralAddress));
         }
-        obj.pushKV("IssueFrequency", issueFrequency);
-        obj.pushKV("Amount", Amount);
+        obj.pushKV("issueFrequency", issueFrequency);
+        obj.pushKV("amount", amount);
         obj.pushKV("exChainType", exChainType);
         CTxDestination dest;
         if (ExtractDestination(externalPayoutScript, dest)) {
@@ -469,7 +469,7 @@ public:
     static const uint16_t CURRENT_VERSION = 1;
 
     uint16_t nVersion{CURRENT_VERSION}; // message version
-    std::string AssetId;
+    std::string assetId;
     uint16_t fee;
     uint256 inputsHash; // replay protection
 
@@ -480,7 +480,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(nVersion);
-        READWRITE(AssetId);
+        READWRITE(assetId);
         READWRITE(fee);
         READWRITE(inputsHash);
     }
@@ -492,8 +492,8 @@ public:
         obj.clear();
         obj.setObject();
         obj.pushKV("version", nVersion);
-        obj.pushKV("Asset Id", AssetId);
-        obj.pushKV("Fee", fee);
+        obj.pushKV("assetId", assetId);
+        obj.pushKV("fee", fee);
         obj.pushKV("inputsHash", inputsHash.ToString());
     }
 };

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -292,26 +292,27 @@ public:
     }
 };
 
-class CNewAssetTx {
+class CNewAssetTx
+{
 public:
     static const uint16_t CURRENT_VERSION = 1;
 
-    uint16_t nVersion{CURRENT_VERSION};// message version
+    uint16_t nVersion{CURRENT_VERSION}; // message version
     std::string Name;
-    bool updatable = true;//if true this asset meta can be modify using assetTx update process. 
-    bool isUnique = false;//true if this is asset is unique it has an identity per token (NFT flag)
-    uint16_t  maxMintCount = 0;
+    bool updatable = true; //if true this asset meta can be modify using assetTx update process.
+    bool isUnique = false; //true if this is asset is unique it has an identity per token (NFT flag)
+    uint16_t maxMintCount = 0;
     uint8_t decimalPoint = 0;
     std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
-    uint16_t fee; // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
+    uint16_t fee;              // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
     //  distribution
-    uint8_t type;//manual, coinbase, address, schedule
+    uint8_t type; //manual, coinbase, address, schedule
     CKeyID targetAddress;
     uint8_t issueFrequency;
     CAmount Amount;
     CKeyID ownerAddress;
     CKeyID collateralAddress;
-    
+
     uint16_t exChainType = 0; // external chain type. each 15 bit unsign number will be map to a external chain. i.e 0 for btc
     CScript externalPayoutScript;
     uint256 externalTxid;
@@ -352,8 +353,8 @@ public:
         obj.pushKV("version", nVersion);
         obj.pushKV("Name", Name);
         obj.pushKV("Isunique", isUnique);
-        obj.pushKV("MaxMintCount", maxMintCount); 
-        obj.pushKV("Updatable", updatable);  
+        obj.pushKV("MaxMintCount", maxMintCount);
+        obj.pushKV("Updatable", updatable);
         obj.pushKV("Decimalpoint", (int) decimalPoint);
         obj.pushKV("ReferenceHash", referenceHash);
         obj.pushKV("fee", fee);
@@ -380,23 +381,24 @@ public:
     }
 };
 
-class CUpdateAssetTx {
+class CUpdateAssetTx
+{
 public:
     static const uint16_t CURRENT_VERSION = 1;
 
-    uint16_t nVersion{CURRENT_VERSION};// message version
+    uint16_t nVersion{CURRENT_VERSION}; // message version
     std::string AssetId;
-    bool updatable = true;//if true this asset meta can be modify using assetTx update process. 
+    bool updatable = true;     //if true this asset meta can be modify using assetTx update process.
     std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
-    uint16_t fee; // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
+    uint16_t fee;              // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
     //  distribution
-    uint8_t type;//manual, coinbase, address, schedule
+    uint8_t type; //manual, coinbase, address, schedule
     CKeyID targetAddress;
     uint8_t issueFrequency;
     CAmount Amount;
     CKeyID ownerAddress;
     CKeyID collateralAddress;
-    
+
     uint16_t exChainType = 0; // external chain type. each 15 bit unsign number will be map to a external chain. i.e 0 for btc
     CScript externalPayoutScript;
     uint256 externalTxid;
@@ -406,8 +408,9 @@ public:
 public:
     ADD_SERIALIZE_METHODS;
 
-    template<typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(nVersion);
         READWRITE(AssetId);
         READWRITE(updatable);
@@ -428,20 +431,21 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue &obj) const {
+    void ToJson(UniValue& obj) const
+    {
         obj.clear();
         obj.setObject();
         obj.pushKV("version", nVersion);
-        obj.pushKV("Id", AssetId); 
+        obj.pushKV("Id", AssetId);
         obj.pushKV("Updatable", updatable);
         obj.pushKV("ReferenceHash", referenceHash);
         obj.pushKV("fee", fee);
         obj.pushKV("Type", type);
         obj.pushKV("TargetAddress", EncodeDestination(targetAddress));
         obj.pushKV("ownerAddress", EncodeDestination(ownerAddress));
-        if( collateralAddress.IsNull()){
+        if (collateralAddress.IsNull()) {
             obj.pushKV("collateralAddress", "N/A");
-        }else{
+        } else {
             obj.pushKV("collateralAddress", EncodeDestination(collateralAddress));
         }
         obj.pushKV("IssueFrequency", issueFrequency);
@@ -454,16 +458,17 @@ public:
             obj.pushKV("externalPayoutAddress", "N/A");
         }
         obj.pushKV("externalTxid", externalTxid.ToString());
-        obj.pushKV("externalConfirmations", (int) externalConfirmations);
+        obj.pushKV("externalConfirmations", (int)externalConfirmations);
         obj.pushKV("inputsHash", inputsHash.ToString());
     }
 };
 
-class CMintAssetTx {
+class CMintAssetTx
+{
 public:
     static const uint16_t CURRENT_VERSION = 1;
 
-    uint16_t nVersion{CURRENT_VERSION};// message version
+    uint16_t nVersion{CURRENT_VERSION}; // message version
     std::string AssetId;
     uint16_t fee;
     uint256 inputsHash; // replay protection
@@ -471,8 +476,9 @@ public:
 public:
     ADD_SERIALIZE_METHODS;
 
-    template<typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
         READWRITE(nVersion);
         READWRITE(AssetId);
         READWRITE(fee);
@@ -481,21 +487,22 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue &obj) const {
+    void ToJson(UniValue& obj) const
+    {
         obj.clear();
         obj.setObject();
         obj.pushKV("version", nVersion);
-        obj.pushKV("Asset Id", AssetId); 
+        obj.pushKV("Asset Id", AssetId);
         obj.pushKV("Fee", fee);
         obj.pushKV("inputsHash", inputsHash.ToString());
     }
 };
 
-bool CheckFutureTx(const CTransaction &tx, const CBlockIndex *pindexPrev, CValidationState &state);
+bool CheckFutureTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 
-bool CheckNewAssetTx(const CTransaction &tx, const CBlockIndex *pindexPrev, CValidationState &state, CAssetsCache* assetsCache);
-bool CheckUpdateAssetTx(const CTransaction &tx, const CBlockIndex *pindexPrev, CValidationState &state, const CCoinsViewCache& view, CAssetsCache* assetsCache);
-bool CheckMintAssetTx(const CTransaction &tx, const CBlockIndex *pindexPrev, CValidationState &state, const CCoinsViewCache& view, CAssetsCache* assetsCache);
+bool CheckNewAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state, CAssetsCache* assetsCache);
+bool CheckUpdateAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state, const CCoinsViewCache& view, CAssetsCache* assetsCache);
+bool CheckMintAssetTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state, const CCoinsViewCache& view, CAssetsCache* assetsCache);
 
 bool CheckProRegTx(const CTransaction &tx, const CBlockIndex *pindexPrev, CValidationState &state,
                    const CCoinsViewCache &view);

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -300,6 +300,7 @@ public:
     std::string Name;
     bool updatable = true;//if true this asset meta can be modify using assetTx update process. 
     bool isUnique = false;//true if this is asset is unique it has an identity per token (NFT flag)
+    uint16_t  maxMintCount = 0;
     uint8_t decimalPoint = 0;
     std::string referenceHash; //hash of the underlying physical or digital assets, IPFS hash can be used here.
     uint16_t fee; // fee was paid for this asset creation in addition to miner fee. it is a whole non-decimal point value.
@@ -326,6 +327,7 @@ public:
         READWRITE(Name);
         READWRITE(updatable);
         READWRITE(isUnique);
+        READWRITE(maxMintCount);
         READWRITE(decimalPoint);
         READWRITE(referenceHash);
         READWRITE(fee);
@@ -349,7 +351,8 @@ public:
         obj.setObject();
         obj.pushKV("version", nVersion);
         obj.pushKV("Name", Name);
-        obj.pushKV("Isunique", isUnique); 
+        obj.pushKV("Isunique", isUnique);
+        obj.pushKV("MaxMintCount", maxMintCount); 
         obj.pushKV("Updatable", updatable);  
         obj.pushKV("Decimalpoint", (int) decimalPoint);
         obj.pushKV("ReferenceHash", referenceHash);

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -244,6 +244,22 @@ public:
     using CoinsList = std::map<CTxDestination, std::vector<std::tuple<COutPoint, WalletTxOut>>>;
     virtual CoinsList listCoins() = 0;
 
+    //! Return AvailableAssets + LockedAssets grouped by wallet address.
+    //! (put change in one group with wallet address)
+    virtual CoinsList listAssets() = 0;
+
+    //! Return list of avaylable assets
+    using AssetList = std::vector<std::string>;
+    virtual AssetList listMyAssets(const CCoinControl* coinControl = nullptr) = 0;
+
+    //! Return list of avaylable assets
+    using UniqueIdList = std::vector<uint16_t>;
+    virtual UniqueIdList listAssetUniqueId(std::string assetId, const CCoinControl* coinControl = nullptr) = 0;
+
+    //!Return asset balance
+    using AssetBalance = std::map<std::string, CAmount>;
+    virtual AssetBalance getAssetsBalance(const CCoinControl* coinControl = nullptr, bool fSpendable = false) = 0;
+
     //! Return wallet transaction output information.
     virtual std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) = 0;
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -992,3 +992,22 @@ void CBlockPolicyEstimator::FlushUnconfirmed() {
     int64_t endclear = GetTimeMicros();
     LogPrint(BCLog::ESTIMATEFEE, "Recorded %u unconfirmed txs from mempool in %ld micros\n", num_entries, endclear - startclear);
 }
+
+int getConfTargetForIndex(int index) {
+    if (index+1 > static_cast<int>(confTargets.size())) {
+        return confTargets.back();
+    }
+    if (index < 0) {
+        return confTargets[0];
+    }
+    return confTargets[index];
+}
+
+int getIndexForConfTarget(int target) {
+    for (unsigned int i = 0; i < confTargets.size(); i++) {
+        if (confTargets[i] >= target) {
+            return i;
+        }
+    }
+    return confTargets.size() - 1;
+}

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <array>
 
 class CAutoFile;
 class CFeeRate;
@@ -272,5 +273,9 @@ private:
     /** Calculation of highest target that reasonable estimate can be provided for */
     unsigned int MaxUsableEstimate() const;
 };
+
+static const std::array<int, 9> confTargets = { {2, 4, 6, 12, 24, 48, 144, 504, 1008} };
+int getConfTargetForIndex(int index);
+int getIndexForConfTarget(int target);
 
 #endif // BITCOIN_POLICY_FEES_H

--- a/src/qt/assetcontroldialog.cpp
+++ b/src/qt/assetcontroldialog.cpp
@@ -1,0 +1,864 @@
+// Copyright (c) 2011-2015 The BitAsset Core developers
+// Copyright (c) 2014-2021 The Dash Core developers
+// Copyright (c) 2020-2022 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/assetcontroldialog.h>
+#include <qt/forms/ui_assetcontroldialog.h>
+
+#include <qt/addresstablemodel.h>
+#include <qt/bitcoinunits.h>
+#include <qt/guiutil.h>
+#include <qt/optionsmodel.h>
+#include <txmempool.h>
+#include <qt/walletmodel.h>
+
+#include <wallet/coincontrol.h>
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <key_io.h>
+#include <policy/fees.h>
+#include <policy/policy.h>
+#include <validation.h> // For mempool
+#include <wallet/fees.h>
+#include <wallet/wallet.h>
+#include <assets/assets.h>
+#include <assets/assetstype.h>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QCursor>
+#include <QDialogButtonBox>
+#include <QFlags>
+#include <QIcon>
+#include <QSettings>
+#include <QString>
+#include <QTreeWidget>
+#include <QStringListModel>
+#include <QSortFilterProxyModel>
+#include <QCompleter>
+#include <QLineEdit>
+
+QList<CAmount> AssetControlDialog::payAmounts;
+bool AssetControlDialog::fSubtractFeeFromAmount = false;
+
+bool CAssetControlWidgetItem::operator<(const QTreeWidgetItem &other) const {
+    int column = treeWidget()->sortColumn();
+    if (column == AssetControlDialog::COLUMN_AMOUNT || column == AssetControlDialog::COLUMN_DATE || column == AssetControlDialog::COLUMN_CONFIRMATIONS)
+        return data(column, Qt::UserRole).toLongLong() < other.data(column, Qt::UserRole).toLongLong();
+    return QTreeWidgetItem::operator<(other);
+}
+
+AssetControlDialog::AssetControlDialog(CCoinControl& coin_control, WalletModel* _model, QWidget* parent) :
+    QDialog(parent),
+    ui(new Ui::AssetControlDialog),
+    m_coin_control(coin_control),
+    model(_model)
+{
+    ui->setupUi(this);
+
+    GUIUtil::setFont({ui->labelAssetControlQuantityText,
+                      ui->labelAssetControlBytesText,
+                      ui->labelAssetControlAmountText,
+                      ui->labelAssetControlLowOutputText,
+                      ui->labelAssetControlFeeText,
+                      ui->labelAssetControlAfterFeeText,
+                      ui->labelAssetControlChangeText
+                     }, GUIUtil::FontWeight::Bold);
+
+    GUIUtil::updateFonts();
+
+    GUIUtil::disableMacFocusRect(this);
+
+    // context menu actions
+    QAction *copyAddressAction = new QAction(tr("Copy address"), this);
+    QAction *copyLabelAction = new QAction(tr("Copy label"), this);
+    QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
+             copyTransactionHashAction = new QAction(tr("Copy transaction ID"), this);  // we need to enable/disable this
+             lockAction = new QAction(tr("Lock unspent"), this);                        // we need to enable/disable this
+             unlockAction = new QAction(tr("Unlock unspent"), this);                    // we need to enable/disable this
+
+    // context menu
+    contextMenu = new QMenu(this);
+    contextMenu->addAction(copyAddressAction);
+    contextMenu->addAction(copyLabelAction);
+    contextMenu->addAction(copyAmountAction);
+    contextMenu->addAction(copyTransactionHashAction);
+    contextMenu->addSeparator();
+    contextMenu->addAction(lockAction);
+    contextMenu->addAction(unlockAction);
+
+    // context menu signals
+    connect(ui->treeWidget, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showMenu(QPoint)));
+    connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(copyAddress()));
+    connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
+    connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
+    connect(copyTransactionHashAction, SIGNAL(triggered()), this, SLOT(copyTransactionHash()));
+    connect(lockAction, SIGNAL(triggered()), this, SLOT(lockAsset()));
+    connect(unlockAction, SIGNAL(triggered()), this, SLOT(unlockAsset()));
+
+    // clipboard actions
+    QAction *clipboardQuantityAction = new QAction(tr("Copy quantity"), this);
+    QAction *clipboardAmountAction = new QAction(tr("Copy amount"), this);
+    QAction *clipboardFeeAction = new QAction(tr("Copy fee"), this);
+    QAction *clipboardAfterFeeAction = new QAction(tr("Copy after fee"), this);
+    QAction *clipboardBytesAction = new QAction(tr("Copy bytes"), this);
+    QAction *clipboardLowOutputAction = new QAction(tr("Copy dust"), this);
+    QAction *clipboardChangeAction = new QAction(tr("Copy change"), this);
+
+    connect(clipboardQuantityAction, SIGNAL(triggered()), this, SLOT(clipboardQuantity()));
+    connect(clipboardAmountAction, SIGNAL(triggered()), this, SLOT(clipboardAmount()));
+    connect(clipboardFeeAction, SIGNAL(triggered()), this, SLOT(clipboardFee()));
+    connect(clipboardAfterFeeAction, SIGNAL(triggered()), this, SLOT(clipboardAfterFee()));
+    connect(clipboardBytesAction, SIGNAL(triggered()), this, SLOT(clipboardBytes()));
+    connect(clipboardLowOutputAction, SIGNAL(triggered()), this, SLOT(clipboardLowOutput()));
+    connect(clipboardChangeAction, SIGNAL(triggered()), this, SLOT(clipboardChange()));
+
+    ui->labelAssetControlQuantity->addAction(clipboardQuantityAction);
+    ui->labelAssetControlAmount->addAction(clipboardAmountAction);
+    ui->labelAssetControlFee->addAction(clipboardFeeAction);
+    ui->labelAssetControlAfterFee->addAction(clipboardAfterFeeAction);
+    ui->labelAssetControlBytes->addAction(clipboardBytesAction);
+    ui->labelAssetControlLowOutput->addAction(clipboardLowOutputAction);
+    ui->labelAssetControlChange->addAction(clipboardChangeAction);
+
+    // toggle tree/list mode
+    connect(ui->radioTreeMode, SIGNAL(toggled(bool)), this, SLOT(radioTreeMode(bool)));
+    connect(ui->radioListMode, SIGNAL(toggled(bool)), this, SLOT(radioListMode(bool)));
+
+    // click on checkbox
+    connect(ui->treeWidget, SIGNAL(itemChanged(QTreeWidgetItem*, int)), this, SLOT(viewItemChanged(QTreeWidgetItem*, int)));
+
+    // click on header
+    ui->treeWidget->header()->setSectionsClickable(true);
+    connect(ui->treeWidget->header(), SIGNAL(sectionClicked(int)), this, SLOT(headerSectionClicked(int)));
+
+    // ok button
+    connect(ui->buttonBox, SIGNAL(clicked( QAbstractButton*)), this, SLOT(buttonBoxClicked(QAbstractButton*)));
+
+    // (un)select all
+    connect(ui->pushButtonSelectAll, SIGNAL(clicked()), this, SLOT(buttonSelectAllClicked()));
+
+    ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 94);
+    ui->treeWidget->setColumnWidth(COLUMN_NAME,250);
+    ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 100);
+    ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);
+    ui->treeWidget->setColumnWidth(COLUMN_DATE, 120);
+    ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 110);
+
+    ui->treeWidget->header()->setStretchLastSection(false);
+    ui->treeWidget->header()->setSectionResizeMode(COLUMN_ADDRESS, QHeaderView::Stretch);
+
+    // default view is sorted by amount desc
+    sortView(COLUMN_AMOUNT, Qt::DescendingOrder);
+
+    connect(ui->assetList, SIGNAL(currentIndexChanged(QString)), this, SLOT(onAssetSelected(QString)));
+
+        /** Setup the asset list combobox */
+    stringModel = new QStringListModel;
+
+    proxy = new QSortFilterProxyModel;
+    proxy->setSourceModel(stringModel);
+    proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+    ui->assetList->setModel(proxy);
+    ui->assetList->setEditable(true);
+    ui->assetList->lineEdit()->setPlaceholderText("Select an asset");
+
+    completer = new QCompleter(proxy,this);
+    completer->setCompletionMode(QCompleter::PopupCompletion);
+    completer->setCaseSensitivity(Qt::CaseInsensitive);
+    ui->assetList->setCompleter(completer);
+
+    // restore list mode and sortorder as a convenience feature
+    QSettings settings;
+    if (settings.contains("nAssetControlMode") && !settings.value("nAssetControlMode").toBool())
+        ui->radioTreeMode->click();
+    if (settings.contains("nAssetControlSortColumn") && settings.contains("nAssetControlSortOrder"))
+        sortView(settings.value("nAssetControlSortColumn").toInt(), (static_cast<Qt::SortOrder>(settings.value("nAssetControlSortOrder").toInt())));
+
+    if(_model->getOptionsModel() && _model->getAddressTableModel())
+    {
+        updateView();
+        updateAssetList();
+        updateLabelLocked();
+        AssetControlDialog::updateLabels(m_coin_control, _model, this);
+    }
+}
+
+AssetControlDialog::~AssetControlDialog()
+{
+    QSettings settings;
+    settings.setValue("nAssetControlMode", ui->radioListMode->isChecked());
+    settings.setValue("nAssetControlSortColumn", sortColumn);
+    settings.setValue("nAssetControlSortOrder", (int)sortOrder);
+
+    delete ui;
+}
+
+// ok button
+void AssetControlDialog::buttonBoxClicked(QAbstractButton* button)
+{
+    if (ui->buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole)
+        Q_EMIT model->assetListChanged();//emit signal to refresh list of asset
+        done(QDialog::Accepted); // closes the dialog
+}
+
+// (un)select all
+void AssetControlDialog::buttonSelectAllClicked()
+{
+    Qt::CheckState state = Qt::Checked;
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++)
+    {
+        if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != Qt::Unchecked)
+        {
+            state = Qt::Unchecked;
+            break;
+        }
+    }
+    ui->treeWidget->setEnabled(false);
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++)
+            if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
+                ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+    ui->treeWidget->setEnabled(true);
+    if (state == Qt::Unchecked)
+        m_coin_control.UnSelectAll(); // just to be sure
+    AssetControlDialog::updateLabels(m_coin_control, model, this);
+}
+
+// Toggle lock state
+void AssetControlDialog::buttonToggleLockClicked()
+{
+    QTreeWidgetItem *item;
+    // Works in list-mode only
+    if(ui->radioListMode->isChecked()){
+        ui->treeWidget->setEnabled(false);
+        for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++){
+            item = ui->treeWidget->topLevelItem(i);
+            COutPoint outpt(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), item->data(COLUMN_ADDRESS, VOutRole).toUInt());
+            if (model->wallet().isLockedCoin(outpt)) {
+                model->wallet().unlockCoin(outpt);
+                item->setDisabled(false);
+                item->setIcon(COLUMN_CHECKBOX, QIcon());
+            }
+            else{
+                model->wallet().lockCoin(outpt);
+                item->setDisabled(true);
+                item->setIcon(COLUMN_CHECKBOX, GUIUtil::getIcon("lock_closed", GUIUtil::ThemedColor::RED));
+            }
+            updateLabelLocked();
+        }
+        ui->treeWidget->setEnabled(true);
+        AssetControlDialog::updateLabels(m_coin_control, model, this);
+    }
+    else{
+        QMessageBox msgBox(this);
+        msgBox.setObjectName("lockMessageBox");
+        msgBox.setText(tr("Please switch to \"List mode\" to use this function."));
+        msgBox.exec();
+    }
+}
+
+// context menu
+void AssetControlDialog::showMenu(const QPoint &point)
+{
+    QTreeWidgetItem *item = ui->treeWidget->itemAt(point);
+    if(item)
+    {
+        contextMenuItem = item;
+
+        // disable some items (like Copy Transaction ID, lock, unlock) for tree roots in context menu
+        if (item->data(COLUMN_ADDRESS, TxHashRole).toString().length() == 64) // transaction hash is 64 characters (this means it is a child node, so it is not a parent node in tree mode)
+        {
+            copyTransactionHashAction->setEnabled(true);
+            if (model->wallet().isLockedCoin(COutPoint(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), item->data(COLUMN_ADDRESS, VOutRole).toUInt())))
+            {
+                lockAction->setEnabled(false);
+                unlockAction->setEnabled(true);
+            }
+            else
+            {
+                lockAction->setEnabled(true);
+                unlockAction->setEnabled(false);
+            }
+        }
+        else // this means click on parent node in tree mode -> disable all
+        {
+            copyTransactionHashAction->setEnabled(false);
+            lockAction->setEnabled(false);
+            unlockAction->setEnabled(false);
+        }
+
+        // show context menu
+        contextMenu->exec(QCursor::pos());
+    }
+}
+
+// context menu action: copy amount
+void AssetControlDialog::copyAmount()
+{
+    GUIUtil::setClipboard(BitcoinUnits::removeSpaces(contextMenuItem->text(COLUMN_AMOUNT)));
+}
+
+// context menu action: copy label
+void AssetControlDialog::copyLabel()
+{
+    if (ui->radioTreeMode->isChecked() && contextMenuItem->text(COLUMN_LABEL).length() == 0 && contextMenuItem->parent())
+        GUIUtil::setClipboard(contextMenuItem->parent()->text(COLUMN_LABEL));
+    else
+        GUIUtil::setClipboard(contextMenuItem->text(COLUMN_LABEL));
+}
+
+// context menu action: copy address
+void AssetControlDialog::copyAddress()
+{
+    if (ui->radioTreeMode->isChecked() && contextMenuItem->text(COLUMN_ADDRESS).length() == 0 && contextMenuItem->parent())
+        GUIUtil::setClipboard(contextMenuItem->parent()->text(COLUMN_ADDRESS));
+    else
+        GUIUtil::setClipboard(contextMenuItem->text(COLUMN_ADDRESS));
+}
+
+// context menu action: copy transaction id
+void AssetControlDialog::copyTransactionHash()
+{
+    GUIUtil::setClipboard(contextMenuItem->data(COLUMN_ADDRESS, TxHashRole).toString());
+}
+
+// context menu action: lock Asset
+void AssetControlDialog::lockAsset()
+{
+    if (contextMenuItem->checkState(COLUMN_CHECKBOX) == Qt::Checked)
+        contextMenuItem->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+
+    COutPoint outpt(uint256S(contextMenuItem->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), contextMenuItem->data(COLUMN_ADDRESS, VOutRole).toUInt());
+    model->wallet().lockCoin(outpt);
+    contextMenuItem->setDisabled(true);
+    contextMenuItem->setIcon(COLUMN_CHECKBOX, GUIUtil::getIcon("lock_closed", GUIUtil::ThemedColor::RED));
+    updateLabelLocked();
+}
+
+// context menu action: unlock Asset
+void AssetControlDialog::unlockAsset()
+{
+    COutPoint outpt(uint256S(contextMenuItem->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), contextMenuItem->data(COLUMN_ADDRESS, VOutRole).toUInt());
+    model->wallet().unlockCoin(outpt);
+    contextMenuItem->setDisabled(false);
+    contextMenuItem->setIcon(COLUMN_CHECKBOX, QIcon());
+    updateLabelLocked();
+}
+
+// copy label "Quantity" to clipboard
+void AssetControlDialog::clipboardQuantity()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlQuantity->text());
+}
+
+// copy label "Amount" to clipboard
+void AssetControlDialog::clipboardAmount()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlAmount->text().left(ui->labelAssetControlAmount->text().indexOf(" ")));
+}
+
+// copy label "Fee" to clipboard
+void AssetControlDialog::clipboardFee()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlFee->text().left(ui->labelAssetControlFee->text().indexOf(" ")).replace(ASYMP_UTF8, ""));
+}
+
+// copy label "After fee" to clipboard
+void AssetControlDialog::clipboardAfterFee()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlAfterFee->text().left(ui->labelAssetControlAfterFee->text().indexOf(" ")).replace(ASYMP_UTF8, ""));
+}
+
+// copy label "Bytes" to clipboard
+void AssetControlDialog::clipboardBytes()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlBytes->text().replace(ASYMP_UTF8, ""));
+}
+
+// copy label "Dust" to clipboard
+void AssetControlDialog::clipboardLowOutput()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlLowOutput->text());
+}
+
+// copy label "Change" to clipboard
+void AssetControlDialog::clipboardChange()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlChange->text().left(ui->labelAssetControlChange->text().indexOf(" ")).replace(ASYMP_UTF8, ""));
+}
+
+// treeview: sort
+void AssetControlDialog::sortView(int column, Qt::SortOrder order)
+{
+    sortColumn = column;
+    sortOrder = order;
+    ui->treeWidget->sortItems(column, order);
+    ui->treeWidget->header()->setSortIndicator(sortColumn, sortOrder);
+}
+
+// treeview: clicked on header
+void AssetControlDialog::headerSectionClicked(int logicalIndex)
+{
+    if (logicalIndex == COLUMN_CHECKBOX) // click on most left column -> do nothing
+    {
+        ui->treeWidget->header()->setSortIndicator(sortColumn, sortOrder);
+    }
+    else
+    {
+        if (sortColumn == logicalIndex)
+            sortOrder = ((sortOrder == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder);
+        else
+        {
+            sortColumn = logicalIndex;
+            sortOrder = ((sortColumn == COLUMN_NAME || sortColumn == COLUMN_LABEL || sortColumn == COLUMN_ADDRESS) ? Qt::AscendingOrder : Qt::DescendingOrder); // if label or address then default => asc, else default => desc
+        }
+
+        sortView(sortColumn, sortOrder);
+    }
+}
+
+// toggle tree mode
+void AssetControlDialog::radioTreeMode(bool checked)
+{
+    if (checked && model)
+        updateView();
+}
+
+// toggle list mode
+void AssetControlDialog::radioListMode(bool checked)
+{
+    if (checked && model)
+        updateView();
+}
+
+// checkbox clicked by user
+void AssetControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
+{
+    if (column == COLUMN_CHECKBOX && item->data(COLUMN_ADDRESS, TxHashRole).toString().length() == 64) // transaction hash is 64 characters (this means it is a child node, so it is not a parent node in tree mode)
+    {
+        COutPoint outpt(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), item->data(COLUMN_ADDRESS, VOutRole).toUInt());
+
+        if (item->checkState(COLUMN_CHECKBOX) == Qt::Unchecked)
+            m_coin_control.UnSelectAsset(outpt);
+        else if (item->isDisabled()) // locked (this happens if "check all" through parent node)
+            item->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+        else {
+            m_coin_control.SelectAsset(outpt);
+        }
+        
+        // selection changed -> update labels
+        if (ui->treeWidget->isEnabled()) // do not update on every click for (un)select all
+            AssetControlDialog::updateLabels(m_coin_control, model, this);
+    }
+}
+
+// shows count of locked unspent outputs
+void AssetControlDialog::updateLabelLocked()
+{
+    std::vector<COutPoint> vOutpts;
+    model->wallet().listLockedCoins(vOutpts);
+    if (vOutpts.size() > 0)
+    {
+       ui->labelLocked->setText(tr("(%1 locked)").arg(vOutpts.size()));
+       ui->labelLocked->setVisible(true);
+    }
+    else ui->labelLocked->setVisible(false);
+}
+
+void AssetControlDialog::updateLabels(CCoinControl& m_coin_control, WalletModel *model, QDialog* dialog)
+{
+    if (!model)
+        return;
+
+    // nPayAmount
+    CAmount nPayAmount = 0;
+    bool fDust = false;
+    CMutableTransaction txDummy;
+    for (const CAmount &amount : AssetControlDialog::payAmounts)
+    {
+        nPayAmount += amount;
+
+        if (amount > 0)
+        {
+            CTxOut txout(amount, static_cast<CScript>(std::vector<unsigned char>(24, 0)));
+            txDummy.vout.push_back(txout);
+            fDust |= IsDust(txout, model->node().getDustRelayFee());
+        }
+    }
+
+    std::string AssetId = "";
+    CAmount nAmount             = 0;
+    CAmount nAssetAmount        = 0;
+    CAmount nPayFee             = 0;
+    CAmount nAfterFee           = 0;
+    CAmount nChange             = 0;
+    unsigned int nBytes         = 0;
+    unsigned int nBytesInputs   = 0;
+    unsigned int nQuantity      = 0;
+    int nQuantityUncompressed   = 0;
+    bool fUnselectedSpent{false};
+    bool fUnselectedNonMixed{false};
+    bool isasset{false};
+
+    std::vector<COutPoint> vAssetControl;
+    m_coin_control.ListSelectedAssets(vAssetControl);
+
+    size_t i = 0;
+    for (const auto& out : model->wallet().getCoins(vAssetControl)) {
+        if (out.depth_in_main_chain < 0) continue;
+
+        // unselect already spent, very unlikely scenario, this could happen
+        // when selected are spent elsewhere, like rpc or another computer
+        const COutPoint& outpt = vAssetControl[i++];
+        if (out.is_spent)
+        {
+            m_coin_control.UnSelectAsset(outpt);
+            fUnselectedSpent = true;
+            continue;
+        }
+
+        // Quantity
+        nQuantity++;
+
+        // Amount
+        nAmount += out.txout.nValue;
+        
+        CAssetTransfer assetTransfer;
+        if(GetTransferAsset(out.txout.scriptPubKey, assetTransfer)){
+            nAssetAmount += assetTransfer.nAmount;
+            AssetId = assetTransfer.AssetId;
+        }
+
+        // Bytes
+        CTxDestination address;
+        if(ExtractDestination(out.txout.scriptPubKey, address))
+        {
+            CPubKey pubkey;
+            CKeyID *keyid = boost::get<CKeyID>(&address);
+            if (keyid && model->wallet().getPubKey(*keyid, pubkey))
+            {
+                nBytesInputs += (pubkey.IsCompressed() ? 148 : 180);
+            }
+            else
+                nBytesInputs += 148; // in all error cases, simply assume 148 here
+        }
+        else nBytesInputs += 148;
+    }
+
+    // calculation
+    if (nQuantity > 0)
+    {
+        // Bytes
+        nBytes = nBytesInputs + ((AssetControlDialog::payAmounts.size() > 0 ? AssetControlDialog::payAmounts.size() + 1 : 2) * 34) + 10; // always assume +1 output for change here
+
+        // in the subtract fee from amount case, we can tell if zero change already and subtract the bytes, so that fee calculation afterwards is accurate
+        if (AssetControlDialog::fSubtractFeeFromAmount)
+            if (nAmount - nPayAmount == 0)
+                nBytes -= 34;
+
+        // Fee
+        nPayFee = model->node().getMinimumFee(nBytes, m_coin_control, nullptr /* returned_target */, nullptr /* reason */);
+
+        if (nPayAmount > 0)
+        {
+            nChange = nAssetAmount - nPayAmount;
+
+            if (nChange == 0)
+                nBytes -= 34;
+        }
+
+        // after fee
+        nAfterFee = std::max<CAmount>(nAmount - nPayFee, 0);
+    }
+
+    // actually update labels
+    int nDisplayUnit = BitcoinUnits::RTM;
+    if (model && model->getOptionsModel())
+        nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
+
+    QLabel *l1 = dialog->findChild<QLabel *>("labelAssetControlQuantity");
+    QLabel *l2 = dialog->findChild<QLabel *>("labelAssetControlAmount");
+    QLabel *l3 = dialog->findChild<QLabel *>("labelAssetControlFee");
+    QLabel *l4 = dialog->findChild<QLabel *>("labelAssetControlAfterFee");
+    QLabel *l5 = dialog->findChild<QLabel *>("labelAssetControlBytes");
+    QLabel *l7 = dialog->findChild<QLabel *>("labelAssetControlLowOutput");
+    QLabel *l8 = dialog->findChild<QLabel *>("labelAssetControlChange");
+
+    // enable/disable "dust" and "change"
+    dialog->findChild<QLabel *>("labelAssetControlLowOutputText")->setEnabled(nPayAmount > 0);
+    dialog->findChild<QLabel *>("labelAssetControlLowOutput")    ->setEnabled(nPayAmount > 0);
+    dialog->findChild<QLabel *>("labelAssetControlChangeText")   ->setEnabled(nPayAmount > 0);
+    dialog->findChild<QLabel *>("labelAssetControlChange")       ->setEnabled(nPayAmount > 0);
+
+    // stats
+    l1->setText(QString::number(nQuantity)); 
+    // Quantity
+    CAssetMetaData assetdata;
+    if(passetsCache->GetAssetMetaData(AssetId, assetdata))
+    l2->setText(BitcoinUnits::formatWithCustomName(QString::fromStdString(assetdata.Name), nAssetAmount));        // Amount
+    l3->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nPayFee));        // Fee
+    l4->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAfterFee));      // After Fee
+    l5->setText(((nBytes > 0) ? ASYMP_UTF8 : "") + QString::number(nBytes));        // Bytes
+    l7->setText(fDust ? tr("yes") : tr("no")); 
+    l8->setText(BitcoinUnits::formatWithCustomName(QString::fromStdString(assetdata.Name), nChange));        // Amount
+    if (nPayFee > 0)
+    {
+        l3->setText(ASYMP_UTF8 + l3->text());
+        l4->setText(ASYMP_UTF8 + l4->text());
+        if (nChange > 0 && !AssetControlDialog::fSubtractFeeFromAmount)
+            l8->setText(ASYMP_UTF8 + l8->text());
+    }
+
+    // turn label red when dust
+    l7->setStyleSheet((fDust) ? GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) : "");
+
+    // tool tips
+    QString toolTipDust = tr("This label turns red if any recipient receives an amount smaller than the current dust threshold.");
+
+    // how many satoshis the estimated fee can vary per byte we guess wrong
+    double dFeeVary = (nBytes != 0) ? (double)nPayFee / nBytes : 0;
+
+    QString toolTip4 = tr("Can vary +/- %1 ruff(s) per input.").arg(dFeeVary);
+
+    l3->setToolTip(toolTip4);
+    l4->setToolTip(toolTip4);
+    l7->setToolTip(toolTipDust);
+    l8->setToolTip(toolTip4);
+    dialog->findChild<QLabel *>("labelAssetControlFeeText")      ->setToolTip(l3->toolTip());
+    dialog->findChild<QLabel *>("labelAssetControlAfterFeeText") ->setToolTip(l4->toolTip());
+    dialog->findChild<QLabel *>("labelAssetControlBytesText")    ->setToolTip(l5->toolTip());
+    dialog->findChild<QLabel *>("labelAssetControlLowOutputText")->setToolTip(l7->toolTip());
+    dialog->findChild<QLabel *>("labelAssetControlChangeText")   ->setToolTip(l8->toolTip());
+
+    // Insufficient funds
+    QLabel *label = dialog->findChild<QLabel *>("labelAssetControlInsuffFunds");
+    if (label)
+        label->setVisible(nChange < 0);
+
+    // Warn about unselected Assets
+    if (fUnselectedSpent) {
+        QMessageBox::warning(dialog, "AssetControl",
+            tr("Some Assets were unselected because they were spent."),
+            QMessageBox::Ok, QMessageBox::Ok);
+    } else if (fUnselectedNonMixed) {
+        QMessageBox::warning(dialog, "AssetControl",
+            tr("Some Assets were unselected because they do not have enough mixing rounds."),
+            QMessageBox::Ok, QMessageBox::Ok);
+    }
+}
+
+void AssetControlDialog::updateView()
+{
+    if (!model || !model->getOptionsModel() || !model->getAddressTableModel())
+        return;
+
+    bool fNormalMode = !m_coin_control.IsUsingCoinJoin();
+    ui->treeWidget->setColumnHidden(COLUMN_LABEL, !fNormalMode);
+    ui->radioTreeMode->setVisible(fNormalMode);
+    ui->radioListMode->setVisible(fNormalMode);
+
+
+    bool treeMode = ui->radioTreeMode->isChecked();
+    ui->treeWidget->clear();
+    ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox
+    ui->treeWidget->setAlternatingRowColors(!treeMode);
+    QFlags<Qt::ItemFlag> flgCheckbox = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
+    QFlags<Qt::ItemFlag> flgTristate = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
+
+    int nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
+
+    QString assetToDisplay = ui->assetList->currentText();
+    std::map<CTxDestination, std::vector<std::tuple<COutPoint, interfaces::WalletTxOut>>> mapassets;
+
+    mapassets = model->wallet().listAssets();
+     
+    for (const auto& Assets : mapassets) {
+        CAssetControlWidgetItem *itemWalletAddress = new CAssetControlWidgetItem();
+        itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+        QString sWalletAddress = QString::fromStdString(EncodeDestination(Assets.first));
+        QString sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
+        QString assetname = "";
+        if (sWalletLabel.isEmpty())
+            sWalletLabel = tr("(no label)");
+        
+        bool hastree = false;
+
+        CAmount nSum = 0;
+        int nChildren = 0;
+        for (const auto& outpair : Assets.second) {
+            const COutPoint& output = std::get<0>(outpair);
+            const interfaces::WalletTxOut& out = std::get<1>(outpair);
+            bool fFullyMixed{false};
+            CAmount nAmount = out.txout.nValue;
+
+            CAssetTransfer assetTransfer;
+            std::string uniqueId = "";
+            if(GetTransferAsset(out.txout.scriptPubKey, assetTransfer)){
+                nAmount = assetTransfer.nAmount;
+                CAssetMetaData assetdata;
+                if(passetsCache->GetAssetMetaData(assetTransfer.AssetId, assetdata)){
+                    if (assetdata.isunique)
+                        uniqueId += " ["+to_string(assetTransfer.uniqueId)+"]";
+                    assetname = QString::fromStdString(assetdata.Name);
+                }
+            }
+
+            if (assetname != assetToDisplay)
+            continue;
+
+            assetname += QString::fromStdString(uniqueId);
+
+            if (treeMode && !hastree)
+            {
+                hastree = true;
+                // wallet address
+                ui->treeWidget->addTopLevelItem(itemWalletAddress);
+
+                itemWalletAddress->setText(COLUMN_NAME, assetname);
+                itemWalletAddress->setToolTip(COLUMN_NAME, assetname);
+
+                itemWalletAddress->setFlags(flgTristate);
+                itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+
+                // label
+                itemWalletAddress->setText(COLUMN_LABEL, sWalletLabel);
+                itemWalletAddress->setToolTip(COLUMN_LABEL, sWalletLabel);
+
+                // address
+                itemWalletAddress->setText(COLUMN_ADDRESS, sWalletAddress);
+                itemWalletAddress->setToolTip(COLUMN_ADDRESS, sWalletAddress);
+            }
+
+           /* if (fHideAdditional) {
+                m_coin_control.UnSelectAsset(output);
+                continue;
+            }*/
+            
+            nSum += nAmount;
+            nChildren++;
+
+            CAssetControlWidgetItem* itemOutput;
+            if (treeMode) {
+                itemOutput = new CAssetControlWidgetItem(itemWalletAddress);
+            } else {
+                itemOutput = new CAssetControlWidgetItem(ui->treeWidget);
+            }
+            itemOutput->setFlags(flgCheckbox);
+            itemOutput->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+
+            // address
+            CTxDestination outputAddress;
+            QString sAddress = "";
+            if (ExtractDestination(out.txout.scriptPubKey, outputAddress)) {
+                sAddress = QString::fromStdString(EncodeDestination(outputAddress));
+
+                // if listMode or change => show raptoreum address. In tree mode, address is not shown again for direct wallet address outputs
+                if (!treeMode || (!(sAddress == sWalletAddress))) {
+                    itemOutput->setText(COLUMN_ADDRESS, sAddress);
+                }
+
+                itemOutput->setToolTip(COLUMN_ADDRESS, sAddress);
+            }
+
+            // label
+            if (!(sAddress == sWalletAddress)) { //change
+                // tooltip from where the change comes from
+                itemOutput->setToolTip(COLUMN_LABEL, tr("change from %1 (%2)").arg(sWalletLabel).arg(sWalletAddress));
+                itemOutput->setText(COLUMN_LABEL, tr("(change)"));
+            } else if (!treeMode) {
+                QString sLabel = model->getAddressTableModel()->labelForAddress(sAddress);
+                if (sLabel.isEmpty()) {
+                    sLabel = tr("(no label)");
+                }
+                itemOutput->setText(COLUMN_LABEL, sLabel);
+            }
+            //asset id
+            itemOutput->setText(COLUMN_NAME, assetname);
+            itemOutput->setToolTip(COLUMN_NAME, assetname);
+            //itemOutput->setData(COLUMN_NAME, TxHashRole, BitcoinUnits::name(model->getOptionsModel()->getDisplayUnit()));
+            // amount
+            itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nAmount));
+            itemOutput->setToolTip(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nAmount));
+            itemOutput->setData(COLUMN_AMOUNT, Qt::UserRole, QVariant((qlonglong)nAmount)); // padding so that sorting works correctly
+
+            // date
+            itemOutput->setText(COLUMN_DATE, GUIUtil::dateTimeStr(out.time));
+            itemOutput->setToolTip(COLUMN_DATE, GUIUtil::dateTimeStr(out.time));
+            itemOutput->setData(COLUMN_DATE, Qt::UserRole, QVariant((qlonglong)out.time));
+
+            // confirmations
+            itemOutput->setText(COLUMN_CONFIRMATIONS, QString::number(out.depth_in_main_chain));
+            itemOutput->setData(COLUMN_CONFIRMATIONS, Qt::UserRole, QVariant((qlonglong)out.depth_in_main_chain));
+
+            // transaction hash
+            itemOutput->setData(COLUMN_ADDRESS, TxHashRole, QString::fromStdString(output.hash.GetHex()));
+
+            // vout index
+            itemOutput->setData(COLUMN_ADDRESS, VOutRole, output.n);
+
+            // disable locked Assets
+            if (model->wallet().isLockedCoin(output)) {
+                m_coin_control.UnSelectAsset(output); // just to be sure
+                itemOutput->setDisabled(true);
+                itemOutput->setIcon(COLUMN_CHECKBOX, GUIUtil::getIcon("lock_closed", GUIUtil::ThemedColor::RED));
+            }
+
+            // set checkbox
+            if (m_coin_control.IsAssetSelected(output)) {
+                itemOutput->setCheckState(COLUMN_CHECKBOX, Qt::Checked);
+            }
+        }
+
+        // amount
+        if (treeMode)
+        {
+            itemWalletAddress->setText(COLUMN_CHECKBOX, "(" + QString::number(nChildren) + ")");
+            itemWalletAddress->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
+            itemWalletAddress->setToolTip(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
+            itemWalletAddress->setData(COLUMN_AMOUNT, Qt::UserRole, QVariant((qlonglong)nSum));
+        }
+    }
+       
+    // expand all partially selected and hide the empty
+    if (treeMode)
+    {
+        for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
+            QTreeWidgetItem* topLevelItem = ui->treeWidget->topLevelItem(i);
+            topLevelItem->setHidden(topLevelItem->childCount() == 0);
+            if (topLevelItem->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked)
+                topLevelItem->setExpanded(true);
+        }
+    }
+
+    // sort view
+    sortView(sortColumn, sortOrder);
+    ui->treeWidget->setEnabled(true);
+}
+
+void AssetControlDialog::onAssetSelected(QString name)
+{
+    AssetControlDialog::updateLabels(m_coin_control,model, this);
+    updateView();
+}
+
+void AssetControlDialog::updateAssetList()
+{
+    // Get the assets list
+    std::vector<std::string> assets = model->wallet().listMyAssets();
+
+    QStringList list;
+    //list << BitcoinUnits::name(model->getOptionsModel()->getDisplayUnit());
+    for (auto assetId : assets) {
+        CAssetMetaData assetdata;
+        if(passetsCache->GetAssetMetaData(assetId, assetdata)){
+            list << QString::fromStdString(assetdata.Name);
+        }
+    }
+
+    stringModel->setStringList(list);
+    ui->assetList->setCurrentIndex(0);
+    ui->assetList->activated(0);
+}

--- a/src/qt/assetcontroldialog.cpp
+++ b/src/qt/assetcontroldialog.cpp
@@ -448,7 +448,7 @@ void AssetControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         else {
             m_coin_control.SelectAsset(outpt);
         }
-        
+
         // selection changed -> update labels
         if (ui->treeWidget->isEnabled()) // do not update on every click for (un)select all
             AssetControlDialog::updateLabels(m_coin_control, model, this);
@@ -525,11 +525,11 @@ void AssetControlDialog::updateLabels(CCoinControl& m_coin_control, WalletModel 
 
         // Amount
         nAmount += out.txout.nValue;
-        
+
         CAssetTransfer assetTransfer;
         if(GetTransferAsset(out.txout.scriptPubKey, assetTransfer)){
             nAssetAmount += assetTransfer.nAmount;
-            AssetId = assetTransfer.AssetId;
+            AssetId = assetTransfer.assetId;
         }
 
         // Bytes
@@ -594,16 +594,16 @@ void AssetControlDialog::updateLabels(CCoinControl& m_coin_control, WalletModel 
     dialog->findChild<QLabel *>("labelAssetControlChange")       ->setEnabled(nPayAmount > 0);
 
     // stats
-    l1->setText(QString::number(nQuantity)); 
+    l1->setText(QString::number(nQuantity));
     // Quantity
-    CAssetMetaData assetdata;
-    if(passetsCache->GetAssetMetaData(AssetId, assetdata))
-    l2->setText(BitcoinUnits::formatWithCustomName(QString::fromStdString(assetdata.Name), nAssetAmount));        // Amount
+    CAssetMetaData assetData;
+    if(passetsCache->GetAssetMetaData(AssetId, assetData))
+    l2->setText(BitcoinUnits::formatWithCustomName(QString::fromStdString(assetData.name), nAssetAmount));        // Amount
     l3->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nPayFee));        // Fee
     l4->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAfterFee));      // After Fee
     l5->setText(((nBytes > 0) ? ASYMP_UTF8 : "") + QString::number(nBytes));        // Bytes
-    l7->setText(fDust ? tr("yes") : tr("no")); 
-    l8->setText(BitcoinUnits::formatWithCustomName(QString::fromStdString(assetdata.Name), nChange));        // Amount
+    l7->setText(fDust ? tr("yes") : tr("no"));
+    l8->setText(BitcoinUnits::formatWithCustomName(QString::fromStdString(assetData.name), nChange));        // Amount
     if (nPayFee > 0)
     {
         l3->setText(ASYMP_UTF8 + l3->text());
@@ -674,7 +674,7 @@ void AssetControlDialog::updateView()
     std::map<CTxDestination, std::vector<std::tuple<COutPoint, interfaces::WalletTxOut>>> mapassets;
 
     mapassets = model->wallet().listAssets();
-     
+
     for (const auto& Assets : mapassets) {
         CAssetControlWidgetItem *itemWalletAddress = new CAssetControlWidgetItem();
         itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
@@ -683,7 +683,7 @@ void AssetControlDialog::updateView()
         QString assetname = "";
         if (sWalletLabel.isEmpty())
             sWalletLabel = tr("(no label)");
-        
+
         bool hastree = false;
 
         CAmount nSum = 0;
@@ -698,11 +698,11 @@ void AssetControlDialog::updateView()
             std::string uniqueId = "";
             if(GetTransferAsset(out.txout.scriptPubKey, assetTransfer)){
                 nAmount = assetTransfer.nAmount;
-                CAssetMetaData assetdata;
-                if(passetsCache->GetAssetMetaData(assetTransfer.AssetId, assetdata)){
-                    if (assetdata.isunique)
+                CAssetMetaData assetData;
+                if(passetsCache->GetAssetMetaData(assetTransfer.assetId, assetData)){
+                    if (assetData.isUnique)
                         uniqueId += " ["+to_string(assetTransfer.uniqueId)+"]";
-                    assetname = QString::fromStdString(assetdata.Name);
+                    assetname = QString::fromStdString(assetData.name);
                 }
             }
 
@@ -736,7 +736,7 @@ void AssetControlDialog::updateView()
                 m_coin_control.UnSelectAsset(output);
                 continue;
             }*/
-            
+
             nSum += nAmount;
             nChildren++;
 
@@ -821,7 +821,7 @@ void AssetControlDialog::updateView()
             itemWalletAddress->setData(COLUMN_AMOUNT, Qt::UserRole, QVariant((qlonglong)nSum));
         }
     }
-       
+
     // expand all partially selected and hide the empty
     if (treeMode)
     {
@@ -852,9 +852,9 @@ void AssetControlDialog::updateAssetList()
     QStringList list;
     //list << BitcoinUnits::name(model->getOptionsModel()->getDisplayUnit());
     for (auto assetId : assets) {
-        CAssetMetaData assetdata;
-        if(passetsCache->GetAssetMetaData(assetId, assetdata)){
-            list << QString::fromStdString(assetdata.Name);
+        CAssetMetaData assetData;
+        if(passetsCache->GetAssetMetaData(assetId, assetData)){
+            list << QString::fromStdString(assetData.name);
         }
     }
 

--- a/src/qt/assetcontroldialog.h
+++ b/src/qt/assetcontroldialog.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2011-2015 The BitAsset Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_ASSETCONTROLDIALOG_H
+#define BITCOIN_QT_ASSETCONTROLDIALOG_H
+
+#include <amount.h>
+
+#include <QAbstractButton>
+#include <QAction>
+#include <QDialog>
+#include <QList>
+#include <QMenu>
+#include <QPoint>
+#include <QString>
+#include <QTreeWidgetItem>
+
+class WalletModel;
+
+class CCoinControl;
+
+class QStringListModel;
+class QSortFilterProxyModel;
+class QCompleter;
+
+namespace Ui {
+    class AssetControlDialog;
+}
+
+#define ASYMP_UTF8 "\xE2\x89\x88"
+
+class CAssetControlWidgetItem : public QTreeWidgetItem
+{
+public:
+    explicit CAssetControlWidgetItem(QTreeWidget *parent, int type = Type) : QTreeWidgetItem(parent, type) {}
+    explicit CAssetControlWidgetItem(int type = Type) : QTreeWidgetItem(type) {}
+    explicit CAssetControlWidgetItem(QTreeWidgetItem *parent, int type = Type) : QTreeWidgetItem(parent, type) {}
+
+    bool operator<(const QTreeWidgetItem &other) const;
+};
+
+
+class AssetControlDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit AssetControlDialog(CCoinControl& Asset_control, WalletModel* model, QWidget *parent = nullptr);
+    ~AssetControlDialog();
+
+    // static because also called from sendAssetsdialog
+    static void updateLabels(CCoinControl& m_coin_control, WalletModel*, QDialog*);
+
+    //update the list of assets
+    void updateAssetList();
+
+    static QList<CAmount> payAmounts;
+    static bool fSubtractFeeFromAmount;
+
+    QStringListModel* stringModel;
+    QSortFilterProxyModel* proxy;
+    QCompleter* completer;
+
+private:
+    Ui::AssetControlDialog *ui;
+    CCoinControl& m_coin_control;
+    WalletModel *model;
+    int sortColumn;
+    Qt::SortOrder sortOrder;
+
+    QMenu *contextMenu;
+    QTreeWidgetItem *contextMenuItem;
+    QAction *copyTransactionHashAction;
+    QAction *lockAction;
+    QAction *unlockAction;
+
+    bool fHideAdditional{true};
+
+    void sortView(int, Qt::SortOrder);
+    void updateView();
+
+    enum
+    {
+        COLUMN_CHECKBOX = 0,
+        COLUMN_NAME,
+        COLUMN_AMOUNT,
+        COLUMN_LABEL,
+        COLUMN_ADDRESS,
+        COLUMN_DATE,
+        COLUMN_CONFIRMATIONS,
+    };
+
+    enum
+    {
+        TxHashRole = Qt::UserRole,
+        VOutRole
+    };
+
+    friend class CAssetControlWidgetItem;
+
+private Q_SLOTS:
+    void showMenu(const QPoint &);
+    void copyAmount();
+    void copyLabel();
+    void copyAddress();
+    void copyTransactionHash();
+    void lockAsset();
+    void unlockAsset();
+    void clipboardQuantity();
+    void clipboardAmount();
+    void clipboardFee();
+    void clipboardAfterFee();
+    void clipboardBytes();
+    void clipboardLowOutput();
+    void clipboardChange();
+    void radioTreeMode(bool);
+    void radioListMode(bool);
+    void viewItemChanged(QTreeWidgetItem*, int);
+    void headerSectionClicked(int);
+    void buttonBoxClicked(QAbstractButton*);
+    void buttonSelectAllClicked();
+    void buttonToggleLockClicked();
+    void updateLabelLocked();
+    void onAssetSelected(QString name);
+
+};
+
+#endif // BITCOIN_QT_ASSETCONTROLDIALOG_H

--- a/src/qt/assetcontroltreewidget.cpp
+++ b/src/qt/assetcontroltreewidget.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2011-2015 The BitAsset Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/assetcontroltreewidget.h>
+#include <qt/assetcontroldialog.h>
+
+AssetControlTreeWidget::AssetControlTreeWidget(QWidget *parent) :
+    QTreeWidget(parent)
+{
+
+}
+
+void AssetControlTreeWidget::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Space) // press spacebar -> select checkbox
+    {
+        event->ignore();
+        if (this->currentItem()) {
+            int COLUMN_CHECKBOX = 0;
+            this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
+        }
+    }
+    else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
+    {
+        event->ignore();
+       // AssetControlDialog *AssetControlDialog = static_cast<AssetControlDialog*>(this->parentWidget());
+       // AssetControlDialog->done(QDialog::Accepted);
+    }
+    else
+    {
+        this->QTreeWidget::keyPressEvent(event);
+    }
+}

--- a/src/qt/assetcontroltreewidget.h
+++ b/src/qt/assetcontroltreewidget.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2011-2014 The BitAsset Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITAsset_QT_AssetCONTROLTREEWIDGET_H
+#define BITAsset_QT_AssetCONTROLTREEWIDGET_H
+
+#include <QKeyEvent>
+#include <QTreeWidget>
+
+class AssetControlTreeWidget : public QTreeWidget
+{
+    Q_OBJECT
+
+public:
+    explicit AssetControlTreeWidget(QWidget *parent = 0);
+
+protected:
+    virtual void keyPressEvent(QKeyEvent *event) override;
+};
+
+#endif // BITAsset_QT_AssetCONTROLTREEWIDGET_H

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -12,16 +12,22 @@
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLineEdit>
+#include <iostream>//remove later
 
 /**
  * Parse a string into a number of base monetary units and
  * return validity.
  * @note Must return 0 if !valid.
  */
-static CAmount parse(const QString &text, int nUnit, bool *valid_out=0)
+static CAmount parse(const QString &text, int nUnit, int nAssetUnit, bool *valid_out=0)
 {
     CAmount val = 0;
-    bool valid = BitcoinUnits::parse(nUnit, text, &val);
+    bool valid = false;
+
+    if (nAssetUnit >= 0)
+        valid = BitcoinUnits::assetParse(nAssetUnit, text, &val);
+    else
+         valid = BitcoinUnits::parse(nUnit, text, &val);
     if(valid)
     {
         if(val < 0 || val > BitcoinUnits::maxMoney())
@@ -38,17 +44,19 @@ class AmountValidator : public QValidator
 {
     Q_OBJECT
     int currentUnit;
+    int assetUnit;
 public:
     explicit AmountValidator(QObject *parent) :
         QValidator(parent),
-        currentUnit(BitcoinUnits::RTM) {}
+        currentUnit(BitcoinUnits::RTM),
+        assetUnit(-1) {}
 
     State validate(QString &input, int &pos) const
     {
         if(input.isEmpty())
             return QValidator::Intermediate;
         bool valid = false;
-        parse(input, currentUnit, &valid);
+        parse(input, currentUnit, assetUnit, &valid);
         /* Make sure we return Intermediate so that fixup() is called on defocus */
         return valid ? QValidator::Intermediate : QValidator::Invalid;
     }
@@ -56,6 +64,11 @@ public:
     void updateUnit(int nUnit)
     {
         currentUnit = nUnit;
+    }
+
+    void updateAssetUnit(int nUnit)
+    {
+        assetUnit = nUnit;
     }
 };
 
@@ -69,7 +82,8 @@ class AmountLineEdit: public QLineEdit
 public:
     explicit AmountLineEdit(QWidget *parent):
         QLineEdit(parent),
-        currentUnit(BitcoinUnits::RTM)
+        currentUnit(BitcoinUnits::RTM),
+        assetUnit(-1)
     {
         setAlignment(Qt::AlignLeft);
         amountValidator = new AmountValidator(this);
@@ -80,21 +94,21 @@ public:
     void fixup(const QString &input)
     {
         bool valid = false;
-        CAmount val = parse(input, currentUnit, &valid);
+        CAmount val = parse(input, currentUnit, assetUnit, &valid);
         if(valid)
         {
-            setText(BitcoinUnits::format(currentUnit, val, false, BitcoinUnits::separatorAlways));
+            setText(BitcoinUnits::format(currentUnit, val, false, BitcoinUnits::separatorAlways, assetUnit));
         }
     }
 
     CAmount value(bool *valid_out=0) const
     {
-        return parse(text(), currentUnit, valid_out);
+        return parse(text(), currentUnit, assetUnit, valid_out);
     }
 
     void setValue(const CAmount& value)
     {
-        setText(BitcoinUnits::format(currentUnit, value, false, BitcoinUnits::separatorAlways));
+        setText(BitcoinUnits::format(currentUnit, value, false, BitcoinUnits::separatorAlways, assetUnit));
         Q_EMIT valueChanged();
     }
 
@@ -106,6 +120,23 @@ public:
         currentUnit = unit;
         amountValidator->updateUnit(unit);
 
+        if(valid)
+            setValue(val);
+        else
+            clear();
+    }
+
+    void setAssetUnit(int unit)
+    {
+        if (unit > MAX_ASSET_UNITS)
+            unit = MAX_ASSET_UNITS;
+        
+        assetUnit = unit;
+        amountValidator->updateAssetUnit(unit);
+
+        bool valid = false;
+        CAmount val = value(&valid);
+        
         if(valid)
             setValue(val);
         else
@@ -125,6 +156,7 @@ public:
 
 private:
     int currentUnit;
+    int assetUnit;
 
 protected:
     bool event(QEvent *event)
@@ -158,7 +190,8 @@ Q_SIGNALS:
 
 BitcoinAmountField::BitcoinAmountField(QWidget *parent) :
     QWidget(parent),
-    amount(0)
+    amount(0),
+    assetUnit(-1)
 {
     amount = new AmountLineEdit(this);
     amount->setLocale(QLocale::c());
@@ -225,7 +258,10 @@ QWidget *BitcoinAmountField::setupTabChain(QWidget *prev)
 
 CAmount BitcoinAmountField::value(bool *valid_out) const
 {
-    return amount->value(valid_out);
+    if (assetUnit >= 0)
+        return amount->value(valid_out) * BitcoinUnits::factorAsset(8 - assetUnit);
+    else
+        return amount->value(valid_out);
 }
 
 void BitcoinAmountField::setValue(const CAmount& value)
@@ -254,4 +290,10 @@ void BitcoinAmountField::unitChanged(int idx)
 void BitcoinAmountField::setDisplayUnit(int newUnit)
 {
     unitChanged(newUnit);
+}
+
+void BitcoinAmountField::setAssetsUnit(int unit)
+{
+    assetUnit = unit;
+    amount->setAssetUnit(assetUnit);
 }

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -44,6 +44,9 @@ public:
     /** Change unit used to display amount. */
     void setDisplayUnit(int unit);
 
+    /** Change assets unit used to display amount. */
+    void setAssetsUnit(int unit);
+
     /** Make field empty and ready for new input. */
     void clear();
 
@@ -65,6 +68,7 @@ protected:
 private:
     AmountLineEdit *amount;
     BitcoinUnits *units;
+    int assetUnit;
 
     void unitChanged(int idx);
 };

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -94,8 +94,10 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     smartnodeButton(0),
     quitAction(0),
     sendCoinsButton(0),
+    sendAssetsButton(0),
     coinJoinCoinsButton(0),
     sendCoinsMenuAction(0),
+    sendAssetsMenuAction(0),
     coinJoinCoinsMenuAction(0),
     usedSendingAddressesAction(0),
     usedReceivingAddressesAction(0),
@@ -398,10 +400,15 @@ void BitcoinGUI::createActions()
     receiveCoinsMenuAction->setStatusTip(tr("Request payments (generates QR codes and raptoreum: URIs)"));
     receiveCoinsMenuAction->setToolTip(receiveCoinsMenuAction->statusTip());
 
+    sendAssetsMenuAction = new QAction(tr("&Send Asset"), this);
+    sendAssetsMenuAction->setStatusTip(tr("Send assets to a Raptoreum address"));
+    sendAssetsMenuAction->setToolTip(sendAssetsMenuAction->statusTip());
+
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
     // can be triggered from the tray menu, and need to show the GUI to be useful.
     connect(sendCoinsMenuAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(sendCoinsMenuAction, SIGNAL(triggered()), this, SLOT(gotoSendCoinsPage()));
+    connect(sendAssetsMenuAction, SIGNAL(triggered()), this, SLOT(gotoSendAssetsPage()));
     connect(coinJoinCoinsMenuAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(coinJoinCoinsMenuAction, SIGNAL(triggered()), this, SLOT(gotoCoinJoinCoinsPage()));
     connect(receiveCoinsMenuAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
@@ -635,8 +642,15 @@ void BitcoinGUI::createToolBars()
             connect(smartnodeButton, SIGNAL(clicked()), this, SLOT(gotoSmartnodePage()));
         }
 
+        sendAssetsButton = new QToolButton(this);
+        sendAssetsButton->setText(sendAssetsMenuAction->text());
+        sendAssetsButton->setStatusTip(sendAssetsMenuAction->statusTip());
+        tabGroup->addButton(sendAssetsButton);
+
         connect(overviewButton, SIGNAL(clicked()), this, SLOT(gotoOverviewPage()));
         connect(sendCoinsButton, SIGNAL(clicked()), this, SLOT(gotoSendCoinsPage()));
+        connect(sendAssetsButton, SIGNAL(clicked()), this, SLOT(gotoSendAssetsPage()));
+        connect(sendAssetsButton, SIGNAL(clicked()), this, SLOT(gotoSendAssetsPage()));
         connect(coinJoinCoinsButton, SIGNAL(clicked()), this, SLOT(gotoCoinJoinCoinsPage()));
         connect(receiveCoinsButton, SIGNAL(clicked()), this, SLOT(gotoReceiveCoinsPage()));
         connect(historyButton, SIGNAL(clicked()), this, SLOT(gotoHistoryPage()));
@@ -854,6 +868,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
         coinJoinCoinsButton->setEnabled(enabled && clientModel->coinJoinOptions().isEnabled());
         receiveCoinsButton->setEnabled(enabled);
         historyButton->setEnabled(enabled);
+        sendAssetsButton->setEnabled(enabled);
         if (smartnodeButton != nullptr) {
             QSettings settings;
             smartnodeButton->setEnabled(enabled && settings.value("fShowSmartnodesTab").toBool());
@@ -867,6 +882,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
 #else
     coinJoinCoinsMenuAction->setEnabled(enabled);
 #endif // ENABLE_WALLET
+    sendAssetsMenuAction->setEnabled(enabled);
     receiveCoinsMenuAction->setEnabled(enabled);
 
     encryptWalletAction->setEnabled(enabled);
@@ -896,6 +912,7 @@ void BitcoinGUI::createIconMenu(QMenu *pmenu)
     pmenu->addSeparator();
     pmenu->addAction(sendCoinsMenuAction);
     pmenu->addAction(coinJoinCoinsMenuAction);
+    pmenu->addAction(sendAssetsMenuAction);
     pmenu->addAction(receiveCoinsMenuAction);
     pmenu->addSeparator();
     pmenu->addAction(signMessageAction);
@@ -1063,6 +1080,12 @@ void BitcoinGUI::gotoSendCoinsPage(QString addr)
 {
     sendCoinsButton->setChecked(true);
     if (walletFrame) walletFrame->gotoSendCoinsPage(addr);
+}
+
+void BitcoinGUI::gotoSendAssetsPage(QString addr)
+{
+    sendAssetsButton->setChecked(true);
+    if (walletFrame) walletFrame->gotoSendAssetsPage(addr);
 }
 
 void BitcoinGUI::gotoCoinJoinCoinsPage(QString addr)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -110,6 +110,7 @@ private:
     QToolBar *appToolBar;
     QToolButton *overviewButton;
     QToolButton *sendCoinsButton;
+    QToolButton *sendAssetsButton;
     QToolButton *coinJoinCoinsButton;
     QToolButton *receiveCoinsButton;
     QToolButton *historyButton;
@@ -117,6 +118,7 @@ private:
     QAction* appToolBarLogoAction;
     QAction *quitAction;
     QAction *sendCoinsMenuAction;
+    QAction *sendAssetsMenuAction;
     QAction *coinJoinCoinsMenuAction;
     QAction *usedSendingAddressesAction;
     QAction *usedReceivingAddressesAction;
@@ -281,6 +283,8 @@ private Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    /** Switch to send assets page */
+    void gotoSendAssetsPage(QString addr = "");
     /** Switch to CoinJoin coins page */
     void gotoCoinJoinCoinsPage(QString addr = "");
 

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -12,6 +12,10 @@
 #include <QAbstractListModel>
 #include <QString>
 
+// Asset units
+#define MAX_ASSET_UNITS 8
+#define MIN_ASSET_UNITS 0
+
 // U+2009 THIN SPACE = UTF-8 E2 80 89
 #define REAL_THIN_SP_CP 0x2009
 #define REAL_THIN_SP_UTF8 "\xE2\x80\x89"
@@ -85,20 +89,28 @@ public:
     static QString description(int unit);
     //! Number of Satoshis (1e-8) per unit
     static qint64 factor(int unit);
+    //! Number of Satoshis (1e-8) per unit for assets
+    static qint64 factorAsset(int unit);
     //! Number of decimals left
     static int decimals(int unit);
     //! Format as string
-    static QString format(int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard);
+    static QString format(int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard, const int nAssetUnit = MIN_ASSET_UNITS - 1);
     static QString simpleFormat(int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard);
     //! Format as string (with unit)
     static QString formatWithUnit(int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard);
+    //! Format as string (with custom name)
+    static QString formatWithCustomName(QString customName, const CAmount& amount, int unit = MAX_ASSET_UNITS, bool plussign=false, SeparatorStyle separators=separatorStandard);
     //! Format as HTML string (with unit)
     static QString formatHtmlWithUnit(int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard);
+    //! Format as HTML string (with custom name)
+    static QString formatHtmlWithCustomName(QString customName, QString uniqueId, int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard);
     //! Format as string (with unit) but floor value up to "digits" settings
     static QString floorWithUnit(int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard);
     static QString floorHtmlWithUnit(int unit, const CAmount& amount, bool plussign=false, SeparatorStyle separators=separatorStandard);
     //! Parse string to coin amount
     static bool parse(int unit, const QString &value, CAmount *val_out);
+    //! Parse string to asset amount
+    static bool assetParse(int assetUnit, const QString &value, CAmount *val_out);
     //! Gets title for amount column including current display unit if optionsModel reference available */
     static QString getAmountColumnTitle(int unit);
     ///@}

--- a/src/qt/forms/assetcontroldialog.ui
+++ b/src/qt/forms/assetcontroldialog.ui
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AssetControlDialog</class>
+ <widget class="QDialog" name="AssetControlDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>954</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Asset Selection</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutTop" stretch="0,0,0,0">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>10</number>
+     </property>
+     <item>
+      <layout class="QFormLayout" name="formLayoutAssetControl1">
+       <property name="horizontalSpacing">
+        <number>10</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>10</number>
+       </property>
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelAssetControlQuantityText">
+         <property name="text">
+          <string>Quantity:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelAssetControlQuantity">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="text">
+          <string notr="true">0</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelAssetControlBytesText">
+         <property name="text">
+          <string>Bytes:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="labelAssetControlBytes">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="text">
+          <string notr="true">0</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QFormLayout" name="formLayoutAssetControl2">
+       <property name="horizontalSpacing">
+        <number>10</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>10</number>
+       </property>
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelAssetControlAmountText">
+         <property name="text">
+          <string>Amount:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelAssetControlAmount">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="text">
+          <string notr="true">0.00 RAPTOREUM</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelAssetControlLowOutputText">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Dust:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="labelAssetControlLowOutput">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="text">
+          <string notr="true">no</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QFormLayout" name="formLayoutAssetControl3">
+       <property name="horizontalSpacing">
+        <number>10</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>10</number>
+       </property>
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelAssetControlFeeText">
+         <property name="text">
+          <string>Fee:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelAssetControlFee">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="text">
+          <string notr="true">0.00 RAPTOREUM</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QFormLayout" name="formLayoutAssetControl4">
+       <property name="horizontalSpacing">
+        <number>10</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>10</number>
+       </property>
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelAssetControlAfterFeeText">
+         <property name="text">
+          <string>After Fee:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelAssetControlAfterFee">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="text">
+          <string notr="true">0.00 RAPTOREUM</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelAssetControlChangeText">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Change:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="labelAssetControlChange">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="text">
+          <string notr="true">0.00 RAPTOREUM</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>40</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0">
+        <property name="spacing">
+         <number>14</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="pushButtonSelectAll">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>(un)select all</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioTreeMode">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Tree mode</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioListMode">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>List mode</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelLocked">
+          <property name="text">
+           <string>(1 locked)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="assetList">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>300</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="AssetControlTreeWidget" name="treeWidget">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="columnCount">
+      <number>7</number>
+     </property>
+     <attribute name="headerShowSortIndicator" stdset="0">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="headerStretchLastSection">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string/>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Asset</string>
+      </property>
+      <property name="toolTip">
+       <string>Confirmed</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Amount</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Received with label</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Received with address</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Date</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Confirmations</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AssetControlTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>qt/assetcontroltreewidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/sendassetsdialog.ui
+++ b/src/qt/forms/sendassetsdialog.ui
@@ -1,0 +1,1192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SendAssetsDialog</class>
+ <widget class="QDialog" name="SendAssetsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>850</width>
+    <height>526</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Send Assets</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,0">
+   <property name="bottomMargin">
+    <number>8</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frameAssetControl">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayoutAssetControl2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayoutAssetControl" stretch="0,0,0,0,1">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>10</number>
+        </property>
+        <property name="topMargin">
+         <number>10</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutAssetControl1">
+          <property name="bottomMargin">
+           <number>15</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="labelAssetControlFeatures">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Asset Control Features</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutAssetControl2" stretch="0,0,0,0">
+          <property name="spacing">
+           <number>8</number>
+          </property>
+          <property name="bottomMargin">
+           <number>10</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="pushButtonAssetControl">
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
+            <property name="text">
+             <string>Inputs...</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelAssetControlAutomaticallySelected">
+            <property name="text">
+             <string>automatically selected</string>
+            </property>
+            <property name="margin">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelAssetControlInsuffFunds">
+            <property name="text">
+             <string>Insufficient funds!</string>
+            </property>
+            <property name="margin">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacerAssetControl">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>1</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QWidget" name="widgetAssetControl" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayoutAssetControl5">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayoutAssetControl3" stretch="0,0,0,1">
+             <property name="spacing">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>10</number>
+             </property>
+             <item>
+              <layout class="QFormLayout" name="formLayoutAssetControl1">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>10</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelAssetControlQuantityText">
+                 <property name="text">
+                  <string>Quantity:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelAssetControlQuantity">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="labelAssetControlBytesText">
+                 <property name="text">
+                  <string>Bytes:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="labelAssetControlBytes">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QFormLayout" name="formLayoutAssetControl2">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelAssetControlAmountText">
+                 <property name="text">
+                  <string>Amount:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelAssetControlAmount">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RAPTOREUM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="labelAssetControlLowOutputText">
+                 <property name="text">
+                  <string>Dust:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="labelAssetControlLowOutput">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">no</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QFormLayout" name="formLayoutAssetControl3">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelAssetControlFeeText">
+                 <property name="text">
+                  <string>Fee:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelAssetControlFee">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RAPTOREUM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QFormLayout" name="formLayoutAssetControl4">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelAssetControlAfterFeeText">
+                 <property name="text">
+                  <string>After Fee:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelAssetControlAfterFee">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RAPTOREUM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="labelAssetControlChangeText">
+                 <property name="text">
+                  <string>Change:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="labelAssetControlChange">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RAPTOREUM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutAssetControl4" stretch="0,0,0">
+          <property name="spacing">
+           <number>12</number>
+          </property>
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <property name="topMargin">
+           <number>5</number>
+          </property>
+          <property name="rightMargin">
+           <number>5</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="checkBoxAssetControlChange">
+            <property name="toolTip">
+             <string>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</string>
+            </property>
+            <property name="text">
+             <string>Custom change address</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QValidatedLineEdit" name="lineEditAssetControlChange">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelAssetControlChangeLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="margin">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacerAssetControl">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>800</width>
+            <height>1</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>830</width>
+        <height>104</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout" name="entries">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frameFee">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayoutFee1">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayoutFee2" stretch="0,0,0">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>10</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutFee1">
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayoutFee7">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <spacer name="verticalSpacerSmartFee">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>1</width>
+                <height>4</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayoutSmartFee">
+              <property name="spacing">
+               <number>10</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="labelFeeHeadline">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Transaction Fee:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelFeeMinimized">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="buttonChooseFee">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>1</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="fallbackFeeWarningLabel">
+              <property name="toolTip">
+               <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</string>
+              </property>
+              <property name="text">
+               <string>Note: Not enough data for fee estimation, using the fallback fee instead.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>1</width>
+                <height>1</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>1</width>
+              <height>1</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonMinimizeFee">
+            <property name="toolTip">
+             <string>collapse fee-settings</string>
+            </property>
+            <property name="text">
+             <string>Hide</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QFrame" name="frameFeeSelection">
+          <layout class="QVBoxLayout" name="verticalLayoutFee12">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QGridLayout" name="gridLayoutFee">
+             <property name="topMargin">
+              <number>10</number>
+             </property>
+             <property name="bottomMargin">
+              <number>4</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>10</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>4</number>
+             </property>
+             <item row="1" column="1">
+              <layout class="QVBoxLayout" name="verticalLayoutFee8">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee13" stretch="0,0,1">
+                 <item>
+                  <widget class="QLabel" name="labelCustomPerKilobyte">
+                   <property name="toolTip">
+                    <string>If the custom fee is set to 1000 ruffs and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 ruffs in fee,&lt;br /&gt;while &quot;at least&quot; pays 1000 ruffs. For transactions bigger than a kilobyte both pay by kilobyte.</string>
+                   </property>
+                   <property name="text">
+                    <string>per kilobyte</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="BitcoinAmountField" name="customFee"/>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_6">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee8">
+                 <item>
+                  <widget class="QCheckBox" name="checkBoxMinimumFee">
+                   <property name="toolTip">
+                    <string>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks.&lt;br /&gt;But be aware that this can end up in a never confirming transaction once there is more demand for raptoreum transactions than the network can process.</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelMinFeeWarning">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="toolTip">
+                    <string>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks.&lt;br /&gt;But be aware that this can end up in a never confirming transaction once there is more demand for raptoreum transactions than the network can process.</string>
+                   </property>
+                   <property name="text">
+                    <string>(read the tooltip)</string>
+                   </property>
+                   <property name="margin">
+                    <number>5</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_2">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="0">
+              <layout class="QVBoxLayout" name="verticalLayoutFee4" stretch="0,1">
+               <property name="topMargin">
+                <number>20</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
+               <item>
+                <widget class="QRadioButton" name="radioSmartFee">
+                 <property name="text">
+                  <string>Recommended:</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">groupFee</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item row="1" column="0">
+              <layout class="QVBoxLayout" name="verticalLayoutFee9" stretch="0,1">
+               <property name="topMargin">
+                <number>30</number>
+               </property>
+               <item>
+                <widget class="QRadioButton" name="radioCustomFee">
+                 <property name="text">
+                  <string>Custom:</string>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">groupFee</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="1">
+              <layout class="QVBoxLayout" name="verticalLayoutFee3" stretch="0,0,1">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee12">
+                 <item>
+                  <widget class="QLabel" name="labelSmartFee">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="margin">
+                    <number>2</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelFeeEstimation">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelSmartFee2">
+                   <property name="text">
+                    <string>(Smart fee not initialized yet. This usually takes a few blocks...)</string>
+                   </property>
+                   <property name="margin">
+                    <number>2</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_5">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee9">
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayoutFee6">
+                   <item>
+                    <widget class="QLabel" name="labelSmartFee3">
+                     <property name="text">
+                      <string>Confirmation time target:</string>
+                     </property>
+                     <property name="margin">
+                      <number>2</number>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayoutFee5">
+                   <property name="rightMargin">
+                    <number>30</number>
+                   </property>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayoutConfTarget">
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QComboBox" name="confTargetSelector"/>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacerConfTarget">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacerFee">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>800</width>
+            <height>1</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="sendButton">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Confirm the send action</string>
+       </property>
+       <property name="text">
+        <string>S&amp;end</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+       <property name="default">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Clear all fields of the form.</string>
+       </property>
+       <property name="text">
+        <string>Clear &amp;All</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="addButton">
+       <property name="toolTip">
+        <string>Send to multiple recipients at once</string>
+       </property>
+       <property name="text">
+        <string>Add &amp;Recipient</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <property name="spacing">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="labelBalanceText">
+         <property name="text">
+          <string>Balance:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelBalance">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string notr="true">123.456 RAPTOREUM</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qt/qvalidatedlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QLineEdit</extends>
+   <header>qt/bitcoinamountfield.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../raptoreum.qrc"/>
+ </resources>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="groupFee"/>
+ </buttongroups>
+</ui>

--- a/src/qt/forms/sendassetsentry.ui
+++ b/src/qt/forms/sendassetsentry.ui
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SendAssetsEntry</class>
+ <widget class="QStackedWidget" name="SendAssetsEntry">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>729</width>
+    <height>192</height>
+   </rect>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::TabFocus</enum>
+  </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
+  <property name="currentIndex">
+   <number>0</number>
+  </property>
+  <widget class="QFrame" name="SendAssets">
+   <property name="toolTip">
+    <string>This is a normal payment.</string>
+   </property>
+   <property name="frameShape">
+    <enum>QFrame::NoFrame</enum>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <property name="topMargin">
+     <number>8</number>
+    </property>
+    <property name="bottomMargin">
+     <number>4</number>
+    </property>
+    <property name="horizontalSpacing">
+     <number>12</number>
+    </property>
+    <property name="verticalSpacing">
+     <number>8</number>
+    </property>
+    <item row="5" column="0">
+     <widget class="QLabel" name="amountLabel">
+      <property name="text">
+       <string>A&amp;mount:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>payAmount</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLineEdit" name="addAsLabel">
+      <property name="toolTip">
+       <string>Enter a label for this address to add it to the list of used addresses</string>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0">
+     <widget class="QLabel" name="maturityLb">
+      <property name="text">
+       <string>Maturity:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="labellLabel">
+      <property name="text">
+       <string>&amp;Label:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>addAsLabel</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <layout class="QHBoxLayout" name="payToLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QValidatedLineEdit" name="payTo">
+        <property name="toolTip">
+         <string>The Raptoreum address to send the payment to</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="addressBookButton">
+        <property name="toolTip">
+         <string>Choose previously used address</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>22</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="shortcut">
+         <string>Alt+A</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="pasteButton">
+        <property name="toolTip">
+         <string>Paste address from clipboard</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>22</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="shortcut">
+         <string>Alt+P</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="deleteButton">
+        <property name="toolTip">
+         <string>Remove this entry</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>22</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="9" column="0" colspan="2">
+     <widget class="Line" name="line">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayoutAmount" stretch="0,0,0,0,0">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="BitcoinAmountField" name="payAmount">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="uniqueIdList">
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>120</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="futureCb">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Enable/Disable future transaction</string>
+        </property>
+        <property name="text">
+         <string>future</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="useAvailableBalanceButton">
+        <property name="minimumSize">
+         <size>
+          <width>250</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Use available balance</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="payToLabel">
+      <property name="text">
+       <string>Pay &amp;To:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>payTo</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="Assetlabel">
+      <property name="text">
+       <string>Asset:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="1">
+     <layout class="QHBoxLayout" name="futureHorizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="maturity">
+        <property name="toolTip">
+         <string>Number of block confirmations for this output to be spendable if happen before timelock</string>
+        </property>
+        <property name="text">
+         <string notr="true">100</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="locktimeLb">
+        <property name="text">
+         <string>Lock time:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="locktime">
+        <property name="toolTip">
+         <string>Time in seconds for this output to be spendable if happen before maturity</string>
+        </property>
+        <property name="text">
+         <string notr="true">100</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="feeLb">
+        <property name="text">
+         <string>Fee:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="feeDisplay">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="0" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QComboBox" name="assetList">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>400</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="BalanceLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Balance:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="AssetBalance">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>123456 RTM</string>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qt/qvalidatedlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QLineEdit</extends>
+   <header>qt/bitcoinamountfield.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>payTo</tabstop>
+  <tabstop>addressBookButton</tabstop>
+  <tabstop>pasteButton</tabstop>
+  <tabstop>deleteButton</tabstop>
+  <tabstop>addAsLabel</tabstop>
+  <tabstop>payAmount</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../raptoreum.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1180,6 +1180,97 @@ QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::seperator {
 }
 
 /******************************************************
+AssetControlDialog
+******************************************************/
+
+QDialog#AssetControlDialog .QLabel#labelAssetControlQuantityText { /* Asset Control Quantity Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlQuantity { /* Asset Control Quantity */
+    min-height: 30px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlBytesText { /* Asset Control Bytes Label */
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlBytes { /* Asset Control Bytes */
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlAmountText { /* Asset Control Amount Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlAmount { /* Asset Control Amount */
+    min-height: 30px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlPriorityText { /* Asset Control Priority Label */
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlPriority { /* Asset Control Priority */
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlFeeText { /* Asset Control Fee Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlFee { /* Asset Control Fee */
+    min-height: 30px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlLowOutputText { /* Asset Control Low Output Label */
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlLowOutput { /* Asset Control Low Output */
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlAfterFeeText { /* Asset Control After Fee Label */
+    min-height: 30px;
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlAfterFee { /* Asset Control After Fee */
+    min-height: 30px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlChangeText { /* Asset Control Change Label */
+    padding-left: 15px;
+}
+QDialog#AssetControlDialog .QLabel#labelAssetControlChange { /* Asset Control Change */
+
+}
+
+QDialog#AssetControlDialog .QFrame#frame .QPushButton#pushButtonSelectAll { /* (un)select all button */
+}
+QDialog#AssetControlDialog .QFrame#frame .QPushButton#pushButtonToggleLock { /* Toggle lock state button */
+}
+
+QDialog#AssetControlDialog .QDialogButtonBox#buttonBox QPushButton { /* Asset Control 'OK' button */
+}
+
+QDialog#AssetControlDialog QHeaderView::section:first { /* Bug Fix: the number 1 displays in this table for some reason... */
+    color: #00000000;
+}
+
+QDialog#AssetControlDialog .AssetControlTreeWidget#treeWidget::item {
+    /*border-bottom: 1px solid red;*/
+    min-height: 25px;
+}
+QDialog#AssetControlDialog .AssetControlTreeWidget#treeWidget::item:hover {
+    background-color: #00000000;
+}
+QDialog#AssetControlDialog .AssetControlTreeWidget#treeWidget::item:selected { /* Asset Control Item (selected) */
+}
+QDialog#AssetControlDialog .AssetControlTreeWidget#treeWidget::item:checked { /* Asset Control Item (checked) */
+}
+
+QDialog#AssetControlDialog .AssetControlTreeWidget#treeWidget::branch:selected { /* Asset Control Branch Icon */
+    background-repeat: no-repeat;
+    background-position: center;
+}
+QDialog#AssetControlDialog .AssetControlTreeWidget#treeWidget::branch:checked { /* Asset Control Branch Icon */
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+QDialog#AssetControlDialog .AssetControlTreeWidget#treeWidget::seperator {
+
+}
+
+/******************************************************
 EditAddressDialog
 ******************************************************/
 
@@ -1741,6 +1832,100 @@ QStackedWidget#SendCoinsEntry .QToolButton#deleteButton_is {
 }
 
 QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
+}
+
+/******************************************************
+SendAssetsDialog
+******************************************************/
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl,
+QDialog#SendAssetsDialog #scrollArea  { /* Asset Control Section */
+    border-bottom: 1px solid red;
+}
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl .QPushButton#pushButtonAssetControl { /* Asset Control Inputs Button */
+}
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl .QLabel#labelAssetControlFeatures { /* Asset Control Header */
+}
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl .QWidget#widgetAssetControl { /* Asset Control Inputs */
+}
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl .QWidget#widgetAssetControl > .QLabel { /* Asset Control Inputs Labels */
+    padding: 2px;
+}
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl .QValidatedLineEdit#lineEditAssetControlChange { /* Custom Change Address */
+}
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl .QLabel#labelAssetControlChangeLabel { /* Custom Change Address Validation Label */
+    margin-right: 112px;
+}
+
+QDialog#SendAssetsDialog .QFrame#frameAssetControl .QLabel#labelAssetControlInsuffFunds { /* Insufficient Funds Label */
+    color: #a84832;
+}
+
+QDialog#SendAssetsDialog .QScrollArea#scrollArea .QWidget#scrollAreaWidgetContents { /* Send To Widget */
+    background-color: #00000000;
+}
+
+QDialog#SendAssetsDialog QLabel#labelBalanceText,
+QDialog#SendAssetsDialog QLabel#labelBalance {
+    qproperty-alignment: 'AlignLeading | AlignLeft';
+    min-height: 20px;
+    max-height: 20px;
+}
+
+QDialog#SendAssetsDialog QLabel#labelBalance {
+    margin-right: 10px;
+}
+
+QDialog#SendAssetsDialog QPushButton#sendButton {
+    margin-left:10px;
+}
+
+#checkboxSubtractFeeFromAmount {
+    padding-left: 10px;
+}
+
+/******************************************************
+SendAssetsEntry
+******************************************************/
+
+QStackedWidget#SendAssetsEntry .QFrame#SendAssets > .QLabel { /* Send Asset Entry Labels */
+    background-color: #00000000;
+    min-width: 50px;
+    min-height: 25px;
+    margin-right: 5px;
+    padding-right: 5px;
+}
+
+QStackedWidget#SendAssetsEntry .QFrame#SendAssets .QLabel#amountLabel {
+}
+
+QStackedWidget#SendAssetsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
+}
+
+QStackedWidget#SendAssetsEntry .QToolButton { /* General Settings for Pay To Icons */
+    background-color: #00000000;
+    margin-left: 5px;
+    margin-right: 5px;
+    border: 0;
+}
+
+QStackedWidget#SendAssetsEntry .QToolButton#addressBookButton { /* Address Book Button */
+    margin-left: 10px;
+}
+
+QStackedWidget#SendAssetsEntry .QToolButton#addressBookButton,
+QStackedWidget#SendAssetsEntry .QToolButton#pasteButton,
+QStackedWidget#SendAssetsEntry .QToolButton#deleteButton,
+QStackedWidget#SendAssetsEntry .QToolButton#deleteButton_is {
+}
+
+QStackedWidget#SendAssetsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
 }
 
 /******************************************************

--- a/src/qt/sendassetsdialog.cpp
+++ b/src/qt/sendassetsdialog.cpp
@@ -1,0 +1,1025 @@
+// Copyright (c) 2011-2015 The BitAsset Core developers
+// Copyright (c) 2014-2021 The Dash Core developers
+// Copyright (c) 2020-2022 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/sendassetsdialog.h>
+#include <qt/forms/ui_sendassetsdialog.h>
+
+#include <qt/addresstablemodel.h>
+#include <qt/bitcoinunits.h>
+#include <qt/clientmodel.h>
+#include <qt/assetcontroldialog.h>
+#include <qt/guiutil.h>
+#include <qt/optionsmodel.h>
+#include <qt/sendassetsentry.h>
+
+#include <interfaces/node.h>
+#include <key_io.h>
+#include <wallet/coincontrol.h>
+#include <ui_interface.h>
+#include <txmempool.h>
+#include <policy/fees.h>
+#include <wallet/fees.h>
+#include <wallet/wallet.h>
+#include <future/fee.h>
+#include <validation.h>
+#include <assets/assets.h>
+#include <assets/assetstype.h>
+
+#include <QFontMetrics>
+#include <QScrollBar>
+#include <QSettings>
+#include <QTextDocument>
+
+#define SEND_CONFIRM_DELAY   3
+
+SendAssetsDialog::SendAssetsDialog(QWidget* parent) :
+    QDialog(parent),
+    ui(new Ui::SendAssetsDialog),
+    clientModel(nullptr),
+    model(nullptr),
+    m_coin_control(new CCoinControl),
+    fNewRecipientAllowed(true),
+    fFeeMinimized(true)
+{
+    ui->setupUi(this);
+
+    GUIUtil::setFont({ui->labelAssetControlFeatures,
+                      ui->labelAssetControlInsuffFunds,
+                      ui->labelAssetControlQuantityText,
+                      ui->labelAssetControlBytesText,
+                      ui->labelAssetControlAmountText,
+                      ui->labelAssetControlLowOutputText,
+                      ui->labelAssetControlFeeText,
+                      ui->labelAssetControlAfterFeeText,
+                      ui->labelAssetControlChangeText,
+                      ui->labelFeeHeadline,
+                      ui->fallbackFeeWarningLabel
+                     }, GUIUtil::FontWeight::Bold);
+
+    GUIUtil::setFont({ui->labelBalance,
+                      ui->labelBalanceText
+                     }, GUIUtil::FontWeight::Bold, 14);
+
+    GUIUtil::setFont({ui->labelAssetControlFeatures
+                     }, GUIUtil::FontWeight::Bold, 16);
+
+    GUIUtil::setupAddressWidget(ui->lineEditAssetControlChange, this);
+
+    addEntry();
+
+    GUIUtil::updateFonts();
+
+    connect(ui->addButton, SIGNAL(clicked()), this, SLOT(addEntry()));
+    connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+
+    // Asset Control
+    connect(ui->pushButtonAssetControl, SIGNAL(clicked()), this, SLOT(AssetControlButtonClicked()));
+    connect(ui->checkBoxAssetControlChange, SIGNAL(stateChanged(int)), this, SLOT(AssetControlChangeChecked(int)));
+    connect(ui->lineEditAssetControlChange, SIGNAL(textEdited(const QString &)), this, SLOT(AssetControlChangeEdited(const QString &)));
+
+    // Asset Control: clipboard actions
+    QAction *clipboardQuantityAction = new QAction(tr("Copy quantity"), this);
+    QAction *clipboardAmountAction = new QAction(tr("Copy amount"), this);
+    QAction *clipboardFeeAction = new QAction(tr("Copy fee"), this);
+    QAction *clipboardAfterFeeAction = new QAction(tr("Copy after fee"), this);
+    QAction *clipboardBytesAction = new QAction(tr("Copy bytes"), this);
+    QAction *clipboardLowOutputAction = new QAction(tr("Copy dust"), this);
+    QAction *clipboardChangeAction = new QAction(tr("Copy change"), this);
+    connect(clipboardQuantityAction, SIGNAL(triggered()), this, SLOT(AssetControlClipboardQuantity()));
+    connect(clipboardAmountAction, SIGNAL(triggered()), this, SLOT(AssetControlClipboardAmount()));
+    connect(clipboardFeeAction, SIGNAL(triggered()), this, SLOT(AssetControlClipboardFee()));
+    connect(clipboardAfterFeeAction, SIGNAL(triggered()), this, SLOT(AssetControlClipboardAfterFee()));
+    connect(clipboardBytesAction, SIGNAL(triggered()), this, SLOT(AssetControlClipboardBytes()));
+    connect(clipboardLowOutputAction, SIGNAL(triggered()), this, SLOT(AssetControlClipboardLowOutput()));
+    connect(clipboardChangeAction, SIGNAL(triggered()), this, SLOT(AssetControlClipboardChange()));
+    ui->labelAssetControlQuantity->addAction(clipboardQuantityAction);
+    ui->labelAssetControlAmount->addAction(clipboardAmountAction);
+    ui->labelAssetControlFee->addAction(clipboardFeeAction);
+    ui->labelAssetControlAfterFee->addAction(clipboardAfterFeeAction);
+    ui->labelAssetControlBytes->addAction(clipboardBytesAction);
+    ui->labelAssetControlLowOutput->addAction(clipboardLowOutputAction);
+    ui->labelAssetControlChange->addAction(clipboardChangeAction);
+
+    // init transaction fee section
+    QSettings settings;
+    if (!settings.contains("fFeeSectionMinimized"))
+        settings.setValue("fFeeSectionMinimized", true);
+    if (!settings.contains("nFeeRadio") && settings.contains("nTransactionFee") && settings.value("nTransactionFee").toLongLong() > 0) // compatibility
+        settings.setValue("nFeeRadio", 1); // custom
+    if (!settings.contains("nFeeRadio"))
+        settings.setValue("nFeeRadio", 0); // recommended
+    if (!settings.contains("nSmartFeeSliderPosition"))
+        settings.setValue("nSmartFeeSliderPosition", 0);
+    if (!settings.contains("nTransactionFee"))
+        settings.setValue("nTransactionFee", (qint64)DEFAULT_TRANSACTION_FEE);
+    if (!settings.contains("fPayOnlyMinFee"))
+        settings.setValue("fPayOnlyMinFee", false);
+
+    ui->groupFee->setId(ui->radioSmartFee, 0);
+    ui->groupFee->setId(ui->radioCustomFee, 1);
+    ui->groupFee->button((int)std::max(0, std::min(1, settings.value("nFeeRadio").toInt())))->setChecked(true);
+    ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
+    ui->checkBoxMinimumFee->setChecked(settings.value("fPayOnlyMinFee").toBool());
+    minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
+    
+    ui->sendButton->setText(tr("S&end"));
+    ui->sendButton->setToolTip(tr("Confirm the send action"));
+
+    m_coin_control->UseCoinJoin(false);       
+}
+
+void SendAssetsDialog::setClientModel(ClientModel *_clientModel)
+{
+    this->clientModel = _clientModel;
+
+    if (_clientModel) {
+        connect(_clientModel, SIGNAL(numBlocksChanged(int,QDateTime,QString,double,bool)), this, SLOT(updateSmartFeeLabel()));
+    }
+}
+
+void SendAssetsDialog::setModel(WalletModel *_model)
+{
+    this->model = _model;
+
+    if(_model && _model->getOptionsModel())
+    {
+        for(int i = 0; i < ui->entries->count(); ++i)
+        {
+            SendAssetsEntry *entry = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(i)->widget());
+            if(entry)
+            {
+                entry->setModel(_model);
+                entry->setCoinControl(&*m_coin_control);
+                entry->updateAssetList();
+            }
+        }
+
+        interfaces::WalletBalances balances = _model->wallet().getBalances();
+        setBalance(balances);
+        connect(_model, SIGNAL(balanceChanged(interfaces::WalletBalances)), this, SLOT(setBalance(interfaces::WalletBalances)));
+        connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+        updateDisplayUnit();
+
+        // Asset Control
+        connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(AssetControlUpdateLabels()));
+        connect(_model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(AssetControlFeatureChanged(bool)));
+        connect(_model, SIGNAL(assetListChanged()), this, SLOT(updateAssetList())); 
+        ui->frameAssetControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
+        AssetControlUpdateLabels();
+
+        // fee section
+        for (const int n : confTargets) {
+            ui->confTargetSelector->addItem(tr("%1 (%2 blocks)").arg(GUIUtil::formatNiceTimeOffset(n*Params().GetConsensus().nPowTargetSpacing)).arg(n));
+        }
+        connect(ui->confTargetSelector, SIGNAL(currentIndexChanged(int)), this, SLOT(updateSmartFeeLabel()));
+        connect(ui->confTargetSelector, SIGNAL(currentIndexChanged(int)), this, SLOT(AssetControlUpdateLabels()));
+        connect(ui->groupFee, SIGNAL(buttonClicked(int)), this, SLOT(updateFeeSectionControls()));
+        connect(ui->groupFee, SIGNAL(buttonClicked(int)), this, SLOT(AssetControlUpdateLabels()));
+        connect(ui->customFee, SIGNAL(valueChanged()), this, SLOT(AssetControlUpdateLabels()));
+        connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(setMinimumFee()));
+        connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(updateFeeSectionControls()));
+        connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(AssetControlUpdateLabels()));
+
+        updateFeeSectionControls();
+        updateMinFeeLabel();
+        updateSmartFeeLabel();
+
+        // set the smartfee-sliders default value (wallets default conf.target or last stored value)
+        QSettings settings;
+        if (settings.value("nSmartFeeSliderPosition").toInt() != 0) {
+            // migrate nSmartFeeSliderPosition to nConfTarget
+            // nConfTarget is available since 0.15 (replaced nSmartFeeSliderPosition)
+            int nConfirmTarget = 25 - settings.value("nSmartFeeSliderPosition").toInt(); // 25 == old slider range
+            settings.setValue("nConfTarget", nConfirmTarget);
+            settings.remove("nSmartFeeSliderPosition");
+        }
+        if (settings.value("nConfTarget").toInt() == 0)
+            ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(model->node().getTxConfirmTarget()));
+        else
+            ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(settings.value("nConfTarget").toInt()));
+    }
+}
+
+SendAssetsDialog::~SendAssetsDialog()
+{
+    QSettings settings;
+    settings.setValue("fFeeSectionMinimized", fFeeMinimized);
+    settings.setValue("nFeeRadio", ui->groupFee->checkedId());
+    settings.setValue("nConfTarget", getConfTargetForIndex(ui->confTargetSelector->currentIndex()));
+    settings.setValue("nTransactionFee", (qint64)ui->customFee->value());
+    settings.setValue("fPayOnlyMinFee", ui->checkBoxMinimumFee->isChecked());
+
+    delete ui;
+}
+
+void SendAssetsDialog::OnDisplay() {
+    for (int i = 0; i < ui->entries->count(); ++i) {
+        SendAssetsEntry *entry = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(i)->widget());
+        if(entry) {
+            entry->SetFutureVisible(sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE) && Params().IsFutureActive(chainActive.Tip()) && i == 0);
+        }
+    }
+}
+
+void SendAssetsDialog::on_sendButton_clicked()
+{
+    if(!model || !model->getOptionsModel())
+        return;
+
+    QList<SendCoinsRecipient> recipients;
+    bool valid = true;
+
+    for(int i = 0; i < ui->entries->count(); ++i)
+    {
+        SendAssetsEntry *entry = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(i)->widget());
+        if(entry)
+        {
+            if(entry->validate(model->node()))
+            {
+                recipients.append(entry->getValue());
+            }
+            else
+            {
+                valid = false;
+            }
+        }
+    }
+
+    if(!valid || recipients.isEmpty())
+    {
+        return;
+    }
+
+    fNewRecipientAllowed = false;
+    // request unlock only if was locked or unlocked for mixing:
+    // this way we let users unlock by walletpassphrase or by menu
+    // and make many transactions while unlocking through this dialog
+    // will call relock
+    WalletModel::EncryptionStatus encStatus = model->getEncryptionStatus();
+    if(encStatus == model->Locked || encStatus == model->UnlockedForMixingOnly)
+    {
+        WalletModel::UnlockContext ctx(model->requestUnlock());
+        if(!ctx.isValid())
+        {
+            // Unlock wallet was cancelled
+            fNewRecipientAllowed = true;
+            return;
+        }
+        send(recipients);
+        return;
+    }
+    // already unlocked or not encrypted at all
+    send(recipients);
+}
+
+void SendAssetsDialog::send(QList<SendCoinsRecipient> recipients)
+{
+    // prepare transaction for getting txFee earlier
+    WalletModelTransaction currentTransaction(recipients);
+    WalletModel::SendAssetsReturn prepareStatus;
+
+    updateAssetControlState(*m_coin_control);
+
+    prepareStatus = model->prepareAssetTransaction(currentTransaction, *m_coin_control);
+
+    // process prepareStatus and on error generate message shown to user
+    processSendAssetsReturn(prepareStatus,
+        BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), currentTransaction.getTransactionFee()));
+
+    if(prepareStatus.status != WalletModel::OK) {
+        fNewRecipientAllowed = true;
+        return;
+    }
+
+    // Format confirmation message
+    QStringList formatted;
+    bool hasFuture = false;
+    std::map<std::string, std::pair<CAmount, uint16_t>> mapAmounts;
+    for (const SendCoinsRecipient &rcp : currentTransaction.getRecipients())
+    {
+        // generate bold amount string with wallet name in case of multiwallet
+        CAssetMetaData assetdata;
+        int decimalPoint = 0;
+        std::string assetId;
+        passetsCache->GetAssetId(rcp.assetId.toStdString(), assetId);
+        if (passetsCache->GetAssetMetaData(assetId , assetdata))
+            decimalPoint = assetdata.Decimalpoint;
+        if (!mapAmounts.count(assetId))
+            mapAmounts[rcp.assetId.toStdString()] = std::make_pair(rcp.assetAmount, decimalPoint);
+        else
+        mapAmounts[rcp.assetId.toStdString()].first += rcp.assetAmount;
+
+        std::string uniqueId = "";
+        if (rcp.uniqueId < MAX_UNIQUE_ID)
+            uniqueId += " ["+to_string(rcp.uniqueId)+"]";
+        QString amount = "<b>" + BitcoinUnits::formatHtmlWithCustomName(QString::fromStdString(assetdata.Name), QString::fromStdString(uniqueId), decimalPoint, rcp.assetAmount);
+        
+        if (model->isMultiwallet()) {
+            amount.append(" <u>"+tr("from wallet %1").arg(GUIUtil::HtmlEscape(model->getWalletName()))+"</u> ");
+        }
+        amount.append("</b> ");
+        // generate monospace address string
+        QString address = "<span style='font-family: monospace;'>" + rcp.address;
+        address.append("</span>");
+
+        QString recipientElement;
+
+        if (!rcp.paymentRequest.IsInitialized()) // normal payment
+        {
+            if(rcp.label.length() > 0) // label with address
+            {
+                recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.label));
+                recipientElement.append(QString(" (%1)").arg(address));
+            }
+            else // just address
+            {
+                recipientElement = tr("%1 to %2").arg(amount, address);
+            }
+        }
+        else if(!rcp.authenticatedMerchant.isEmpty()) // authenticated payment request
+        {
+            recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.authenticatedMerchant));
+        }
+        else // unauthenticated payment request
+        {
+            recipientElement = tr("%1 to %2").arg(amount, address);
+        }
+        //std::cout << rcp.amount << " is future output " << rcp.isFutureOutput << "\n";
+        if(rcp.isFutureOutput) {
+            hasFuture = true;
+            if(recipients[0].maturity >= 0) {
+                recipientElement.append(tr("<br>Confirmations in: <b>%1 blocks</b><br />").arg(recipients[0].maturity));
+            }
+            if(recipients[0].locktime >= 0) {
+                recipientElement.append(tr("Time in: <b>%1 seconds from first confirmed</b><br />")
+                                                .arg(recipients[0].locktime));
+            }
+            if(recipients[0].maturity >= 0 && recipients[0].locktime >= 0) {
+                int calcBlock = (recipients[0].maturity * 2 * 60);
+                if(calcBlock < recipients[0].locktime) {
+                    recipientElement.append("This transaction will likely mature based on confirmations.");
+                } else {
+                    recipientElement.append("This transaction will likely mature based on time.");
+                }
+            } else if(recipients[0].maturity < 0 && recipients[0].locktime < 0){
+                recipientElement.append("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'><b>No maturity is set. Transaction will mature as normal.</b></span>");
+            }
+        }
+
+        formatted.append(recipientElement);
+    }
+
+    // Limit number of displayed entries
+    int messageEntries = formatted.size();
+    int displayedEntries = 0;
+    for(int i = 0; i < formatted.size(); i++){
+        if(i >= MAX_SEND_ASSET_POPUP_ENTRIES){
+            formatted.removeLast();
+            i--;
+        }
+        else{
+            displayedEntries = i+1;
+        }
+    }
+
+    QString questionString = tr("Are you sure you want to send?");
+    questionString.append("<br /><br />");
+    questionString.append(formatted.join("<br />"));
+    questionString.append("<br />");
+
+    questionString.append(tr("using") + " <b>" + tr("any available funds") + "</b>");
+
+    if (displayedEntries < messageEntries) {
+        questionString.append("<br />");
+        questionString.append("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>");
+        questionString.append(tr("<b>(%1 of %2 entries displayed)</b>").arg(displayedEntries).arg(messageEntries));
+        questionString.append("</span>");
+    }
+
+    CAmount txFee = currentTransaction.getTransactionFee();
+    txFee += hasFuture ? getFutureFeesCoin() : 0;
+    if(txFee > 0)
+    {
+        // append fee string if a fee is required
+        questionString.append("<hr /><span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>");
+        questionString.append(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), txFee));
+        questionString.append("</span> ");
+        questionString.append(tr("are added as transaction fee"));
+    }
+
+    // Show some additioinal information
+    questionString.append("<hr />");
+    // append transaction size
+    questionString.append(tr("Transaction size: %1").arg(QString::number((double)currentTransaction.getTransactionSize() / 1000)) + " kB");
+    questionString.append("<br />");
+    CFeeRate feeRate(txFee, currentTransaction.getTransactionSize());
+    questionString.append(tr("Fee rate: %1").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), feeRate.GetFeePerK())) + "/kB");
+
+    // add total amount in all subdivision units
+    questionString.append("<hr />");
+    CAmount totalAmount = currentTransaction.getTotalTransactionAmount() + txFee;
+
+    // Show total amount
+    questionString.append(tr("Total Amount:<br>"));
+    for (auto entry : mapAmounts){
+        questionString.append(tr("<b>%1</b><br>")
+        .arg(BitcoinUnits::formatHtmlWithCustomName(QString::fromStdString(entry.first), "", entry.second.second, entry.second.first)));
+    }
+    questionString.append(tr("<b>%1</b>")
+        .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount)));
+
+    // Display message box
+    SendAssetConfirmationDialog confirmationDialog(tr("Confirm send Assets"),
+        questionString, SEND_CONFIRM_DELAY, this);
+    confirmationDialog.exec();
+    QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
+
+    if(retval != QMessageBox::Yes)
+    {
+        fNewRecipientAllowed = true;
+        return;
+    }
+
+    // now send the prepared transaction
+    WalletModel::SendAssetsReturn sendStatus = model->sendAssets(currentTransaction, m_coin_control->IsUsingCoinJoin());
+    // process sendStatus and on error generate message shown to user
+    processSendAssetsReturn(sendStatus);
+
+    if (sendStatus.status == WalletModel::OK)
+    {
+        accept();
+        m_coin_control->UnSelectAll();
+        AssetControlUpdateLabels();
+        Q_EMIT coinsSent(currentTransaction.getWtx()->get().GetHash());
+    }
+    fNewRecipientAllowed = true;
+}
+
+void SendAssetsDialog::clear()
+{
+    // Clear Asset control settings
+    m_coin_control->UnSelectAll();
+    ui->checkBoxAssetControlChange->setChecked(false);
+    ui->lineEditAssetControlChange->clear();
+    AssetControlUpdateLabels();
+
+    // Remove entries until only one left
+    while(ui->entries->count())
+    {
+        ui->entries->takeAt(0)->widget()->deleteLater();
+    }
+    addEntry();
+
+    updateTabsAndLabels();
+}
+
+void SendAssetsDialog::reject()
+{
+    clear();
+}
+
+void SendAssetsDialog::accept()
+{
+    clear();
+}
+
+SendAssetsEntry *SendAssetsDialog::addEntry()
+{
+
+    SendAssetsEntry* entry = new SendAssetsEntry(this, sporkManager.IsSporkActive(SPORK_22_SPECIAL_TX_FEE)
+                                                            && Params().IsFutureActive(chainActive.Tip())
+                                                            && ui->entries->count() == 0);
+    entry->setModel(model);
+    entry->setCoinControl(&*m_coin_control);
+    ui->entries->addWidget(entry);
+    connect(entry, SIGNAL(removeEntry(SendAssetsEntry*)), this, SLOT(removeEntry(SendAssetsEntry*)));
+    connect(entry, SIGNAL(useAvailableAssetsBalance(SendAssetsEntry*)), this, SLOT(useAvailableAssetsBalance(SendAssetsEntry*)));
+    connect(entry, SIGNAL(payAmountChanged()), this, SLOT(AssetControlUpdateLabels()));
+    
+    // Focus the field, so that entry can start immediately
+    entry->clear();
+    entry->setFocus();
+    ui->scrollAreaWidgetContents->resize(ui->scrollAreaWidgetContents->sizeHint());
+    qApp->processEvents();
+    QScrollBar* bar = ui->scrollArea->verticalScrollBar();
+    if(bar)
+        bar->setSliderPosition(bar->maximum());
+
+    updateTabsAndLabels();
+    if(model)
+    entry->updateAssetList();
+    return entry;
+}
+
+void SendAssetsDialog::updateTabsAndLabels()
+{
+    setupTabChain(0);
+    AssetControlUpdateLabels();
+}
+
+void SendAssetsDialog::removeEntry(SendAssetsEntry* entry)
+{
+    entry->hide();
+
+    // If the last entry is about to be removed add an empty one
+    if (ui->entries->count() == 1)
+        addEntry();
+
+    entry->deleteLater();
+
+    updateTabsAndLabels();
+}
+
+QWidget *SendAssetsDialog::setupTabChain(QWidget *prev)
+{
+    for(int i = 0; i < ui->entries->count(); ++i)
+    {
+        SendAssetsEntry *entry = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(i)->widget());
+        if(entry)
+        {
+            prev = entry->setupTabChain(prev);
+        }
+    }
+    QWidget::setTabOrder(prev, ui->sendButton);
+    QWidget::setTabOrder(ui->sendButton, ui->clearButton);
+    QWidget::setTabOrder(ui->clearButton, ui->addButton);
+    return ui->addButton;
+}
+
+void SendAssetsDialog::setAddress(const QString &address)
+{
+    SendAssetsEntry *entry = 0;
+    // Replace the first entry if it is still unused
+    if(ui->entries->count() == 1)
+    {
+        SendAssetsEntry *first = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(0)->widget());
+        if(first->isClear())
+        {
+            entry = first;
+        }
+    }
+    if(!entry)
+    {
+        entry = addEntry();
+    }
+
+    entry->setAddress(address);
+}
+
+void SendAssetsDialog::pasteEntry(const SendCoinsRecipient &rv)
+{
+    if(!fNewRecipientAllowed)
+        return;
+
+    SendAssetsEntry *entry = 0;
+    // Replace the first entry if it is still unused
+    if(ui->entries->count() == 1)
+    {
+        SendAssetsEntry *first = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(0)->widget());
+        if(first->isClear())
+        {
+            entry = first;
+        }
+    }
+    if(!entry)
+    {
+        entry = addEntry();
+    }
+
+    entry->setValue(rv);
+    updateTabsAndLabels();
+}
+
+bool SendAssetsDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
+{
+    // Just paste the entry, all pre-checks
+    // are done in paymentserver.cpp.
+    pasteEntry(rv);
+    return true;
+}
+
+void SendAssetsDialog::setBalance(const interfaces::WalletBalances& balances)
+{
+    if(model && model->getOptionsModel())
+    {
+        CAmount bal = balances.balance;
+        ui->labelBalance->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), bal));
+    }
+}
+
+void SendAssetsDialog::updateDisplayUnit()
+{
+    setBalance(model->wallet().getBalances());
+    AssetControlUpdateLabels();
+    ui->customFee->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
+    updateMinFeeLabel();
+    updateSmartFeeLabel();
+}
+
+void SendAssetsDialog::processSendAssetsReturn(const WalletModel::SendAssetsReturn &sendAssetsReturn, const QString &msgArg)
+{
+    QPair<QString, CClientUIInterface::MessageBoxFlags> msgParams;
+    // Default to a warning message, override if error message is needed
+    msgParams.second = CClientUIInterface::MSG_WARNING;
+
+    // This comment is specific to SendAssetsDialog usage of WalletModel::SendAssetsReturn.
+    // WalletModel::TransactionCommitFailed is used only in WalletModel::sendAssets()
+    // all others are used only in WalletModel::prepareTransaction()
+    switch(sendAssetsReturn.status)
+    {
+    case WalletModel::InvalidAddress:
+        msgParams.first = tr("The recipient address is not valid. Please recheck.");
+        break;
+    case WalletModel::InvalidAmount:
+        msgParams.first = tr("The amount to pay must be larger than 0.");
+        break;
+    case WalletModel::AmountExceedsBalance:
+        msgParams.first = tr("The amount exceeds your balance.");
+        break;
+    case WalletModel::AmountWithFeeExceedsBalance:
+        msgParams.first = tr("The total exceeds your balance when the %1 transaction fee is included.").arg(msgArg);
+        break;
+    case WalletModel::DuplicateAddress:
+        msgParams.first = tr("Duplicate address found: addresses should only be used once each.");
+        break;
+    case WalletModel::TransactionCreationFailed:
+        msgParams.first = tr("Transaction creation failed!");
+        msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
+    case WalletModel::TransactionCommitFailed:
+        msgParams.first = tr("The transaction was rejected with the following reason: %1").arg(sendAssetsReturn.reasonCommitFailed);
+        msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
+    case WalletModel::AbsurdFee:
+        msgParams.first = tr("A fee higher than %1 is considered an absurdly high fee.").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), model->node().getMaxTxFee()));
+        break;
+    case WalletModel::PaymentRequestExpired:
+        msgParams.first = tr("Payment request expired.");
+        msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
+    case WalletModel::AmountExceedsmaxmoney:
+        msgParams.first = tr("The amount to pay exceeds the limit of 21 million per transaction.");
+        break;    
+    // included to prevent a compiler warning.
+    case WalletModel::OK:
+    default:
+        return;
+    }
+
+    Q_EMIT message(tr("Send Assets"), msgParams.first, msgParams.second);
+}
+
+void SendAssetsDialog::minimizeFeeSection(bool fMinimize)
+{
+    ui->labelFeeMinimized->setVisible(fMinimize);
+    ui->buttonChooseFee  ->setVisible(fMinimize);
+    ui->buttonMinimizeFee->setVisible(!fMinimize);
+    ui->frameFeeSelection->setVisible(!fMinimize);
+    ui->horizontalLayoutSmartFee->setContentsMargins(0, (fMinimize ? 0 : 6), 0, 0);
+    fFeeMinimized = fMinimize;
+}
+
+void SendAssetsDialog::on_buttonChooseFee_clicked()
+{
+    minimizeFeeSection(false);
+}
+
+void SendAssetsDialog::on_buttonMinimizeFee_clicked()
+{
+    updateFeeMinimizedLabel();
+    minimizeFeeSection(true);
+}
+
+void SendAssetsDialog::useAvailableAssetsBalance(SendAssetsEntry* entry)
+{
+    // Calculate available amount to send.
+    CAmount amount = 0;//model->wallet().getAvailableBalance(*m_coin_control);
+    std::map<std::string, CAmount> assetsbalance = model->wallet().getAssetsBalance( &*m_coin_control, true);
+    QString assetName = entry->getValue().assetId;
+    std::string assetId;
+    if (passetsCache->GetAssetId(assetName.toStdString(), assetId)){
+    if (assetsbalance.count(assetId))
+        amount = assetsbalance[assetId];
+    }
+    for (int i = 0; i < ui->entries->count(); ++i) {
+        SendAssetsEntry* e = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(i)->widget());
+        if (e && !e->isHidden() && e != entry) {
+            if (e->getValue().assetId == assetName)
+            amount -= e->getValue().amount;
+        }
+    }
+
+    if (amount > 0) {
+      entry->setAmount(amount);
+    } else {
+      entry->setAmount(0);
+    }
+}
+
+
+void SendAssetsDialog::setMinimumFee()
+{
+    ui->customFee->setValue(model->node().getRequiredFee(1000));
+}
+
+void SendAssetsDialog::updateFeeSectionControls()
+{
+    ui->confTargetSelector      ->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelSmartFee           ->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelSmartFee2          ->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelSmartFee3          ->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelFeeEstimation      ->setEnabled(ui->radioSmartFee->isChecked());
+    ui->checkBoxMinimumFee      ->setEnabled(ui->radioCustomFee->isChecked());
+    ui->labelMinFeeWarning      ->setEnabled(ui->radioCustomFee->isChecked());
+    ui->labelCustomPerKilobyte  ->setEnabled(ui->radioCustomFee->isChecked() && !ui->checkBoxMinimumFee->isChecked());
+    ui->customFee               ->setEnabled(ui->radioCustomFee->isChecked() && !ui->checkBoxMinimumFee->isChecked());
+}
+
+void SendAssetsDialog::updateFeeMinimizedLabel()
+{
+    if(!model || !model->getOptionsModel())
+        return;
+
+    if (ui->radioSmartFee->isChecked())
+        ui->labelFeeMinimized->setText(ui->labelSmartFee->text());
+    else {
+        ui->labelFeeMinimized->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), ui->customFee->value()) + "/kB");
+    }
+}
+
+void SendAssetsDialog::updateMinFeeLabel()
+{
+    if (model && model->getOptionsModel())
+        ui->checkBoxMinimumFee->setText(tr("Pay only the required fee of %1").arg(
+            BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), model->node().getRequiredFee(1000)) + "/kB")
+        );
+}
+
+void SendAssetsDialog::updateAssetControlState(CCoinControl& ctrl)
+{
+    if (ui->radioCustomFee->isChecked()) {
+        ctrl.m_feerate = CFeeRate(ui->customFee->value());
+    } else {
+        ctrl.m_feerate.reset();
+    }
+    // Avoid using global defaults when sending money from the GUI
+    // Either custom fee will be used or if not selected, the confirmation target from dropdown box
+    ctrl.m_confirm_target = getConfTargetForIndex(ui->confTargetSelector->currentIndex());
+}
+
+void SendAssetsDialog::updateSmartFeeLabel()
+{
+    if(!model || !model->getOptionsModel())
+        return;
+    updateAssetControlState(*m_coin_control);
+    m_coin_control->m_feerate.reset(); // Explicitly use only fee estimation rate for smart fee labels
+    int returned_target;
+    FeeReason reason;
+    CFeeRate feeRate = CFeeRate(model->node().getMinimumFee(1000, *m_coin_control, &returned_target, &reason));
+
+    ui->labelSmartFee->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), feeRate.GetFeePerK()) + "/kB");
+
+    if (reason == FeeReason::FALLBACK) {
+        ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
+        ui->labelFeeEstimation->setText("");
+        ui->fallbackFeeWarningLabel->setVisible(true);
+    }
+    else
+    {
+        ui->labelSmartFee2->hide();
+        ui->labelFeeEstimation->setText(tr("Estimated to begin confirmation within %n block(s).", "", returned_target));
+        ui->fallbackFeeWarningLabel->setVisible(false);
+    }
+
+    updateFeeMinimizedLabel();
+}
+
+// Asset Control: copy label "Quantity" to clipboard
+void SendAssetsDialog::AssetControlClipboardQuantity()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlQuantity->text());
+}
+
+// Asset Control: copy label "Amount" to clipboard
+void SendAssetsDialog::AssetControlClipboardAmount()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlAmount->text().left(ui->labelAssetControlAmount->text().indexOf(" ")));
+}
+
+// Asset Control: copy label "Fee" to clipboard
+void SendAssetsDialog::AssetControlClipboardFee()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlFee->text().left(ui->labelAssetControlFee->text().indexOf(" ")).replace(ASYMP_UTF8, ""));
+}
+
+// Asset Control: copy label "After fee" to clipboard
+void SendAssetsDialog::AssetControlClipboardAfterFee()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlAfterFee->text().left(ui->labelAssetControlAfterFee->text().indexOf(" ")).replace(ASYMP_UTF8, ""));
+}
+
+// Asset Control: copy label "Bytes" to clipboard
+void SendAssetsDialog::AssetControlClipboardBytes()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlBytes->text().replace(ASYMP_UTF8, ""));
+}
+
+// Asset Control: copy label "Dust" to clipboard
+void SendAssetsDialog::AssetControlClipboardLowOutput()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlLowOutput->text());
+}
+
+// Asset Control: copy label "Change" to clipboard
+void SendAssetsDialog::AssetControlClipboardChange()
+{
+    GUIUtil::setClipboard(ui->labelAssetControlChange->text().left(ui->labelAssetControlChange->text().indexOf(" ")).replace(ASYMP_UTF8, ""));
+}
+
+// Asset Control: settings menu - Asset control enabled/disabled by user
+void SendAssetsDialog::AssetControlFeatureChanged(bool checked)
+{
+    ui->frameAssetControl->setVisible(checked);
+
+    if (!checked && model) { // Asset control features disabled
+        m_coin_control->SetNull(false);
+    }
+
+    AssetControlUpdateLabels();
+}
+
+// Asset Control: button inputs -> show actual Asset control dialog
+void SendAssetsDialog::AssetControlButtonClicked()
+{
+    AssetControlDialog dlg(*m_coin_control, model, this);
+    dlg.exec();
+    AssetControlUpdateLabels();
+}
+
+// Asset Control: checkbox custom change address
+void SendAssetsDialog::AssetControlChangeChecked(int state)
+{
+    if (state == Qt::Unchecked)
+    {
+        m_coin_control->destChange = CNoDestination();
+        ui->labelAssetControlChangeLabel->clear();
+    }
+    else
+        // use this to re-validate an already entered address
+        AssetControlChangeEdited(ui->lineEditAssetControlChange->text());
+
+    ui->lineEditAssetControlChange->setEnabled((state == Qt::Checked));
+}
+
+// Asset Control: custom change address changed
+void SendAssetsDialog::AssetControlChangeEdited(const QString& text)
+{
+    if (model && model->getAddressTableModel())
+    {
+        // Default to no change address until verified
+        m_coin_control->destChange = CNoDestination();
+        ui->labelAssetControlChangeLabel->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+
+        const CTxDestination dest = DecodeDestination(text.toStdString());
+
+        if (text.isEmpty()) // Nothing entered
+        {
+            ui->labelAssetControlChangeLabel->setText("");
+        }
+        else if (!IsValidDestination(dest)) // Invalid address
+        {
+            ui->labelAssetControlChangeLabel->setText(tr("Warning: Invalid Raptoreum address"));
+        }
+        else // Valid address
+        {
+            if (!model->wallet().isSpendable(dest)) {
+                ui->labelAssetControlChangeLabel->setText(tr("Warning: Unknown change address"));
+
+                // confirmation dialog
+                QMessageBox::StandardButton btnRetVal = QMessageBox::question(this, tr("Confirm custom change address"), tr("The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?"),
+                    QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+
+                if(btnRetVal == QMessageBox::Yes)
+                    m_coin_control->destChange = dest;
+                else
+                {
+                    ui->lineEditAssetControlChange->setText("");
+                    ui->labelAssetControlChangeLabel->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_PRIMARY));
+                    ui->labelAssetControlChangeLabel->setText("");
+                }
+            }
+            else // Known change address
+            {
+                ui->labelAssetControlChangeLabel->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_PRIMARY));
+
+                // Query label
+                QString associatedLabel = model->getAddressTableModel()->labelForAddress(text);
+                if (!associatedLabel.isEmpty())
+                    ui->labelAssetControlChangeLabel->setText(associatedLabel);
+                else
+                    ui->labelAssetControlChangeLabel->setText(tr("(no label)"));
+
+                m_coin_control->destChange = dest;
+            }
+        }
+    }
+}
+
+// Asset Control: update labels
+void SendAssetsDialog::AssetControlUpdateLabels()
+{
+    if (!model || !model->getOptionsModel())
+        return;
+
+    updateAssetControlState(*m_coin_control);
+
+    // set pay amounts
+    AssetControlDialog::payAmounts.clear();
+    AssetControlDialog::fSubtractFeeFromAmount = false;
+
+    for(int i = 0; i < ui->entries->count(); ++i)
+    {
+        SendAssetsEntry *entry = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(i)->widget());
+        if(entry && !entry->isHidden())
+        {
+            SendCoinsRecipient rcp = entry->getValue();
+            AssetControlDialog::payAmounts.append(rcp.assetAmount);
+            if (rcp.fSubtractFeeFromAmount)
+                AssetControlDialog::fSubtractFeeFromAmount = true;
+        }
+    }
+
+    if (m_coin_control->HasAssetSelected())
+    {
+        // actual Asset control calculation
+        AssetControlDialog::updateLabels(*m_coin_control, model, this);
+
+        // show Asset control stats
+        ui->labelAssetControlAutomaticallySelected->hide();
+        ui->widgetAssetControl->show();
+    }
+    else
+    {
+        // hide Asset control stats
+        ui->labelAssetControlAutomaticallySelected->show();
+        ui->widgetAssetControl->hide();
+        ui->labelAssetControlInsuffFunds->hide();
+    }
+}
+
+void SendAssetsDialog::updateAssetList()
+{
+    for(int i = 0; i < ui->entries->count(); ++i)
+    {
+        SendAssetsEntry *entry = qobject_cast<SendAssetsEntry*>(ui->entries->itemAt(i)->widget());
+        if (entry) {
+            entry->updateAssetList();
+        }
+    }
+}
+
+SendAssetConfirmationDialog::SendAssetConfirmationDialog(const QString &title, const QString &text, int _secDelay,
+    QWidget *parent) :
+    QMessageBox(QMessageBox::Question, title, text, QMessageBox::Yes | QMessageBox::Cancel, parent), secDelay(_secDelay)
+{
+    GUIUtil::updateFonts();
+    setDefaultButton(QMessageBox::Cancel);
+    yesButton = button(QMessageBox::Yes);
+    updateYesButton();
+    connect(&countDownTimer, SIGNAL(timeout()), this, SLOT(countDown()));
+}
+
+int SendAssetConfirmationDialog::exec()
+{
+    updateYesButton();
+    countDownTimer.start(1000);
+    return QMessageBox::exec();
+}
+
+void SendAssetConfirmationDialog::countDown()
+{
+    secDelay--;
+    updateYesButton();
+
+    if(secDelay <= 0)
+    {
+        countDownTimer.stop();
+    }
+}
+
+void SendAssetConfirmationDialog::updateYesButton()
+{
+    if(secDelay > 0)
+    {
+        yesButton->setEnabled(false);
+        yesButton->setText(tr("Yes") + " (" + QString::number(secDelay) + ")");
+    }
+    else
+    {
+        yesButton->setEnabled(true);
+        yesButton->setText(tr("Yes"));
+    }
+}

--- a/src/qt/sendassetsdialog.cpp
+++ b/src/qt/sendassetsdialog.cpp
@@ -124,11 +124,11 @@ SendAssetsDialog::SendAssetsDialog(QWidget* parent) :
     ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
     ui->checkBoxMinimumFee->setChecked(settings.value("fPayOnlyMinFee").toBool());
     minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
-    
+
     ui->sendButton->setText(tr("S&end"));
     ui->sendButton->setToolTip(tr("Confirm the send action"));
 
-    m_coin_control->UseCoinJoin(false);       
+    m_coin_control->UseCoinJoin(false);
 }
 
 void SendAssetsDialog::setClientModel(ClientModel *_clientModel)
@@ -166,7 +166,7 @@ void SendAssetsDialog::setModel(WalletModel *_model)
         // Asset Control
         connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(AssetControlUpdateLabels()));
         connect(_model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(AssetControlFeatureChanged(bool)));
-        connect(_model, SIGNAL(assetListChanged()), this, SLOT(updateAssetList())); 
+        connect(_model, SIGNAL(assetListChanged()), this, SLOT(updateAssetList()));
         ui->frameAssetControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
         AssetControlUpdateLabels();
 
@@ -301,12 +301,12 @@ void SendAssetsDialog::send(QList<SendCoinsRecipient> recipients)
     for (const SendCoinsRecipient &rcp : currentTransaction.getRecipients())
     {
         // generate bold amount string with wallet name in case of multiwallet
-        CAssetMetaData assetdata;
+        CAssetMetaData assetData;
         int decimalPoint = 0;
         std::string assetId;
         passetsCache->GetAssetId(rcp.assetId.toStdString(), assetId);
-        if (passetsCache->GetAssetMetaData(assetId , assetdata))
-            decimalPoint = assetdata.Decimalpoint;
+        if (passetsCache->GetAssetMetaData(assetId , assetData))
+            decimalPoint = assetData.decimalPoint;
         if (!mapAmounts.count(assetId))
             mapAmounts[rcp.assetId.toStdString()] = std::make_pair(rcp.assetAmount, decimalPoint);
         else
@@ -315,8 +315,8 @@ void SendAssetsDialog::send(QList<SendCoinsRecipient> recipients)
         std::string uniqueId = "";
         if (rcp.uniqueId < MAX_UNIQUE_ID)
             uniqueId += " ["+to_string(rcp.uniqueId)+"]";
-        QString amount = "<b>" + BitcoinUnits::formatHtmlWithCustomName(QString::fromStdString(assetdata.Name), QString::fromStdString(uniqueId), decimalPoint, rcp.assetAmount);
-        
+        QString amount = "<b>" + BitcoinUnits::formatHtmlWithCustomName(QString::fromStdString(assetData.name), QString::fromStdString(uniqueId), decimalPoint, rcp.assetAmount);
+
         if (model->isMultiwallet()) {
             amount.append(" <u>"+tr("from wallet %1").arg(GUIUtil::HtmlEscape(model->getWalletName()))+"</u> ");
         }
@@ -498,7 +498,7 @@ SendAssetsEntry *SendAssetsDialog::addEntry()
     connect(entry, SIGNAL(removeEntry(SendAssetsEntry*)), this, SLOT(removeEntry(SendAssetsEntry*)));
     connect(entry, SIGNAL(useAvailableAssetsBalance(SendAssetsEntry*)), this, SLOT(useAvailableAssetsBalance(SendAssetsEntry*)));
     connect(entry, SIGNAL(payAmountChanged()), this, SLOT(AssetControlUpdateLabels()));
-    
+
     // Focus the field, so that entry can start immediately
     entry->clear();
     entry->setFocus();
@@ -662,7 +662,7 @@ void SendAssetsDialog::processSendAssetsReturn(const WalletModel::SendAssetsRetu
         break;
     case WalletModel::AmountExceedsmaxmoney:
         msgParams.first = tr("The amount to pay exceeds the limit of 21 million per transaction.");
-        break;    
+        break;
     // included to prevent a compiler warning.
     case WalletModel::OK:
     default:

--- a/src/qt/sendassetsdialog.h
+++ b/src/qt/sendassetsdialog.h
@@ -1,0 +1,131 @@
+// Copyright (c) 2011-2015 The BitAsset Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITAsset_QT_SENDAssetSDIALOG_H
+#define BITAsset_QT_SENDAssetSDIALOG_H
+
+#include <qt/walletmodel.h>
+
+#include <QDialog>
+#include <QMessageBox>
+#include <QShowEvent>
+#include <QString>
+#include <QTimer>
+
+static const int MAX_SEND_ASSET_POPUP_ENTRIES = 10;
+
+class CCoinControl;
+class ClientModel;
+class SendAssetsEntry;
+class SendCoinsRecipient;
+
+namespace Ui {
+    class SendAssetsDialog;
+}
+
+QT_BEGIN_NAMESPACE
+class QUrl;
+QT_END_NAMESPACE
+
+/** Dialog for sending bitAssets */
+class SendAssetsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SendAssetsDialog( QWidget* parent = 0);
+    ~SendAssetsDialog();
+
+    void setClientModel(ClientModel *clientModel);
+    void setModel(WalletModel *model);
+
+    /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases (issue https://bugreports.qt-project.org/browse/QTBUG-10907).
+     */
+    QWidget *setupTabChain(QWidget *prev);
+
+    void setAddress(const QString &address);
+    void pasteEntry(const SendCoinsRecipient &rv);
+    bool handlePaymentRequest(const SendCoinsRecipient &recipient);
+    void OnDisplay();
+
+public Q_SLOTS:
+    void clear();
+    void reject();
+    void accept();
+    SendAssetsEntry *addEntry();
+    void updateTabsAndLabels();
+    void setBalance(const interfaces::WalletBalances& balances);
+    void updateAssetList();
+
+Q_SIGNALS:
+    void coinsSent(const uint256& txid);
+
+private:
+    Ui::SendAssetsDialog *ui;
+    ClientModel *clientModel;
+    WalletModel *model;
+    std::unique_ptr<CCoinControl> m_coin_control;
+    bool fNewRecipientAllowed;
+    void send(QList<SendCoinsRecipient> recipients);
+    bool fFeeMinimized;
+
+    // Process WalletModel::SendAssetsReturn and generate a pair consisting
+    // of a message and message flags for use in Q_EMIT message().
+    // Additional parameter msgArg can be used via .arg(msgArg).
+    void processSendAssetsReturn(const WalletModel::SendAssetsReturn &sendAssetsReturn, const QString &msgArg = QString());
+    void minimizeFeeSection(bool fMinimize);
+    void updateFeeMinimizedLabel();
+    // Update the passed in CCoinControl with state from the GUI
+    void updateAssetControlState(CCoinControl& ctrl);
+    
+private Q_SLOTS:
+    void on_sendButton_clicked();
+    void on_buttonChooseFee_clicked();
+    void on_buttonMinimizeFee_clicked();
+    void removeEntry(SendAssetsEntry* entry);
+    void useAvailableAssetsBalance(SendAssetsEntry* entry);
+    void updateDisplayUnit();
+    void AssetControlFeatureChanged(bool);
+    void AssetControlButtonClicked();
+    void AssetControlChangeChecked(int);
+    void AssetControlChangeEdited(const QString &);
+    void AssetControlUpdateLabels();
+    void AssetControlClipboardQuantity();
+    void AssetControlClipboardAmount();
+    void AssetControlClipboardFee();
+    void AssetControlClipboardAfterFee();
+    void AssetControlClipboardBytes();
+    void AssetControlClipboardLowOutput();
+    void AssetControlClipboardChange();
+    void setMinimumFee();
+    void updateFeeSectionControls();
+    void updateMinFeeLabel();
+    void updateSmartFeeLabel();
+    
+Q_SIGNALS:
+    // Fired when a message should be reported to the user
+    void message(const QString &title, const QString &message, unsigned int style);
+};
+
+
+
+class SendAssetConfirmationDialog : public QMessageBox
+{
+    Q_OBJECT
+
+public:
+    SendAssetConfirmationDialog(const QString &title, const QString &text, int secDelay = 0, QWidget *parent = 0);
+    int exec();
+
+private Q_SLOTS:
+    void countDown();
+    void updateYesButton();
+
+private:
+    QAbstractButton *yesButton;
+    QTimer countDownTimer;
+    int secDelay;
+};
+
+#endif // BITAsset_QT_SENDAssetSDIALOG_H

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -84,7 +84,7 @@ SendAssetsEntry::SendAssetsEntry(QWidget* parent, bool hideFuture) :
 
     proxyId = new QSortFilterProxyModel;
     proxyId->setSourceModel(stringModelId);
-    
+
     ui->uniqueIdList->setModel(proxyId);
     ui->uniqueIdList->setEditable(false);
 }
@@ -137,7 +137,7 @@ void SendAssetsEntry::setModel(WalletModel *_model)
 
 void SendAssetsEntry::setCoinControl(CCoinControl* coin_control)
 {
-  this->m_coin_control = coin_control;  
+  this->m_coin_control = coin_control;
 }
 
 void SendAssetsEntry::clear()
@@ -276,7 +276,7 @@ QWidget *SendAssetsEntry::setupTabChain(QWidget *prev)
 void SendAssetsEntry::setValue(const SendCoinsRecipient &value)
 {
     recipient = value;
-    
+
     // normal payment
     ui->payTo->setText(recipient.address);
     ui->addAsLabel->setText(recipient.label);
@@ -358,11 +358,11 @@ void SendAssetsEntry::SetFutureVisible(bool visible) {
 void SendAssetsEntry::onAssetSelected(QString name)
 {
     static QString prevname = "";
-    
+
     //return if name is empty
-    if (name == "") 
+    if (name == "")
         return;
-    
+
     std::map<std::string, CAmount> assetsbalance = model->wallet().getAssetsBalance();
     CAmount bal = 0;
     std::string assetId;
@@ -373,13 +373,13 @@ void SendAssetsEntry::onAssetSelected(QString name)
 
     //update balance
     ui->AssetBalance->setText(BitcoinUnits::formatWithCustomName(name, bal));
-   
+
     CAssetMetaData assetdata;
     if(!passetsCache->GetAssetMetaData(assetId, assetdata))
         return;
-    
-    if (assetdata.isunique){
-        
+
+    if (assetdata.isUnique){
+
         uniqueAssetSelected = true;
         ui->payAmount->setAssetsUnit(0);
         ui->payAmount->setValue(1);
@@ -389,7 +389,7 @@ void SendAssetsEntry::onAssetSelected(QString name)
         ui->amountLabel->setText("U&niqueId:");
 
         //make a copy of current selected uniqueId to restore after
-        //updating the list of uniquetId
+        //updating the list of uniqueId
         int index = ui->uniqueIdList->currentIndex();
         QString uniqueId = ui->uniqueIdList->currentText();
 
@@ -402,24 +402,24 @@ void SendAssetsEntry::onAssetSelected(QString name)
 
         stringModelId->setStringList(list);
 
-        //retore selected assetid
+        //restore selected assetId
         if (index >= 0 && name == prevname){
             index = ui->uniqueIdList->findText(uniqueId);
             ui->uniqueIdList->setCurrentIndex(index);
         } else {
             ui->uniqueIdList->setCurrentIndex(0);
-            ui->uniqueIdList->activated(0); 
+            ui->uniqueIdList->activated(0);
         }
     }else{
-        
+
         uniqueAssetSelected = false;
         ui->amountLabel->setText("A&mount:");
         ui->payAmount->setVisible(true);
         ui->useAvailableBalanceButton->setEnabled(true);
         ui->uniqueIdList->setVisible(false);
-    
+
         if (name != prevname){
-            ui->payAmount->setAssetsUnit(assetdata.Decimalpoint);
+            ui->payAmount->setAssetsUnit(assetdata.decimalPoint);
             ui->payAmount->setValue(0);
         }
     }
@@ -438,16 +438,16 @@ void SendAssetsEntry::updateAssetList()
 
     QStringList list;
     for (auto assetId : assets) {
-        CAssetMetaData assetdata;
-        if(passetsCache->GetAssetMetaData(assetId, assetdata)){
-            list << QString::fromStdString(assetdata.Name);
+        CAssetMetaData assetData;
+        if(passetsCache->GetAssetMetaData(assetId, assetData)){
+            list << QString::fromStdString(assetData.name);
         }
     }
 
     //update the list
     stringModel->setStringList(list);
-    
-    //retore selected asset
+
+    //restore selected asset
     if (index >= 0){
         index = ui->assetList->findText(name);
         ui->assetList->setCurrentIndex(index);

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -1,0 +1,463 @@
+// Copyright (c) 2011-2015 The BitAsset Core developers
+// Copyright (c) 2014-2020 The Dash Core developers
+// Copyright (c) 2020-2022 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/sendassetsentry.h>
+#include <qt/forms/ui_sendassetsentry.h>
+
+#include <qt/addressbookpage.h>
+#include <qt/addresstablemodel.h>
+#include <qt/guiutil.h>
+#include <qt/optionsmodel.h>
+#include <future/fee.h>
+#include <qt/bitcoinunits.h>
+#include <assets/assets.h>
+#include <assets/assetstype.h>
+#include <validation.h>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QString>
+#include <QStringListModel>
+#include <QSortFilterProxyModel>
+#include <QCompleter>
+#include <QLineEdit>
+
+SendAssetsEntry::SendAssetsEntry(QWidget* parent, bool hideFuture) :
+    QStackedWidget(parent),
+    ui(new Ui::SendAssetsEntry),
+    model(0)
+{
+    ui->setupUi(this);
+
+    GUIUtil::disableMacFocusRect(this);
+
+    setCurrentWidget(ui->SendAssets);
+
+    ui->addAsLabel->setPlaceholderText(tr("Enter a label for this address to add it to your address book"));
+
+    setButtonIcons();
+
+    // normal raptoreum address field
+    GUIUtil::setupAddressWidget(ui->payTo, this, true);
+
+    GUIUtil::setFont({ui->payToLabel,
+                     ui->Assetlabel,
+                     ui->labellLabel,
+                     ui->amountLabel,
+                     ui->maturityLb,
+                     ui->locktimeLb}, GUIUtil::FontWeight::Normal, 15);
+
+    GUIUtil::updateFonts();
+    this->futureToggleChanged();
+    ui->futureCb->setVisible(hideFuture);
+    ui->maturity->setValidator(new QIntValidator(-1, INT_MAX, this));
+    ui->locktime->setValidator(new QIntValidator(-1, INT_MAX, this));
+    // Connect signals
+    connect(ui->payAmount, SIGNAL(valueChanged()), this, SIGNAL(payAmountChanged()));
+    connect(ui->deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(ui->useAvailableBalanceButton, SIGNAL(clicked()), this, SLOT(useAvailableAssetsBalanceClicked()));
+    connect(ui->futureCb, SIGNAL(toggled(bool)), this, SLOT(futureToggleChanged()));
+
+    connect(ui->assetList, SIGNAL(currentIndexChanged(QString)), this, SLOT(onAssetSelected(QString)));
+
+    /** Setup the asset list combobox */
+    stringModel = new QStringListModel;
+
+    proxy = new QSortFilterProxyModel;
+    proxy->setSourceModel(stringModel);
+    proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+    ui->assetList->setModel(proxy);
+    ui->assetList->setEditable(true);
+    ui->assetList->lineEdit()->setPlaceholderText("Select an asset");
+
+    completer = new QCompleter(proxy,this);
+    completer->setCompletionMode(QCompleter::PopupCompletion);
+    completer->setCaseSensitivity(Qt::CaseInsensitive);
+    ui->assetList->setCompleter(completer);
+
+    //uniqueid selection
+    stringModelId = new QStringListModel;
+
+    proxyId = new QSortFilterProxyModel;
+    proxyId->setSourceModel(stringModelId);
+    
+    ui->uniqueIdList->setModel(proxyId);
+    ui->uniqueIdList->setEditable(false);
+}
+
+SendAssetsEntry::~SendAssetsEntry()
+{
+    delete ui;
+}
+
+void SendAssetsEntry::on_pasteButton_clicked()
+{
+    // Paste text from clipboard into recipient field
+    ui->payTo->setText(QApplication::clipboard()->text());
+}
+
+void SendAssetsEntry::on_addressBookButton_clicked()
+{
+    if(!model)
+        return;
+    AddressBookPage dlg(AddressBookPage::ForSelection, AddressBookPage::SendingTab, this);
+    dlg.setModel(model->getAddressTableModel());
+    if(dlg.exec())
+    {
+        ui->payTo->setText(dlg.getReturnValue());
+        ui->payAmount->setFocus();
+    }
+}
+
+void SendAssetsEntry::on_payTo_textChanged(const QString &address)
+{
+    SendCoinsRecipient rcp;
+    if (GUIUtil::parseBitcoinURI(address, &rcp)) {
+        ui->payTo->blockSignals(true);
+        setValue(rcp);
+        ui->payTo->blockSignals(false);
+    } else {
+        updateLabel(address);
+    }
+}
+
+void SendAssetsEntry::setModel(WalletModel *_model)
+{
+    this->model = _model;
+
+    if (_model && _model->getOptionsModel())
+        connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+
+    clear();
+}
+
+void SendAssetsEntry::setCoinControl(CCoinControl* coin_control)
+{
+  this->m_coin_control = coin_control;  
+}
+
+void SendAssetsEntry::clear()
+{
+    // clear UI elements for normal payment
+    ui->payTo->clear();
+    ui->addAsLabel->clear();
+    ui->payAmount->clear();
+    ui->maturity->setText("100");
+    ui->locktime->setText("100");
+    // update the display unit, to not use the default ("BTC")
+    updateDisplayUnit();
+}
+
+void SendAssetsEntry::futureToggleChanged() {
+    bool isFuture = ui->futureCb->isChecked();
+    if(isFuture) {
+        char feeDisplay[18];
+        sprintf(feeDisplay, "%d RTM", getFutureFees());
+        ui->feeDisplay->setText(feeDisplay);
+    }
+    ui->maturityLb->setVisible(isFuture);
+    ui->maturity->setVisible(isFuture);
+    ui->locktime->setVisible(isFuture);
+    ui->locktimeLb->setVisible(isFuture);
+    ui->feeDisplay->setVisible(isFuture);
+    ui->feeLb->setVisible(isFuture);
+}
+
+void SendAssetsEntry::deleteClicked()
+{
+    Q_EMIT removeEntry(this);
+}
+
+void SendAssetsEntry::useAvailableAssetsBalanceClicked()
+{
+    Q_EMIT useAvailableAssetsBalance(this);
+}
+
+bool SendAssetsEntry::validate(interfaces::Node& node)
+{
+    if (!model)
+        return false;
+
+    // Check input validity
+    bool retval = true;
+
+    // Skip checks for payment request
+    if (recipient.paymentRequest.IsInitialized())
+        return retval;
+
+    if (!model->validateAddress(ui->payTo->text()))
+    {
+        ui->payTo->setValid(false);
+        retval = false;
+    }
+
+    if (ui->assetList->currentIndex() == -1 )
+    {
+        retval = false;
+    }
+
+    if (uniqueAssetSelected && ui->assetList->currentIndex() == -1 )
+    {
+        retval = false;
+    }
+
+    if (!ui->payAmount->validate())
+    {
+        retval = false;
+    }
+
+    // Sending a zero amount is invalid
+    if (ui->payAmount->value(0) <= 0)
+    {
+        ui->payAmount->setValid(false);
+        retval = false;
+    }
+
+    std::string assetId;
+    passetsCache->GetAssetId(ui->assetList->currentText().toStdString(), assetId);
+    if (!validateAmount(assetId, ui->payAmount->value())){
+        ui->payAmount->setValid(false);
+        retval = false;
+    }
+
+    // Reject dust outputs:
+    if (retval && GUIUtil::isDust(node, ui->payTo->text(), ui->payAmount->value())) {
+        ui->payAmount->setValid(false);
+        retval = false;
+    }
+
+    return retval;
+}
+
+SendCoinsRecipient SendAssetsEntry::getValue()
+{
+    // Payment request
+    if (recipient.paymentRequest.IsInitialized())
+        return recipient;
+
+    // Normal payment
+    recipient.assetId = ui->assetList->currentText();
+    recipient.address = ui->payTo->text();
+    recipient.label = ui->addAsLabel->text();
+    CAmount amount = ui->payAmount->value();
+    recipient.amount = 0;
+    recipient.assetAmount = amount;
+    recipient.fSubtractFeeFromAmount = false;
+    if (uniqueAssetSelected)
+        recipient.uniqueId = ui->uniqueIdList->currentText().toInt();
+    else
+        recipient.uniqueId = MAX_UNIQUE_ID;
+    //std::cout << " ui->futureCb->isChecked() " << ui->futureCb->isChecked() << "\n";
+    if(ui->futureCb->isChecked()) {
+        recipient.isFutureOutput = true;
+        recipient.maturity = ui->maturity->text().isEmpty() ? -1 : std::stoi(ui->maturity->text().toStdString());
+        recipient.locktime = ui->locktime->text().isEmpty() ? -1 : std::stol(ui->locktime->text().toStdString());
+    } else {
+        recipient.isFutureOutput = false;
+        recipient.maturity = -1;
+        recipient.locktime = -1;
+    }
+    return recipient;
+}
+
+QWidget *SendAssetsEntry::setupTabChain(QWidget *prev)
+{
+    QWidget::setTabOrder(prev, ui->payTo);
+    QWidget::setTabOrder(ui->payTo, ui->addAsLabel);
+    QWidget::setTabOrder(ui->addressBookButton, ui->pasteButton);
+    QWidget::setTabOrder(ui->pasteButton, ui->deleteButton);
+    return ui->deleteButton;
+}
+
+void SendAssetsEntry::setValue(const SendCoinsRecipient &value)
+{
+    recipient = value;
+    
+    // normal payment
+    ui->payTo->setText(recipient.address);
+    ui->addAsLabel->setText(recipient.label);
+    ui->payAmount->setValue(recipient.amount);
+
+    updateLabel(recipient.address);
+}
+
+void SendAssetsEntry::setAddress(const QString &address)
+{
+    ui->payTo->setText(address);
+    ui->payAmount->setFocus();
+}
+
+void SendAssetsEntry::setAmount(const CAmount &amount)
+{
+    ui->payAmount->setValue(amount);
+}
+
+bool SendAssetsEntry::isClear()
+{
+    return ui->payTo->text().isEmpty();
+}
+
+void SendAssetsEntry::setFocus()
+{
+    ui->payTo->setFocus();
+}
+
+void SendAssetsEntry::updateDisplayUnit()
+{
+    if(model && model->getOptionsModel())
+    {
+        // Update payAmount with the current unit
+        ui->payAmount->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
+    }
+}
+
+void SendAssetsEntry::changeEvent(QEvent* e)
+{
+    QStackedWidget::changeEvent(e);
+    if (e->type() == QEvent::StyleChange) {
+        // Adjust button icon colors on theme changes
+        setButtonIcons();
+    }
+}
+
+void SendAssetsEntry::setButtonIcons()
+{
+    GUIUtil::setIcon(ui->addressBookButton, "address-book");
+    GUIUtil::setIcon(ui->pasteButton, "editpaste");
+    GUIUtil::setIcon(ui->deleteButton, "remove", GUIUtil::ThemedColor::RED);
+}
+
+bool SendAssetsEntry::updateLabel(const QString &address)
+{
+    if(!model)
+        return false;
+
+    // Fill in label from address book, if address has an associated label
+    QString associatedLabel = model->getAddressTableModel()->labelForAddress(address);
+    if(!associatedLabel.isEmpty())
+    {
+        ui->addAsLabel->setText(associatedLabel);
+        return true;
+    }
+
+    return false;
+}
+
+void SendAssetsEntry::SetFutureVisible(bool visible) {
+    if(!visible) {
+        ui->futureCb->setChecked(false);
+    }
+    futureToggleChanged();
+    ui->futureCb->setVisible(visible);
+}
+
+void SendAssetsEntry::onAssetSelected(QString name)
+{
+    static QString prevname = "";
+    
+    //return if name is empty
+    if (name == "") 
+        return;
+    
+    std::map<std::string, CAmount> assetsbalance = model->wallet().getAssetsBalance();
+    CAmount bal = 0;
+    std::string assetId;
+    if (passetsCache->GetAssetId(name.toStdString(), assetId)){
+    if (assetsbalance.count(assetId))
+        bal = assetsbalance[assetId];
+    }
+
+    //update balance
+    ui->AssetBalance->setText(BitcoinUnits::formatWithCustomName(name, bal));
+   
+    CAssetMetaData assetdata;
+    if(!passetsCache->GetAssetMetaData(assetId, assetdata))
+        return;
+    
+    if (assetdata.isunique){
+        
+        uniqueAssetSelected = true;
+        ui->payAmount->setAssetsUnit(0);
+        ui->payAmount->setValue(1);
+        ui->payAmount->setVisible(false);
+        ui->useAvailableBalanceButton->setEnabled(false);
+        ui->uniqueIdList->setVisible(true);
+        ui->amountLabel->setText("U&niqueId:");
+
+        //make a copy of current selected uniqueId to restore after
+        //updating the list of uniquetId
+        int index = ui->uniqueIdList->currentIndex();
+        QString uniqueId = ui->uniqueIdList->currentText();
+
+        //update the unique list
+        std::vector<uint16_t> assetsIds = model->wallet().listAssetUniqueId(assetId, m_coin_control);
+        QStringList list;
+        for (auto uniqueid : assetsIds) {
+            list << QString::number(uniqueid);
+        }
+
+        stringModelId->setStringList(list);
+
+        //retore selected assetid
+        if (index >= 0 && name == prevname){
+            index = ui->uniqueIdList->findText(uniqueId);
+            ui->uniqueIdList->setCurrentIndex(index);
+        } else {
+            ui->uniqueIdList->setCurrentIndex(0);
+            ui->uniqueIdList->activated(0); 
+        }
+    }else{
+        
+        uniqueAssetSelected = false;
+        ui->amountLabel->setText("A&mount:");
+        ui->payAmount->setVisible(true);
+        ui->useAvailableBalanceButton->setEnabled(true);
+        ui->uniqueIdList->setVisible(false);
+    
+        if (name != prevname){
+            ui->payAmount->setAssetsUnit(assetdata.Decimalpoint);
+            ui->payAmount->setValue(0);
+        }
+    }
+    prevname = name;
+}
+
+void SendAssetsEntry::updateAssetList()
+{
+    //make a copy of current selected asset to restore selection after
+    //updating the list of available assets
+    int index = ui->assetList->currentIndex();
+    QString name = ui->assetList->currentText();
+
+    // Get available assets list
+    std::vector<std::string> assets = model->wallet().listMyAssets(m_coin_control);
+
+    QStringList list;
+    for (auto assetId : assets) {
+        CAssetMetaData assetdata;
+        if(passetsCache->GetAssetMetaData(assetId, assetdata)){
+            list << QString::fromStdString(assetdata.Name);
+        }
+    }
+
+    //update the list
+    stringModel->setStringList(list);
+    
+    //retore selected asset
+    if (index >= 0){
+        index = ui->assetList->findText(name);
+        ui->assetList->setCurrentIndex(index);
+    } else {
+        ui->AssetBalance->setText(tr("Select an asset to see the balance"));
+        ui->assetList->lineEdit()->setPlaceholderText(tr("Select an asset to transfer"));
+        ui->payAmount->clear();
+        ui->payAmount->setAssetsUnit(MAX_ASSET_UNITS);
+        //hide unique list
+        ui->uniqueIdList->setVisible(false);
+        ui->assetList->setFocus();
+    }
+}

--- a/src/qt/sendassetsentry.h
+++ b/src/qt/sendassetsentry.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2011-2015 The BitAsset Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITAsset_QT_SENDAssetSENTRY_H
+#define BITAsset_QT_SENDAssetSENTRY_H
+
+#include <qt/walletmodel.h>
+
+#include <QStackedWidget>
+
+class WalletModel;
+class QStringListModel;
+class QSortFilterProxyModel;
+class QCompleter;
+
+namespace Ui {
+    class SendAssetsEntry;
+}
+
+/**
+ * A single entry in the dialog for sending bitAssets.
+ * Stacked widget, with different UIs for payment requests
+ * with a strong payee identity.
+ */
+class SendAssetsEntry : public QStackedWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SendAssetsEntry(QWidget* parent = 0, bool hideFuture = false);
+    ~SendAssetsEntry();
+
+    void setModel(WalletModel *model);
+    void setCoinControl(CCoinControl* coin_control);
+    bool validate(interfaces::Node& node);
+    SendCoinsRecipient getValue();
+
+    /** Return whether the entry is still empty and unedited */
+    bool isClear();
+
+    void setValue(const SendCoinsRecipient &value);
+    void setAddress(const QString &address);
+    void setAmount(const CAmount &amount);
+    void SetFutureVisible(const bool visible);
+
+    //update the list of assets
+    void updateAssetList();
+
+    /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases
+     *  (issue https://bugreports.qt-project.org/browse/QTBUG-10907).
+     */
+    QWidget *setupTabChain(QWidget *prev);
+
+    void setFocus();
+
+public Q_SLOTS:
+    void clear();
+
+Q_SIGNALS:
+    void removeEntry(SendAssetsEntry *entry);
+    void useAvailableAssetsBalance(SendAssetsEntry* entry);
+    void payAmountChanged();
+
+private Q_SLOTS:
+    void deleteClicked();
+    void useAvailableAssetsBalanceClicked();
+    void on_payTo_textChanged(const QString &address);
+    void on_addressBookButton_clicked();
+    void on_pasteButton_clicked();
+    void updateDisplayUnit();
+    void futureToggleChanged();
+    void onAssetSelected(QString name);
+    
+protected:
+    void changeEvent(QEvent* e);
+
+private:
+    SendCoinsRecipient recipient;
+    Ui::SendAssetsEntry *ui;
+    WalletModel *model;
+    CCoinControl* m_coin_control;
+    bool uniqueAssetSelected;
+
+    QStringListModel* stringModel;
+    QSortFilterProxyModel* proxy;
+    QCompleter* completer;
+
+    QStringListModel* stringModelId;
+    QSortFilterProxyModel* proxyId;
+
+    /** Set required icons for buttons inside the dialog */
+    void setButtonIcons();
+    bool updateLabel(const QString &address);
+};
+
+#endif // BITAsset_QT_SENDAssetSENTRY_H

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -33,25 +33,6 @@
 
 #define SEND_CONFIRM_DELAY   3
 
-static const std::array<int, 9> confTargets = { {2, 4, 6, 12, 24, 48, 144, 504, 1008} };
-int getConfTargetForIndex(int index) {
-    if (index+1 > static_cast<int>(confTargets.size())) {
-        return confTargets.back();
-    }
-    if (index < 0) {
-        return confTargets[0];
-    }
-    return confTargets[index];
-}
-int getIndexForConfTarget(int target) {
-    for (unsigned int i = 0; i < confTargets.size(); i++) {
-        if (confTargets[i] >= target) {
-            return i;
-        }
-    }
-    return confTargets.size() - 1;
-}
-
 SendCoinsDialog::SendCoinsDialog(bool _fCoinJoin, QWidget* parent) :
     QDialog(parent),
     ui(new Ui::SendCoinsDialog),

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -159,6 +159,13 @@ void WalletFrame::gotoSendCoinsPage(QString addr)
         i.value()->gotoSendCoinsPage(addr);
 }
 
+void WalletFrame::gotoSendAssetsPage(QString addr)
+{
+    QMap<QString, WalletView*>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->gotoSendAssetsPage(addr);
+}
+
 void WalletFrame::gotoCoinJoinCoinsPage(QString addr)
 {
     QMap<QString, WalletView*>::const_iterator i;

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -72,6 +72,8 @@ public Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    /** Switch to send coins page */
+    void gotoSendAssetsPage(QString addr = "");
     /** Switch to CoinJoin coins page */
     void gotoCoinJoinCoinsPage(QString addr = "");
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -56,9 +56,12 @@ public:
     // Info: As we don't need to process addresses in here when using
     // payment requests, we can abuse it for displaying an address list.
     // Todo: This is a hack, should be replaced with a cleaner solution!
+    QString assetId;
+    int uniqueId;
     QString address;
     QString label;
     CAmount amount;
+    CAmount assetAmount;
     // If from a payment request, this is used for storing the memo
     QString message;
 
@@ -247,6 +250,24 @@ public:
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction, bool fIsCoinJoin);
 
+    // Return status record for SendAssets, contains error id + information
+    struct SendAssetsReturn
+    {
+        SendAssetsReturn(StatusCode _status = OK, QString _reasonCommitFailed = "")
+            : status(_status),
+              reasonCommitFailed(_reasonCommitFailed)
+        {
+        }
+        StatusCode status;
+        QString reasonCommitFailed;
+    };
+
+    // prepare transaction for getting txfee before sending coins
+    SendAssetsReturn prepareAssetTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl);
+
+    // Send coins to a list of recipients
+    SendAssetsReturn sendAssets(WalletModelTransaction &transaction, bool fIsCoinJoin);
+
     // Wallet encryption
     bool setWalletEncrypted(bool encrypted, const SecureString &passphrase);
 
@@ -366,6 +387,7 @@ Q_SIGNALS:
     // Watch-only address added
     void notifyWatchonlyChanged(bool fHaveWatchonly);
 
+    void assetListChanged();
     // Signal that wallet is about to be removed
     void unload();
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -273,6 +273,13 @@ void WalletView::gotoSendCoinsPage(QString addr)
 
 void WalletView::gotoSendAssetsPage(QString addr)
 {
+    static bool fFirstVisit = true;
+
+    if (fFirstVisit){
+        fFirstVisit = false;
+        sendAssetsPage->updateAssetList();
+    }
+    
     setCurrentWidget(sendAssetsPage);
     sendAssetsPage->OnDisplay();
     if (!addr.isEmpty()) {

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -13,6 +13,7 @@
 #include <qt/overviewpage.h>
 #include <qt/receivecoinsdialog.h>
 #include <qt/sendcoinsdialog.h>
+#include <qt/sendassetsdialog.h>
 #include <qt/signverifymessagedialog.h>
 #include <qt/transactionrecord.h>
 #include <qt/transactiontablemodel.h>
@@ -73,6 +74,7 @@ WalletView::WalletView(QWidget* parent) :
 
     receiveCoinsPage = new ReceiveCoinsDialog();
     sendCoinsPage = new SendCoinsDialog();
+    sendAssetsPage = new SendAssetsDialog();
     coinJoinCoinsPage = new SendCoinsDialog(true);
 
     usedSendingAddressesPage = new AddressBookPage(AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
@@ -83,7 +85,8 @@ WalletView::WalletView(QWidget* parent) :
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
     addWidget(coinJoinCoinsPage);
-
+    addWidget(sendAssetsPage);
+    
     QSettings settings;
     if (settings.value("fShowSmartnodesTab").toBool()) {
         smartnodeListPage = new SmartnodeList();
@@ -96,6 +99,7 @@ WalletView::WalletView(QWidget* parent) :
 
     // Highlight transaction after send
     connect(sendCoinsPage, SIGNAL(coinsSent(uint256)), transactionView, SLOT(focusTransaction(uint256)));
+    connect(sendAssetsPage, SIGNAL(coinsSent(uint256)), transactionView, SLOT(focusTransaction(uint256)));
     connect(coinJoinCoinsPage, SIGNAL(coinsSent(uint256)), transactionView, SLOT(focusTransaction(uint256)));
 
     // Double-clicking on a transaction on the transaction history page shows details
@@ -109,6 +113,7 @@ WalletView::WalletView(QWidget* parent) :
 
     // Pass through messages from SendCoinsDialog
     connect(sendCoinsPage, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
+    connect(sendAssetsPage, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
     connect(coinJoinCoinsPage, SIGNAL(message(QString, QString, unsigned int)), this, SIGNAL(message(QString, QString, unsigned int)));
 
     // Pass through messages from transactionView
@@ -130,6 +135,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
 
         // Navigate to transaction history page after send
         connect(sendCoinsPage, SIGNAL(coinsSent(uint256)), gui, SLOT(gotoHistoryPage()));
+        connect(sendAssetsPage, SIGNAL(coinsSent(uint256)), gui, SLOT(gotoHistoryPage()));
         connect(coinJoinCoinsPage, SIGNAL(coinsSent(uint256)), gui, SLOT(gotoHistoryPage()));
 
         // Receive and report messages
@@ -152,6 +158,7 @@ void WalletView::setClientModel(ClientModel *_clientModel)
 
     overviewPage->setClientModel(_clientModel);
     sendCoinsPage->setClientModel(_clientModel);
+    sendAssetsPage->setClientModel(_clientModel);
     coinJoinCoinsPage->setClientModel(_clientModel);
     QSettings settings;
     if (settings.value("fShowSmartnodesTab").toBool()) {
@@ -172,6 +179,7 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
     }
     receiveCoinsPage->setModel(_walletModel);
     sendCoinsPage->setModel(_walletModel);
+    sendAssetsPage->setModel(_walletModel);
     coinJoinCoinsPage->setModel(_walletModel);
     usedReceivingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
     usedSendingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
@@ -227,6 +235,8 @@ void WalletView::processNewTransaction(const QModelIndex& parent, int start, int
     QString label = ttm->data(index, TransactionTableModel::LabelRole).toString();
 
     Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address, label, walletModel->getWalletName());
+    
+    sendAssetsPage->updateAssetList();
 }
 
 void WalletView::gotoOverviewPage()
@@ -258,6 +268,15 @@ void WalletView::gotoSendCoinsPage(QString addr)
     sendCoinsPage->OnDisplay();
     if (!addr.isEmpty()) {
         sendCoinsPage->setAddress(addr);
+    }
+}
+
+void WalletView::gotoSendAssetsPage(QString addr)
+{
+    setCurrentWidget(sendAssetsPage);
+    sendAssetsPage->OnDisplay();
+    if (!addr.isEmpty()) {
+        sendAssetsPage->setAddress(addr);
     }
 }
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -15,6 +15,7 @@ class ClientModel;
 class OverviewPage;
 class ReceiveCoinsDialog;
 class SendCoinsDialog;
+class SendAssetsDialog;
 class SendCoinsRecipient;
 class TransactionView;
 class WalletModel;
@@ -64,6 +65,7 @@ private:
     QWidget *transactionsPage;
     ReceiveCoinsDialog *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
+    SendAssetsDialog *sendAssetsPage;
     SendCoinsDialog* coinJoinCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
@@ -85,6 +87,8 @@ public Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    /** Switch to send assets page */
+    void gotoSendAssetsPage(QString addr = "");
     /** Switch to CoinJoin coins page */
     void gotoCoinJoinCoinsPage(QString addr = "");
 

--- a/src/test/assets_tests.cpp
+++ b/src/test/assets_tests.cpp
@@ -97,27 +97,27 @@ static void SignTransaction(CMutableTransaction& tx, const CKey& coinbaseKey)
 static CMutableTransaction CreateNewAssetTx(SimpleUTXOMap& utxos, const CKey& coinbaseKey, std::string name, bool updatable, bool is_unique, uint8_t type, uint8_t decimalPoint, CAmount amount)
 {
     CKeyID ownerKey = coinbaseKey.GetPubKey().GetID();
-    CNewAssetTx newasset;
+    CNewAssetTx newAsset;
 
-    newasset.Name = name;
-    newasset.updatable = updatable;
-    newasset.isUnique = is_unique;
-    newasset.decimalPoint = decimalPoint;
-    newasset.referenceHash = "";
-    newasset.type = type;
-    newasset.maxMintCount = 10;
-    newasset.fee = getAssetsFees();
-    newasset.targetAddress = ownerKey;
-    newasset.ownerAddress = ownerKey;
-    newasset.Amount = amount * COIN;
-    //newasset.collateralAddress = CKey();
+    newAsset.name = name;
+    newAsset.updatable = updatable;
+    newAsset.isUnique = is_unique;
+    newAsset.decimalPoint = decimalPoint;
+    newAsset.referenceHash = "";
+    newAsset.type = type;
+    newAsset.maxMintCount = 10;
+    newAsset.fee = getAssetsFees();
+    newAsset.targetAddress = ownerKey;
+    newAsset.ownerAddress = ownerKey;
+    newAsset.amount = amount * COIN;
+    //newAsset.collateralAddress = CKey();
 
     CMutableTransaction tx;
     tx.nVersion = 3;
     tx.nType = TRANSACTION_NEW_ASSET;
-    FundTransaction(tx, utxos, GetScriptForDestination(coinbaseKey.GetPubKey().GetID()), newasset.fee * COIN + 1 * COIN, coinbaseKey);
-    newasset.inputsHash = CalcTxInputsHash(tx);
-    SetTxPayload(tx, newasset);
+    FundTransaction(tx, utxos, GetScriptForDestination(coinbaseKey.GetPubKey().GetID()), newAsset.fee * COIN + 1 * COIN, coinbaseKey);
+    newAsset.inputsHash = CalcTxInputsHash(tx);
+    SetTxPayload(tx, newAsset);
     SignTransaction(tx, coinbaseKey);
 
     return tx;
@@ -126,28 +126,28 @@ static CMutableTransaction CreateNewAssetTx(SimpleUTXOMap& utxos, const CKey& co
 static CMutableTransaction CreateUpdateAssetTx(SimpleUTXOMap& utxos, const CKey& coinbaseKey, const CKey& newowner, std::string assetId, bool updatable, uint8_t type, CAmount amount)
 {
     CKeyID ownerKey = newowner.GetPubKey().GetID();
-    CUpdateAssetTx upasset;
+    CUpdateAssetTx upAsset;
 
     CAssetMetaData asset;
     passetsCache->GetAssetMetaData(assetId, asset);
-    
-    upasset.AssetId = assetId;
-    upasset.updatable = updatable;
-    upasset.referenceHash = "";
-    upasset.fee = getAssetsFees();
-    upasset.type = type;
-    upasset.targetAddress = asset.targetAddress;
-    upasset.issueFrequency = asset.issueFrequency;
-    upasset.Amount = amount * COIN;
-    upasset.ownerAddress = ownerKey;
-    upasset.collateralAddress = asset.collateralAddress;
-    
+
+    upAsset.assetId = assetId;
+    upAsset.updatable = updatable;
+    upAsset.referenceHash = "";
+    upAsset.fee = getAssetsFees();
+    upAsset.type = type;
+    upAsset.targetAddress = asset.targetAddress;
+    upAsset.issueFrequency = asset.issueFrequency;
+    upAsset.amount = amount * COIN;
+    upAsset.ownerAddress = ownerKey;
+    upAsset.collateralAddress = asset.collateralAddress;
+
     CMutableTransaction tx;
     tx.nVersion = 3;
     tx.nType = TRANSACTION_UPDATE_ASSET;
-    FundTransaction(tx, utxos, GetScriptForDestination(coinbaseKey.GetPubKey().GetID()), upasset.fee * COIN + 1 * COIN, coinbaseKey);
-    upasset.inputsHash = CalcTxInputsHash(tx);
-    SetTxPayload(tx, upasset);
+    FundTransaction(tx, utxos, GetScriptForDestination(coinbaseKey.GetPubKey().GetID()), upAsset.fee * COIN + 1 * COIN, coinbaseKey);
+    upAsset.inputsHash = CalcTxInputsHash(tx);
+    SetTxPayload(tx, upAsset);
     SignTransaction(tx, coinbaseKey);
 
     return tx;
@@ -160,30 +160,30 @@ static CMutableTransaction CreateMintAssetTx(SimpleUTXOMap& utxos, const CKey& c
 
     CAssetMetaData asset;
     passetsCache->GetAssetMetaData(assetId, asset);
-    
-    mint.AssetId = assetId;
+
+    mint.assetId = assetId;
     mint.fee = getAssetsFees();
-    
+
     CMutableTransaction tx;
     tx.nVersion = 3;
     tx.nType = TRANSACTION_MINT_ASSET;
 
-    
-    if (asset.isunique){
-        int endid = (asset.circulatingSupply + asset.Amount) / COIN;
-        for ( int id = asset.circulatingSupply / COIN; id < endid; ++id){
+
+    if (asset.isUnique) {
+        int endId = (asset.circulatingSupply + asset.amount) / COIN;
+        for (int id = asset.circulatingSupply / COIN; id < endId; ++id) {
             CScript scriptPubKey = GetScriptForDestination(asset.targetAddress);
-            CAssetTransfer assetTransfer(asset.assetId, 1 * COIN , id);
+            CAssetTransfer assetTransfer(asset.assetId, 1 * COIN, id);
             assetTransfer.BuildAssetTransaction(scriptPubKey);
-            CTxOut out(0 , scriptPubKey);
+            CTxOut out(0, scriptPubKey);
             tx.vout.push_back(out);
         }
     } else {
         CScript scriptPubKey = GetScriptForDestination(asset.targetAddress);
-        CAssetTransfer assetTransfer(assetId, asset.Amount);
+        CAssetTransfer assetTransfer(assetId, asset.amount);
         assetTransfer.BuildAssetTransaction(scriptPubKey);
-        CTxOut out(0 , scriptPubKey);
-        tx.vout.push_back(out);   
+        CTxOut out(0, scriptPubKey);
+        tx.vout.push_back(out);
     }
 
     FundTransaction(tx, utxos, GetScriptForDestination(coinbaseKey.GetPubKey().GetID()), mint.fee * COIN + 1 * COIN, coinbaseKey);
@@ -225,7 +225,7 @@ BOOST_FIXTURE_TEST_CASE(assets_creation, TestChainDIP3BeforeActivationSetup)
 
     BOOST_ASSERT(chainActive.Height() == nHeight + 1);
     BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
-    
+
     //invalid asset name
     tx = CreateNewAssetTx(utxos, coinbaseKey,"*Test_Asset*", true, false, 0, 8, 1000);
     txns = {tx};
@@ -281,8 +281,8 @@ BOOST_FIXTURE_TEST_CASE(assets_update, TestChainDIP3BeforeActivationSetup)
     //change asset owner
     CKey key;
     key.MakeNewKey(false);
-    std::string assetid = tx.GetHash().ToString();
-    tx = CreateUpdateAssetTx(utxos, coinbaseKey, key, assetid, true, 0, 1000);
+    std::string assetId = tx.GetHash().ToString();
+    tx = CreateUpdateAssetTx(utxos, coinbaseKey, key, assetId, true, 0, 1000);
     {
         auto block = std::make_shared<CBlock>(CreateBlock({tx}, coinbaseKey));
         ProcessNewBlock(Params(), block, true, nullptr);
@@ -291,11 +291,11 @@ BOOST_FIXTURE_TEST_CASE(assets_update, TestChainDIP3BeforeActivationSetup)
         BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
     }
 
-    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetid, asset));
+    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetId, asset));
     BOOST_ASSERT(asset.ownerAddress == key.GetPubKey().GetID());
 
     //any atemp to update with the coinbaseKey should fail
-    tx = CreateUpdateAssetTx(utxos, coinbaseKey, coinbaseKey, assetid, true, 0, 10000);
+    tx = CreateUpdateAssetTx(utxos, coinbaseKey, coinbaseKey, assetId, true, 0, 10000);
     {
         auto block = std::make_shared<CBlock>(CreateBlock({tx}, coinbaseKey));
         ProcessNewBlock(Params(), block, true, nullptr);
@@ -328,9 +328,9 @@ BOOST_FIXTURE_TEST_CASE(assets_mint, TestChainDIP3BeforeActivationSetup)
         BOOST_ASSERT(chainActive.Height() == nHeight + 1);
         BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
     }
-    
-    std::string assetid = tx.GetHash().ToString();
-    tx = CreateMintAssetTx(utxos, coinbaseKey, assetid);
+
+    std::string assetId = tx.GetHash().ToString();
+    tx = CreateMintAssetTx(utxos, coinbaseKey, assetId);
 
     {
         auto block = std::make_shared<CBlock>(CreateBlock({tx}, coinbaseKey));
@@ -341,8 +341,8 @@ BOOST_FIXTURE_TEST_CASE(assets_mint, TestChainDIP3BeforeActivationSetup)
     }
 
     CAssetMetaData asset;
-    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetid, asset));
-    
+    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetId, asset));
+
     BOOST_ASSERT(asset.circulatingSupply == 1000 * COIN);
 
     //transfer asset
@@ -351,14 +351,14 @@ BOOST_FIXTURE_TEST_CASE(assets_mint, TestChainDIP3BeforeActivationSetup)
     CKey key;
     key.MakeNewKey(false);
     CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-    CAssetTransfer assetTransfer(assetid, 100 * COIN);
+    CAssetTransfer assetTransfer(assetId, 100 * COIN);
     assetTransfer.BuildAssetTransaction(scriptPubKey);
     CTxOut out(0 , scriptPubKey);
     tx2.vout.push_back(out);
 
     //change
     CScript scriptPubKey2 = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
-    CAssetTransfer assetTransfer2(assetid, 900 * COIN);
+    CAssetTransfer assetTransfer2(assetId, 900 * COIN);
     assetTransfer2.BuildAssetTransaction(scriptPubKey2);
     CTxOut out2(0 , scriptPubKey2);
     tx2.vout.push_back(out2);
@@ -402,9 +402,9 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
     }
 
-    std::string assetid = tx.GetHash().ToString();
+    std::string assetId = tx.GetHash().ToString();
 
-    tx = CreateMintAssetTx(utxos, coinbaseKey, assetid);
+    tx = CreateMintAssetTx(utxos, coinbaseKey, assetId);
 
     {
         auto block = std::make_shared<CBlock>(CreateBlock({tx}, coinbaseKey));
@@ -413,10 +413,10 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         BOOST_ASSERT(chainActive.Height() == nHeight + 2);
         BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
     }
-    
+
     CAssetMetaData asset;
-    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetid, asset));
-    
+    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetId, asset));
+
     BOOST_ASSERT(asset.circulatingSupply == 100 * COIN);
 
     {
@@ -426,13 +426,13 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         CKey key;
         key.MakeNewKey(false);
         CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer(assetid, 12.1234 * COIN);
+        CAssetTransfer assetTransfer(assetId, 12.1234 * COIN);
         assetTransfer.BuildAssetTransaction(scriptPubKey);
         CTxOut out(0 , scriptPubKey);
         tx2.vout.push_back(out);
         //change
         CScript scriptPubKey2 = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
-        CAssetTransfer assetTransfer2(assetid, 87.8766 * COIN);
+        CAssetTransfer assetTransfer2(assetId, 87.8766 * COIN);
         assetTransfer2.BuildAssetTransaction(scriptPubKey2);
         CTxOut out2(0 , scriptPubKey2);
         tx2.vout.push_back(out2);
@@ -456,13 +456,13 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         CKey key;
         key.MakeNewKey(false);
         CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer(assetid, 12.12 * COIN);
+        CAssetTransfer assetTransfer(assetId, 12.12 * COIN);
         assetTransfer.BuildAssetTransaction(scriptPubKey);
         CTxOut out(0 , scriptPubKey);
         tx2.vout.push_back(out);
         //change
         CScript scriptPubKey2 = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
-        CAssetTransfer assetTransfer2(assetid, 88.88 * COIN);
+        CAssetTransfer assetTransfer2(assetId, 88.88 * COIN);
         assetTransfer2.BuildAssetTransaction(scriptPubKey2);
         CTxOut out2(0 , scriptPubKey2);
         tx2.vout.push_back(out2);
@@ -486,13 +486,13 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         CKey key;
         key.MakeNewKey(false);
         CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer(assetid, 12.12 * COIN);
+        CAssetTransfer assetTransfer(assetId, 12.12 * COIN);
         assetTransfer.BuildAssetTransaction(scriptPubKey);
         CTxOut out(1 * COIN , scriptPubKey);
         tx2.vout.push_back(out);
         //change
         CScript scriptPubKey2 = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
-        CAssetTransfer assetTransfer2(assetid, 87.88 * COIN);
+        CAssetTransfer assetTransfer2(assetId, 87.88 * COIN);
         assetTransfer2.BuildAssetTransaction(scriptPubKey2);
         CTxOut out2(0 , scriptPubKey2);
         tx2.vout.push_back(out2);
@@ -523,9 +523,9 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         BOOST_ASSERT(chainActive.Height() == nHeight + 1);
         BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
     }
-    
-    assetid = tx.GetHash().ToString();
-    tx = CreateMintAssetTx(utxos, coinbaseKey, assetid);
+
+    assetId = tx.GetHash().ToString();
+    tx = CreateMintAssetTx(utxos, coinbaseKey, assetId);
 
     {
         auto block = std::make_shared<CBlock>(CreateBlock({tx}, coinbaseKey));
@@ -535,8 +535,8 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
     }
 
-    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetid, asset));
-    
+    BOOST_ASSERT(passetsCache->GetAssetMetaData(assetId, asset));
+
     BOOST_ASSERT(asset.circulatingSupply == 10 * COIN);
 
     {
@@ -546,7 +546,7 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         CKey key;
         key.MakeNewKey(false);
         CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer(assetid, 1 * COIN, 8);
+        CAssetTransfer assetTransfer(assetId, 1 * COIN, 8);
         assetTransfer.BuildAssetTransaction(scriptPubKey);
         CTxOut out(0 , scriptPubKey);
         tx2.vout.push_back(out);
@@ -570,7 +570,7 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         CKey key;
         key.MakeNewKey(false);
         CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer(assetid, 1 * COIN, 0);
+        CAssetTransfer assetTransfer(assetId, 1 * COIN, 0);
         assetTransfer.BuildAssetTransaction(scriptPubKey);
         CTxOut out(0 , scriptPubKey);
         tx2.vout.push_back(out);
@@ -595,19 +595,19 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         CKey key;
         key.MakeNewKey(false);
         CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer(assetid, 1 * COIN, 0);//uniqueId=0
+        CAssetTransfer assetTransfer(assetId, 1 * COIN, 0);//uniqueId=0
         assetTransfer.BuildAssetTransaction(scriptPubKey);
         CTxOut out(0 , scriptPubKey);
         tx2.vout.push_back(out);
 
         CScript scriptPubKey2 = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer2(assetid, 1 * COIN, 1);////uniqueId=1
+        CAssetTransfer assetTransfer2(assetId, 1 * COIN, 1);////uniqueId=1
         assetTransfer.BuildAssetTransaction(scriptPubKey2);
         CTxOut out2(0 , scriptPubKey2);
         tx2.vout.push_back(out2);
 
         tx2.vin.push_back(CTxIn(COutPoint(tx.GetHash(), 0)));//uniqueId=0
- 
+
 
         FundTransaction(tx2, utxos, GetScriptForDestination(coinbaseKey.GetPubKey().GetID()),1 * COIN, coinbaseKey);
         SignTransaction(tx2, coinbaseKey);
@@ -626,7 +626,7 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         CKey key;
         key.MakeNewKey(false);
         CScript scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        CAssetTransfer assetTransfer(assetid, 1 * COIN, 0);
+        CAssetTransfer assetTransfer(assetId, 1 * COIN, 0);
         assetTransfer.BuildAssetTransaction(scriptPubKey);
         CTxOut out(1 , scriptPubKey);
         tx2.vout.push_back(out);
@@ -636,7 +636,7 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
         FundTransaction(tx2, utxos, GetScriptForDestination(coinbaseKey.GetPubKey().GetID()),1 * COIN, coinbaseKey);
         SignTransaction(tx2, coinbaseKey);
 
-    
+
         auto block = std::make_shared<CBlock>(CreateBlock({tx2}, coinbaseKey));
         ProcessNewBlock(Params(), block, true, nullptr);
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -462,17 +462,17 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         CNewAssetTx assetTx;
         bool ok = GetTxPayload(tx, assetTx);
         assert(ok);
-        mapAssetsToHash.emplace(assetTx.Name, tx.GetHash());
+        mapAssetsToHash.emplace(assetTx.name, tx.GetHash());
     } else if (tx.nType == TRANSACTION_UPDATE_ASSET) {
         CUpdateAssetTx assetTx;
         bool ok = GetTxPayload(tx, assetTx);
         assert(ok);
-        mapAssetsIdToHash.emplace(assetTx.AssetId, tx.GetHash());
+        mapAssetsIdToHash.emplace(assetTx.assetId, tx.GetHash());
     } else if (tx.nType == TRANSACTION_MINT_ASSET) {
         CMintAssetTx assetTx;
         bool ok = GetTxPayload(tx, assetTx);
         assert(ok);
-        mapAssetsIdToHash.emplace(assetTx.AssetId, tx.GetHash());
+        mapAssetsIdToHash.emplace(assetTx.assetId, tx.GetHash());
     }
 
     return true;
@@ -766,19 +766,19 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         if (!GetTxPayload(it->GetTx(), assetTx)) {
             assert(false);
         }
-        mapAssetsToHash.erase(assetTx.Name);
+        mapAssetsToHash.erase(assetTx.name);
     } else if (it->GetTx().nType == TRANSACTION_UPDATE_ASSET) {
         CUpdateAssetTx assetTx;
         if (!GetTxPayload(it->GetTx(), assetTx)) {
             assert(false);
         }
-        mapAssetsIdToHash.erase(assetTx.AssetId);
+        mapAssetsIdToHash.erase(assetTx.assetId);
     } else if (it->GetTx().nType == TRANSACTION_MINT_ASSET) {
         CMintAssetTx assetTx;
         if (!GetTxPayload(it->GetTx(), assetTx)) {
             assert(false);
         }
-        mapAssetsIdToHash.erase(assetTx.AssetId);
+        mapAssetsIdToHash.erase(assetTx.assetId);
     }
 
     totalTxSize -= it->GetTxSize();
@@ -1442,7 +1442,7 @@ bool CTxMemPool::existsAssetTxConflict(const CTransaction &tx) const {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Invalid transaction payload, tx: %s", __func__, tx.ToString()); /* Continued */
             return true; // i.e. can't decode payload == conflict
         }
-        auto it = mapAssetsToHash.find(assetTx.Name);
+        auto it = mapAssetsToHash.find(assetTx.name);
         return it != mapAssetsToHash.end() && it->second != tx.GetHash();
     } else if (tx.nType == TRANSACTION_UPDATE_ASSET) {
         CUpdateAssetTx assetTx;
@@ -1450,7 +1450,7 @@ bool CTxMemPool::existsAssetTxConflict(const CTransaction &tx) const {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Invalid transaction payload, tx: %s", __func__, tx.ToString()); /* Continued */
             return true; // i.e. can't decode payload == conflict
         }
-        auto it = mapAssetsIdToHash.find(assetTx.AssetId);
+        auto it = mapAssetsIdToHash.find(assetTx.assetId);
         return it != mapAssetsIdToHash.end() && it->second != tx.GetHash();
     } else if (tx.nType == TRANSACTION_MINT_ASSET) {
         CMintAssetTx assetTx;
@@ -1458,7 +1458,7 @@ bool CTxMemPool::existsAssetTxConflict(const CTransaction &tx) const {
             LogPrint(BCLog::MEMPOOL, "%s: ERROR: Invalid transaction payload, tx: %s", __func__, tx.ToString()); /* Continued */
             return true; // i.e. can't decode payload == conflict
         }
-        auto it = mapAssetsIdToHash.find(assetTx.AssetId);
+        auto it = mapAssetsIdToHash.find(assetTx.assetId);
         return it != mapAssetsIdToHash.end() && it->second != tx.GetHash();
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -458,6 +458,21 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         if (dmn->pdmnState->pubKeyOperator.Get() != CBLSPublicKey()) {
             newit->isKeyChangeProTx = true;
         }
+    } else if (tx.nType == TRANSACTION_NEW_ASSET) {
+        CNewAssetTx assetTx;
+        bool ok = GetTxPayload(tx, assetTx);
+        assert(ok);
+        mapAssetsToHash.emplace(assetTx.Name, tx.GetHash());
+    } else if (tx.nType == TRANSACTION_UPDATE_ASSET) {
+        CUpdateAssetTx assetTx;
+        bool ok = GetTxPayload(tx, assetTx);
+        assert(ok);
+        mapAssetsIdToHash.emplace(assetTx.AssetId, tx.GetHash());
+    } else if (tx.nType == TRANSACTION_MINT_ASSET) {
+        CMintAssetTx assetTx;
+        bool ok = GetTxPayload(tx, assetTx);
+        assert(ok);
+        mapAssetsIdToHash.emplace(assetTx.AssetId, tx.GetHash());
     }
 
     return true;
@@ -746,6 +761,24 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
             assert(false);
         }
         eraseProTxRef(proTx.proTxHash, it->GetTx().GetHash());
+    } else if (it->GetTx().nType == TRANSACTION_NEW_ASSET) {
+        CNewAssetTx assetTx;
+        if (!GetTxPayload(it->GetTx(), assetTx)) {
+            assert(false);
+        }
+        mapAssetsToHash.erase(assetTx.Name);
+    } else if (it->GetTx().nType == TRANSACTION_UPDATE_ASSET) {
+        CUpdateAssetTx assetTx;
+        if (!GetTxPayload(it->GetTx(), assetTx)) {
+            assert(false);
+        }
+        mapAssetsIdToHash.erase(assetTx.AssetId);
+    } else if (it->GetTx().nType == TRANSACTION_MINT_ASSET) {
+        CMintAssetTx assetTx;
+        if (!GetTxPayload(it->GetTx(), assetTx)) {
+            assert(false);
+        }
+        mapAssetsIdToHash.erase(assetTx.AssetId);
     }
 
     totalTxSize -= it->GetTxSize();
@@ -1398,6 +1431,48 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         }
     }
     return false;
+}
+
+bool CTxMemPool::existsAssetTxConflict(const CTransaction &tx) const {
+    LOCK(cs);
+
+    if (tx.nType == TRANSACTION_NEW_ASSET) {
+        CNewAssetTx assetTx;
+        if (!GetTxPayload(tx, assetTx)) {
+            LogPrint(BCLog::MEMPOOL, "%s: ERROR: Invalid transaction payload, tx: %s", __func__, tx.ToString()); /* Continued */
+            return true; // i.e. can't decode payload == conflict
+        }
+        auto it = mapAssetsToHash.find(assetTx.Name);
+        return it != mapAssetsToHash.end() && it->second != tx.GetHash();
+    } else if (tx.nType == TRANSACTION_UPDATE_ASSET) {
+        CUpdateAssetTx assetTx;
+        if (!GetTxPayload(tx, assetTx)) {
+            LogPrint(BCLog::MEMPOOL, "%s: ERROR: Invalid transaction payload, tx: %s", __func__, tx.ToString()); /* Continued */
+            return true; // i.e. can't decode payload == conflict
+        }
+        auto it = mapAssetsIdToHash.find(assetTx.AssetId);
+        return it != mapAssetsIdToHash.end() && it->second != tx.GetHash();
+    } else if (tx.nType == TRANSACTION_MINT_ASSET) {
+        CMintAssetTx assetTx;
+        if (!GetTxPayload(tx, assetTx)) {
+            LogPrint(BCLog::MEMPOOL, "%s: ERROR: Invalid transaction payload, tx: %s", __func__, tx.ToString()); /* Continued */
+            return true; // i.e. can't decode payload == conflict
+        }
+        auto it = mapAssetsIdToHash.find(assetTx.AssetId);
+        return it != mapAssetsIdToHash.end() && it->second != tx.GetHash();
+    }
+
+    return false;
+}
+
+bool CTxMemPool::CheckForNewAssetConflict(const std::string assetName) const{
+    auto it = mapAssetsToHash.find(assetName);
+        return it != mapAssetsToHash.end();
+}
+
+bool CTxMemPool::CheckForMintAssetConflict(const std::string assetId) const{
+    auto it = mapAssetsIdToHash.find(assetId);
+        return it != mapAssetsIdToHash.end();
 }
 
 void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -536,6 +536,9 @@ private:
     std::map<uint256, uint256> mapProTxBlsPubKeyHashes;
     std::map<COutPoint, uint256> mapProTxCollaterals;
 
+    std::map<std::string, uint256> mapAssetsToHash;
+    std::map<std::string, uint256> mapAssetsIdToHash;
+
     void UpdateParent(txiter entry, txiter parent, bool add);
     void UpdateChild(txiter entry, txiter child, bool add);
 
@@ -694,6 +697,9 @@ public:
     std::vector<TxMempoolInfo> infoAll() const;
 
     bool existsProviderTxConflict(const CTransaction &tx) const;
+    bool existsAssetTxConflict(const CTransaction &tx) const;
+    bool CheckForNewAssetConflict(const std::string assetName) const;
+    bool CheckForMintAssetConflict(const std::string assetId) const;
 
     size_t DynamicMemoryUsage() const;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -846,10 +846,14 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         // DoS scoring a node for non-critical errors, e.g. duplicate keys because a TX is received that was already
         // mined
         // NOTE: we use UTXO here and do NOT allow mempool txes as smartnode collaterals
-        if (!CheckSpecialTx(tx, chainActive.Tip(), state, *pcoinsTip.get(), &assetsCache))
+        if (!CheckSpecialTx(tx, chainActive.Tip(), state, view, &assetsCache))
             return false;
         if (pool.existsProviderTxConflict(tx)) {
             return state.DoS(0, false, REJECT_DUPLICATE, "protx-dup");
+        }
+        //check for asset conflicts on mempool
+        if (pool.existsAssetTxConflict(tx)) {
+            return state.DoS(0, false, REJECT_DUPLICATE, "asset-dup");
         }
 
         // If we aren't going to actually accept it but just were verifying it, we are fine already

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1789,8 +1789,8 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
 
         if(Params().IsAssetsActive(chainActive.Tip()) && assetsCache) {
             if (tx.nType == TRANSACTION_NEW_ASSET){
-                CNewAssetTx assettx;
-                if (GetTxPayload(tx, assettx)) {
+                CNewAssetTx assetTx;
+                if (GetTxPayload(tx, assetTx)) {
                     if (assetsCache->CheckIfAssetExists(tx.GetHash().ToString())){
                         if (!assetsCache->RemoveAsset(tx.GetHash().ToString())){
                             error("DisconnectBlock(): failed to remove asset: %s", tx.GetHash().ToString());
@@ -1799,21 +1799,21 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                     }
                 }
             } else if (tx.nType == TRANSACTION_UPDATE_ASSET){
-                CUpdateAssetTx assettx;
-                if (GetTxPayload(tx, assettx)) {
-                    if (assetsCache->CheckIfAssetExists(assettx.AssetId)){
-                        if (!assetsCache->UndoUpdateAsset(assettx, vUndoData)){
-                            error("DisconnectBlock(): failed to und update asset: %s", assettx.AssetId);
+                CUpdateAssetTx assetTx;
+                if (GetTxPayload(tx, assetTx)) {
+                    if (assetsCache->CheckIfAssetExists(assetTx.assetId)){
+                        if (!assetsCache->UndoUpdateAsset(assetTx, vUndoData)){
+                            error("DisconnectBlock(): failed to und update asset: %s", assetTx.assetId);
                             return DISCONNECT_FAILED;
                         }
-                    }      
+                    }
                 }
             } else if (tx.nType == TRANSACTION_MINT_ASSET){
-                CMintAssetTx assettx;
-                if (GetTxPayload(tx, assettx)) {
-                    if (assetsCache->CheckIfAssetExists(assettx.AssetId)){
-                        if (!assetsCache->UndoMintAsset(assettx, vUndoData)){
-                            error("DisconnectBlock(): failed to rundo mint asset: %s", assettx.AssetId);
+                CMintAssetTx assetTx;
+                if (GetTxPayload(tx, assetTx)) {
+                    if (assetsCache->CheckIfAssetExists(assetTx.assetId)){
+                        if (!assetsCache->UndoMintAsset(assetTx, vUndoData)){
+                            error("DisconnectBlock(): failed to rundo mint asset: %s", assetTx.assetId);
                             return DISCONNECT_FAILED;
                         }
                     }
@@ -2465,7 +2465,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         std::pair<std::string, CBlockAssetUndo>* undoAssetData = &undoPair;
 
         UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight, assetsCache, undoAssetData);
-        
+
         if (!undoAssetData->first.empty()) {
             vUndoAssetMetaData.emplace_back(*undoAssetData);
         }
@@ -2720,7 +2720,7 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
             }
             if (Params().IsAssetsActive(chainActive.Tip())){
                 if (passetsCache && !passetsCache->DumpCacheToDatabase())
-                        return AbortNode(state, "Failed to write to asset database");               
+                        return AbortNode(state, "Failed to write to asset database");
             }
             nLastFlush = nNow;
         }
@@ -3390,7 +3390,7 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
         if (pindexOldTip == pindexBestHeader) {
             pindexBestInvalid = pindexBestHeader;
             pindexBestHeader = pindexBestHeader->pprev;
-            atomicHeaderHeight = pindexBestHeader ? pindexBestHeader->nHeight : -1;            
+            atomicHeaderHeight = pindexBestHeader ? pindexBestHeader->nHeight : -1;
         }
     }
 
@@ -5493,4 +5493,3 @@ public:
         mapBlockIndex.clear();
     }
 } instance_of_cmaincleanup;
-

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3140,34 +3140,34 @@ void CWallet::AvailableCoins(std::vector<COutput>& vCoins, std::map<std::string,
                 ExtractDestination(pcoin->tx->vout[i].scriptPubKey, destination);
                 address = EncodeDestination(destination);
                 // If we already have the maximum amount or size for this asset, skip it
-                if (setAssetMaxFound.count(assetTransfer.AssetId))
+                if (setAssetMaxFound.count(assetTransfer.assetId))
                     continue;
 
                 // Initialize the map vector is it doesn't exist yet
-                if (!mapAssetCoins.count(assetTransfer.AssetId)) {
+                if (!mapAssetCoins.count(assetTransfer.assetId)) {
                     std::vector<COutput> vOutput;
-                    mapAssetCoins.insert(std::make_pair(assetTransfer.AssetId, vOutput));
+                    mapAssetCoins.insert(std::make_pair(assetTransfer.assetId, vOutput));
                 }
 
                 // Add the COutput to the map of available Asset Coins
-                mapAssetCoins.at(assetTransfer.AssetId).push_back(COutput(pcoin, i, nDepth, fSpendableIn, fSolvableIn, safeTx && isCoinSpendable, pcoin->tx->nType == TRANSACTION_FUTURE, isCoinSpendable));
+                mapAssetCoins.at(assetTransfer.assetId).push_back(COutput(pcoin, i, nDepth, fSpendableIn, fSolvableIn, safeTx && isCoinSpendable, pcoin->tx->nType == TRANSACTION_FUTURE, isCoinSpendable));
 
                 // Initialize the map of current asset totals
-                if (!mapAssetTotals.count(assetTransfer.AssetId))
-                    mapAssetTotals[assetTransfer.AssetId] = 0;
+                if (!mapAssetTotals.count(assetTransfer.assetId))
+                    mapAssetTotals[assetTransfer.assetId] = 0;
 
                 // Update the map of totals depending the which type of asset tx we are looking at
-                mapAssetTotals[assetTransfer.AssetId] += assetTransfer.nAmount;
+                mapAssetTotals[assetTransfer.assetId] += assetTransfer.nAmount;
 
                 // Checks the sum amount of all UTXO's, and adds to the set of assets that we found the max for
                 if (nMinimumSumAmount != MAX_MONEY) {
-                    if (mapAssetTotals[assetTransfer.AssetId] >= nMinimumSumAmount)
-                        setAssetMaxFound.insert(assetTransfer.AssetId);
+                    if (mapAssetTotals[assetTransfer.assetId] >= nMinimumSumAmount)
+                        setAssetMaxFound.insert(assetTransfer.assetId);
                 }
 
                 // Checks the maximum number of UTXO's, and addes to set of of asset that we found the max for
-                if (nMaximumCount > 0 && mapAssetCoins[assetTransfer.AssetId].size() >= nMaximumCount) {
-                    setAssetMaxFound.insert(assetTransfer.AssetId);
+                if (nMaximumCount > 0 && mapAssetCoins[assetTransfer.assetId].size() >= nMaximumCount) {
+                    setAssetMaxFound.insert(assetTransfer.assetId);
                 }
             }
 
@@ -4032,9 +4032,9 @@ bool CWallet::GetBudgetSystemCollateralTX(CTransactionRef& tx, uint256 hash, CAm
     return true;
 }
 
-bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, const CCoinControl& coin_control, bool sign, int nExtraPayloadSize, FuturePartialPayload* fpp, CNewAssetTx* newasset, CMintAssetTx* mint)
+bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, const CCoinControl& coin_control, bool sign, int nExtraPayloadSize, FuturePartialPayload* fpp, CNewAssetTx* newAsset, CMintAssetTx* mint)
 {
-    if (!Params().IsAssetsActive(chainActive.Tip()) && (newasset || mint))
+    if (!Params().IsAssetsActive(chainActive.Tip()) && (newAsset || mint))
         return false;
 
     CAmount nValue = 0;
@@ -4049,15 +4049,15 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
             std::string address;
             if (GetTransferAsset(recipient.scriptPubKey, assetTransfer)) {
                 fHasAsset = true;
-                if (!mapAssetValue.count(assetTransfer.AssetId))
-                    mapAssetValue[assetTransfer.AssetId] = 0;
+                if (!mapAssetValue.count(assetTransfer.assetId))
+                    mapAssetValue[assetTransfer.assetId] = 0;
 
                 if (assetTransfer.isUnique) {
-                    if (!mapAssetUniqueId.count(assetTransfer.AssetId)) {
+                    if (!mapAssetUniqueId.count(assetTransfer.assetId)) {
                         std::vector<uint16_t> tmpvec;
-                        mapAssetUniqueId.insert(std::make_pair(assetTransfer.AssetId, tmpvec));
+                        mapAssetUniqueId.insert(std::make_pair(assetTransfer.assetId, tmpvec));
                     }
-                    mapAssetUniqueId.at(assetTransfer.AssetId).push_back(assetTransfer.uniqueId);
+                    mapAssetUniqueId.at(assetTransfer.assetId).push_back(assetTransfer.uniqueId);
                 }
 
                 if (assetTransfer.nAmount <= 0) {
@@ -4070,7 +4070,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                     return false;
                 }
 
-                mapAssetValue[assetTransfer.AssetId] += assetTransfer.nAmount;
+                mapAssetValue[assetTransfer.assetId] += assetTransfer.nAmount;
             }
         }
 
@@ -4083,7 +4083,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
         if (recipient.fSubtractFeeFromAmount)
             nSubtractFeeFromAmount++;
     }
-    if (vecSend.empty() && !newasset) {
+    if (vecSend.empty() && !newAsset) {
         strFailReason = _("Transaction must have at least one recipient");
         return false;
     }
@@ -4105,10 +4105,10 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
         ftx.updatableByDestination = false;
         ftx.fee = getFutureFees();
         specialFees = getFutureFeesCoin();
-    } else if (newasset) {
+    } else if (newAsset) {
         txNew.nVersion = 3;
         txNew.nType = TRANSACTION_NEW_ASSET;
-        atx = *newasset;
+        atx = *newAsset;
         atx.nVersion = CNewAssetTx::CURRENT_VERSION;
         specialFees = getAssetsFeesCoin();
     } else if (mint) {
@@ -4260,7 +4260,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                     }
                     txNew.vout.push_back(txout);
                 }
-                if (newasset) {
+                if (newAsset) {
                     CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
                     ds << atx;
                     txNew.vExtraPayload.assign(ds.begin(), ds.end());
@@ -4519,7 +4519,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
             }
             UpdateSpecialTxInputsHash(txNew, ftx);
             SetTxPayload(txNew, ftx);
-        } else if (newasset) {
+        } else if (newAsset) {
             UpdateSpecialTxInputsHash(txNew, atx);
             SetTxPayload(txNew, atx);
         } else if (mint) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2218,8 +2218,8 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
             address = CNoDestination();
         }
 
-         if (!txout.scriptPubKey.IsAssetScript()) {
-            COutputEntry output = {address, txout.nValue, (int) i};
+        if (!txout.scriptPubKey.IsAssetScript()) {
+            COutputEntry output = {address, txout.nValue, (int)i};
 
             // If we are debited by the transaction, add the output as a "sent" entry
             if (nDebit > 0)
@@ -3027,20 +3027,19 @@ CAmount CWallet::GetAvailableBalance(const CCoinControl* coinControl) const
     return balance;
 }
 
-void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const CCoinControl *coinControl, const CAmount &nMinimumAmount, const CAmount &nMaximumAmount, const CAmount &nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth) const
+void CWallet::AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe, const CCoinControl* coinControl, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth) const
 {
     std::map<std::string, std::vector<COutput>> mapAssetCoins;
-    AvailableCoins(vCoins, mapAssetCoins, true, false, fOnlySafe, coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth); 
-
+    AvailableCoins(vCoins, mapAssetCoins, true, false, fOnlySafe, coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
 }
 
-void CWallet::AvailableAssets(std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fOnlySafe, const CCoinControl *coinControl, const CAmount &nMinimumAmount, const CAmount &nMaximumAmount, const CAmount &nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth) const
+void CWallet::AvailableAssets(std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fOnlySafe, const CCoinControl* coinControl, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth) const
 {
-   std::vector<COutput> vCoins;
-   AvailableCoins(vCoins, mapAssetCoins, false, true, fOnlySafe, coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth); 
+    std::vector<COutput> vCoins;
+    AvailableCoins(vCoins, mapAssetCoins, false, true, fOnlySafe, coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
 }
 
-void CWallet::AvailableCoins(std::vector<COutput> &vCoins, std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fGetRTM, bool fOnlyAssets, bool fOnlySafe, const CCoinControl *coinControl, const CAmount &nMinimumAmount, const CAmount &nMaximumAmount, const CAmount &nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth) const
+void CWallet::AvailableCoins(std::vector<COutput>& vCoins, std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fGetRTM, bool fOnlyAssets, bool fOnlySafe, const CCoinControl* coinControl, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount, const int nMinDepth, const int nMaxDepth) const
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(cs_wallet);
@@ -3052,11 +3051,11 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, std::map<std::string,
 
     CAmount nTotal = 0;
     bool fRTMLimitHit = false;
-    
+
     std::map<std::string, CAmount> mapAssetTotals;
     std::map<uint256, COutPoint> mapOutPoints;
     std::set<std::string> setAssetMaxFound;
-    
+
     bool fGetAssets = Params().IsAssetsActive(chainActive.Tip()) && fOnlyAssets;
 
     for (auto pcoin : GetSpendableTXs()) {
@@ -3089,20 +3088,20 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, std::map<std::string,
             if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 if (!CCoinJoin::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                 found = IsFullyMixed(COutPoint(wtxid, i));
-            } else if(nCoinType == CoinType::ONLY_READY_TO_MIX) {
+            } else if (nCoinType == CoinType::ONLY_READY_TO_MIX) {
                 if (!CCoinJoin::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                 found = !IsFullyMixed(COutPoint(wtxid, i));
-            } else if(nCoinType == CoinType::ONLY_NONDENOMINATED) {
+            } else if (nCoinType == CoinType::ONLY_NONDENOMINATED) {
                 if (CCoinJoin::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                 found = !CCoinJoin::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
-            } else if(nCoinType == CoinType::ONLY_SMARTNODE_COLLATERAL) {
+            } else if (nCoinType == CoinType::ONLY_SMARTNODE_COLLATERAL) {
                 found = collaterals.isValidCollateral(pcoin->tx->vout[i].nValue);
-            } else if(nCoinType == CoinType::ONLY_COINJOIN_COLLATERAL) {
+            } else if (nCoinType == CoinType::ONLY_COINJOIN_COLLATERAL) {
                 found = CCoinJoin::IsCollateralAmount(pcoin->tx->vout[i].nValue);
             } else {
                 found = true;
             }
-            if(!found) continue;
+            if (!found) continue;
 
             bool isAssetScript = pcoin->tx->vout[i].scriptPubKey.IsAssetScript();
 
@@ -3111,7 +3110,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, std::map<std::string,
 
             if (coinControl && !isAssetScript && coinControl->HasSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsSelected(COutPoint(wtxid, i)))
                 continue;
-            
+
             if (coinControl && isAssetScript && coinControl->HasAssetSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsAssetSelected(COutPoint(wtxid, i)))
                 continue;
 
@@ -3132,11 +3131,11 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, std::map<std::string,
             bool isCoinSpendable = pcoin->isFutureSpendable(i);
 
             std::string address;
-            if (fGetAssets && isAssetScript ) {
+            if (fGetAssets && isAssetScript) {
                 CAssetTransfer assetTransfer;
                 if (!GetTransferAsset(pcoin->tx->vout[i].scriptPubKey, assetTransfer))
                     continue;
-                    
+
                 CTxDestination destination;
                 ExtractDestination(pcoin->tx->vout[i].scriptPubKey, destination);
                 address = EncodeDestination(destination);
@@ -3151,8 +3150,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, std::map<std::string,
                 }
 
                 // Add the COutput to the map of available Asset Coins
-                mapAssetCoins.at(assetTransfer.AssetId).push_back(
-                        COutput(pcoin, i, nDepth, fSpendableIn, fSolvableIn, safeTx && isCoinSpendable, pcoin->tx->nType == TRANSACTION_FUTURE, isCoinSpendable));
+                mapAssetCoins.at(assetTransfer.AssetId).push_back(COutput(pcoin, i, nDepth, fSpendableIn, fSolvableIn, safeTx && isCoinSpendable, pcoin->tx->nType == TRANSACTION_FUTURE, isCoinSpendable));
 
                 // Initialize the map of current asset totals
                 if (!mapAssetTotals.count(assetTransfer.AssetId))
@@ -3265,7 +3263,7 @@ std::map<CTxDestination, std::vector<COutput>> CWallet::ListAssets() const
 
     LOCK2(cs_main, cs_wallet);
     for (auto asset : mapAssets) {
-        for (auto &coin : asset.second) {
+        for (auto& coin : asset.second) {
             CTxDestination address;
             if (coin.fSpendable &&
                 ExtractDestination(FindNonChangeParentOutput(*coin.tx->tx, coin.i).scriptPubKey, address)) {
@@ -3302,10 +3300,9 @@ std::map<std::string, CAmount> CWallet::getAssetsBalance(const CCoinControl* coi
     AvailableAssets(mapAssets, true, coinControl);
 
     std::map<std::string, CAmount> result;
-    for (auto asset  : mapAssets){
+    for (auto asset : mapAssets) {
         CAmount balance = 0;
-        for (auto output : asset.second){
-
+        for (auto output : asset.second) {
             if (fSpendable && !OutputEligibleForSpending(output, CoinEligibilityFilter(1, 1, 0)))
                 continue;
 
@@ -3532,8 +3529,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
     return res;
 }
 
-static void ApproximateBestAssetSubset(const std::vector<std::pair<CInputCoin, CAmount> >& vValue, const CAmount& nTotalLower, const CAmount& nTargetValue,
-                                  std::vector<char>& vfBest, CAmount& nBest, int iterations = 1000)
+static void ApproximateBestAssetSubset(const std::vector<std::pair<CInputCoin, CAmount>>& vValue, const CAmount& nTotalLower, const CAmount& nTargetValue, std::vector<char>& vfBest, CAmount& nBest, int iterations = 1000)
 {
     std::vector<char> vfIncluded;
 
@@ -3542,30 +3538,24 @@ static void ApproximateBestAssetSubset(const std::vector<std::pair<CInputCoin, C
 
     FastRandomContext insecure_rand;
 
-    for (int nRep = 0; nRep < iterations && nBest != nTargetValue; nRep++)
-    {
+    for (int nRep = 0; nRep < iterations && nBest != nTargetValue; nRep++) {
         vfIncluded.assign(vValue.size(), false);
         CAmount nTotal = 0;
         bool fReachedTarget = false;
-        for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++)
-        {
-            for (unsigned int i = 0; i < vValue.size(); i++)
-            {
+        for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++) {
+            for (unsigned int i = 0; i < vValue.size(); i++) {
                 //The solver here uses a randomized algorithm,
                 //the randomness serves no real security purpose but is just
                 //needed to prevent degenerate behavior and it is important
                 //that the rng is fast. We do not use a constant random sequence,
                 //because there may be some privacy improvement by making
                 //the selection random.
-                if (nPass == 0 ? insecure_rand.randbool() : !vfIncluded[i])
-                {
+                if (nPass == 0 ? insecure_rand.randbool() : !vfIncluded[i]) {
                     nTotal += vValue[i].second;
                     vfIncluded[i] = true;
-                    if (nTotal >= nTargetValue)
-                    {
+                    if (nTotal >= nTargetValue) {
                         fReachedTarget = true;
-                        if (nTotal < nBest)
-                        {
+                        if (nTotal < nBest) {
                             nBest = nTotal;
                             vfBest = vfIncluded;
                         }
@@ -3578,8 +3568,7 @@ static void ApproximateBestAssetSubset(const std::vector<std::pair<CInputCoin, C
     }
 }
 
-bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, const std::string& strAssetName, std::vector<COutput> vCoins,
-                                 std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet) const
+bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, const std::string& strAssetName, std::vector<COutput> vCoins, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet) const
 {
     setCoinsRet.clear();
     nValueRet = 0;
@@ -3587,15 +3576,13 @@ bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const CoinEligibi
     // List of values less than target
     boost::optional<CInputCoin> coinLowestLarger;
     boost::optional<CAmount> coinLowestLargerAmount;
-    std::vector<std::pair<CInputCoin, CAmount> > vValue;
+    std::vector<std::pair<CInputCoin, CAmount>> vValue;
     std::map<COutPoint, CAmount> mapValueAmount;
     CAmount nTotalLower = 0;
 
     random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
-    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-    for (const COutput &output : vCoins)
-    {
-        
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    for (const COutput& output : vCoins) {
         if (!OutputEligibleForSpending(output, eligibility_filter))
             continue;
 
@@ -3611,41 +3598,33 @@ bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const CoinEligibi
             continue;
         nTempAmount = transferTemp.nAmount;
 
-        if (nTempAmount == nTargetValue)
-        {
+        if (nTempAmount == nTargetValue) {
             setCoinsRet.insert(coin);
             nValueRet += nTempAmount;
             return true;
-        }
-        else if (nTempAmount < nTargetValue + MIN_CHANGE)
-        {
+        } else if (nTempAmount < nTargetValue + MIN_CHANGE) {
             vValue.push_back(std::make_pair(coin, nTempAmount));
             nTotalLower += nTempAmount;
-        }
-        else if (!coinLowestLarger || !coinLowestLargerAmount || nTempAmount < coinLowestLargerAmount)
-        {
+        } else if (!coinLowestLarger || !coinLowestLargerAmount || nTempAmount < coinLowestLargerAmount) {
             coinLowestLarger = coin;
             coinLowestLargerAmount = nTempAmount;
         }
     }
 
-    if (nTotalLower == nTargetValue)
-    {
-        for (const auto& pair : vValue)
-        {
+    if (nTotalLower == nTargetValue) {
+        for (const auto& pair : vValue) {
             setCoinsRet.insert(pair.first);
             nValueRet += pair.second;
         }
         return true;
     }
 
-    if (nTotalLower < nTargetValue)
-    {
+    if (nTotalLower < nTargetValue) {
         if (!coinLowestLarger || !coinLowestLargerAmount)
             return false;
         setCoinsRet.insert(coinLowestLarger.get());
 
-        #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         nValueRet += coinLowestLargerAmount.get();
         return true;
     }
@@ -3663,15 +3642,12 @@ bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const CoinEligibi
     // If we have a bigger coin and (either the stochastic approximation didn't find a good solution,
     //                                   or the next bigger coin is closer), return the bigger coin
     if (coinLowestLarger && coinLowestLargerAmount &&
-        ((nBest != nTargetValue && nBest < nTargetValue + MIN_CHANGE) || coinLowestLargerAmount <= nBest))
-    {
+        ((nBest != nTargetValue && nBest < nTargetValue + MIN_CHANGE) || coinLowestLargerAmount <= nBest)) {
         setCoinsRet.insert(coinLowestLarger.get());
         nValueRet += coinLowestLargerAmount.get();
-    }
-    else {
+    } else {
         for (unsigned int i = 0; i < vValue.size(); i++)
-            if (vfBest[i])
-            {
+            if (vfBest[i]) {
                 setCoinsRet.insert(vValue[i].first);
                 nValueRet += vValue[i].second;
             }
@@ -3690,7 +3666,7 @@ bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const CoinEligibi
     return true;
 }
 
-bool CWallet::SelectAssets(const std::map<std::string, std::vector<COutput> >& mapAvailableAssets, const std::map<std::string, CAmount>& mapAssetTargetValue, std::map<std::string, std::vector<uint16_t>> mapAssetUniqueId, std::set<CInputCoin>& setCoinsRet, std::map<std::string, CAmount>& mapValueRet) const
+bool CWallet::SelectAssets(const std::map<std::string, std::vector<COutput>>& mapAvailableAssets, const std::map<std::string, CAmount>& mapAssetTargetValue, std::map<std::string, std::vector<uint16_t>> mapAssetUniqueId, std::set<CInputCoin>& setCoinsRet, std::map<std::string, CAmount>& mapValueRet) const
 {
     size_t nMaxChainLength = std::min(gArgs.GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT), gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT));
     bool fRejectLongChains = gArgs.GetBoolArg("-walletrejectlongchains", DEFAULT_WALLET_REJECT_LONG_CHAINS);
@@ -3718,40 +3694,39 @@ bool CWallet::SelectAssets(const std::map<std::string, std::vector<COutput> >& m
         if (!mapValueRet.count(strAssetName))
             mapValueRet.insert(std::make_pair(strAssetName, 0));
 
-        
-        if (mapAssetUniqueId.count(strAssetName)){
+
+        if (mapAssetUniqueId.count(strAssetName)) {
             //unique asset selection
             std::vector<uint16_t> uniqueIds = mapAssetUniqueId.at(strAssetName);
-            for (auto entry : assetVector.second){
-                
+            for (auto entry : assetVector.second) {
                 if (!OutputEligibleForSpending(entry, CoinEligibilityFilter(1, 1, 0)))
                     continue;
-                
+
                 CInputCoin coin(entry.tx->tx, entry.i);
                 CAssetTransfer assetTransfer;
-                if(GetTransferAsset(coin.txout.scriptPubKey, assetTransfer)){
-                    if (std::find(uniqueIds.begin(), uniqueIds.end(), assetTransfer.uniqueId) != uniqueIds.end()){
+                if (GetTransferAsset(coin.txout.scriptPubKey, assetTransfer)) {
+                    if (std::find(uniqueIds.begin(), uniqueIds.end(), assetTransfer.uniqueId) != uniqueIds.end()) {
                         setCoinsRet.insert(coin);
                         mapValueRet.at(strAssetName) += assetTransfer.nAmount;
-                    } 
+                    }
                 }
             }
             if (mapValueRet.at(strAssetName) != mapAssetTargetValue.at(strAssetName))
                 return false; //no funds
-        } else {      
+        } else {
             //regular asset selection
             // assign our temporary variable
             nTempAmountRet = mapValueRet.at(strAssetName);
             nTempTargetValue = mapAssetTargetValue.at(strAssetName);
 
             bool res = nTempTargetValue <= nValueFromPresetInputs ||
-                    SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 6, 0), strAssetName, vAssets, tempCoinsRet, nTempAmountRet) ||
-                    SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 1, 0), strAssetName, vAssets, tempCoinsRet, nTempAmountRet) ||
-                    (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, 2), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
-                    (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::min((size_t)4, nMaxChainLength/3)), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
-                    (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, nMaxChainLength/2), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
-                    (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, nMaxChainLength), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
-                    (bSpendZeroConfChange && !fRejectLongChains && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::numeric_limits<uint64_t>::max()), strAssetName, vAssets, tempCoinsRet, nTempAmountRet));
+                       SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 6, 0), strAssetName, vAssets, tempCoinsRet, nTempAmountRet) ||
+                       SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(1, 1, 0), strAssetName, vAssets, tempCoinsRet, nTempAmountRet) ||
+                       (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, 2), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
+                       (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::min((size_t)4, nMaxChainLength / 3)), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
+                       (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, nMaxChainLength / 2), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
+                       (bSpendZeroConfChange && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, nMaxChainLength), strAssetName, vAssets, tempCoinsRet, nTempAmountRet)) ||
+                       (bSpendZeroConfChange && !fRejectLongChains && SelectAssetsMinConf(nTempTargetValue - nValueFromPresetInputs, CoinEligibilityFilter(0, 1, std::numeric_limits<uint64_t>::max()), strAssetName, vAssets, tempCoinsRet, nTempAmountRet));
 
             if (res) {
                 setCoinsRet.insert(tempCoinsRet.begin(), tempCoinsRet.end());
@@ -4068,29 +4043,28 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
     std::map<std::string, std::vector<uint16_t>> mapAssetUniqueId;
     int nChangePosRequest = nChangePosInOut;
     unsigned int nSubtractFeeFromAmount = 0;
-    for (const auto& recipient : vecSend)
-    {
-         if (recipient.scriptPubKey.IsAssetScript()) {
+    for (const auto& recipient : vecSend) {
+        if (recipient.scriptPubKey.IsAssetScript()) {
             CAssetTransfer assetTransfer;
             std::string address;
             if (GetTransferAsset(recipient.scriptPubKey, assetTransfer)) {
                 fHasAsset = true;
                 if (!mapAssetValue.count(assetTransfer.AssetId))
                     mapAssetValue[assetTransfer.AssetId] = 0;
-                
-                if (assetTransfer.isUnique){
-                    if (!mapAssetUniqueId.count(assetTransfer.AssetId)){
+
+                if (assetTransfer.isUnique) {
+                    if (!mapAssetUniqueId.count(assetTransfer.AssetId)) {
                         std::vector<uint16_t> tmpvec;
                         mapAssetUniqueId.insert(std::make_pair(assetTransfer.AssetId, tmpvec));
                     }
                     mapAssetUniqueId.at(assetTransfer.AssetId).push_back(assetTransfer.uniqueId);
                 }
-                
+
                 if (assetTransfer.nAmount <= 0) {
                     strFailReason = _("Asset Transfer amounts must be greater than 0");
                     return false;
                 }
-                
+
                 if (assetTransfer.isUnique && assetTransfer.nAmount != 1 * COIN) {
                     strFailReason = _("Unique Asset Transfer amount must be 1");
                     return false;
@@ -4100,8 +4074,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
             }
         }
 
-        if (nValue < 0 || recipient.nAmount < 0)
-        {
+        if (nValue < 0 || recipient.nAmount < 0) {
             strFailReason = _("Transaction amounts must not be negative");
             return false;
         }
@@ -4110,36 +4083,35 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
         if (recipient.fSubtractFeeFromAmount)
             nSubtractFeeFromAmount++;
     }
-    if (vecSend.empty() && !newasset)
-    {
+    if (vecSend.empty() && !newasset) {
         strFailReason = _("Transaction must have at least one recipient");
         return false;
     }
 
     bool fTransferAsset = fHasAsset && !mint;
-    
+
     CMutableTransaction txNew;
     CFutureTx ftx;
     CNewAssetTx atx;
     CMintAssetTx mtx;
     CAmount specialFees = 0;
-    if(fpp) {
-      txNew.nVersion = 3;
-      txNew.nType = TRANSACTION_FUTURE;
-      ftx.nVersion = CFutureTx::CURRENT_VERSION;
-      ftx.lockTime = fpp->locktime;
-      ftx.maturity = fpp->maturity;
-      ftx.lockOutputIndex = 0;
-      ftx.updatableByDestination = false;
-      ftx.fee = getFutureFees();
-      specialFees = getFutureFeesCoin();
-    } else if(newasset){
+    if (fpp) {
+        txNew.nVersion = 3;
+        txNew.nType = TRANSACTION_FUTURE;
+        ftx.nVersion = CFutureTx::CURRENT_VERSION;
+        ftx.lockTime = fpp->locktime;
+        ftx.maturity = fpp->maturity;
+        ftx.lockOutputIndex = 0;
+        ftx.updatableByDestination = false;
+        ftx.fee = getFutureFees();
+        specialFees = getFutureFeesCoin();
+    } else if (newasset) {
         txNew.nVersion = 3;
         txNew.nType = TRANSACTION_NEW_ASSET;
         atx = *newasset;
         atx.nVersion = CNewAssetTx::CURRENT_VERSION;
         specialFees = getAssetsFeesCoin();
-    }else if(mint){
+    } else if (mint) {
         txNew.nVersion = 3;
         txNew.nType = TRANSACTION_MINT_ASSET;
         mtx = *mint;
@@ -4190,11 +4162,11 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
             std::vector<COutput> vAvailableCoins;
             std::map<std::string, std::vector<COutput>> mapAssetCoins;
             if (fTransferAsset)
-            AvailableCoins(vAvailableCoins, mapAssetCoins, true, &coin_control);
+                AvailableCoins(vAvailableCoins, mapAssetCoins, true, &coin_control);
             else
-            AvailableCoins(vAvailableCoins, true, &coin_control);
+                AvailableCoins(vAvailableCoins, true, &coin_control);
             CoinSelectionParams coin_selection_params; // Parameters for coin selection, init with dummy
-            coin_selection_params.use_bnb = false; // never use BnB
+            coin_selection_params.use_bnb = false;     // never use BnB
 
             for (auto out : vAvailableCoins) {
                 if (out.fSpendable && out.isFutureSpendable) {
@@ -4222,8 +4194,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                 CPubKey vchPubKey;
                 bool ret;
                 ret = reservekey.GetReservedKey(vchPubKey, true);
-                if (!ret)
-                {
+                if (!ret) {
                     strFailReason = _("Keypool ran out, please call keypoolrefill first");
                     return false;
                 }
@@ -4244,8 +4215,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
             CAmount nAmountToSelectAdditional{0};
             // Start with nAmountToSelectAdditional=0 and loop until there is enough to cover the request + fees, try it 500 times.
             int nMaxTries = 500;
-            while (--nMaxTries > 0)
-            {
+            while (--nMaxTries > 0) {
                 std::map<std::string, CAmount> mapAssetsIn;
                 nChangePosInOut = std::numeric_limits<int>::max();
                 txNew.vin.clear();
@@ -4258,12 +4228,10 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                     nValueToSelect += nAmountToSelectAdditional;
                 }
                 // vouts to the payees
-                for (const auto& recipient : vecSend)
-                {
+                for (const auto& recipient : vecSend) {
                     CTxOut txout(recipient.nAmount, recipient.scriptPubKey);
 
-                    if (recipient.fSubtractFeeFromAmount)
-                    {
+                    if (recipient.fSubtractFeeFromAmount) {
                         assert(nSubtractFeeFromAmount != 0);
                         txout.nValue -= nFeeRet / nSubtractFeeFromAmount; // Subtract fee equally from each selected recipient
 
@@ -4273,39 +4241,35 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                             txout.nValue -= nFeeRet % nSubtractFeeFromAmount;
                         }
                     }
-                    if (IsDust(txout, ::dustRelayFee) && !recipient.scriptPubKey.IsAssetScript())
-                    {
-                        if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
-                        {
+                    if (IsDust(txout, ::dustRelayFee) && !recipient.scriptPubKey.IsAssetScript()) {
+                        if (recipient.fSubtractFeeFromAmount && nFeeRet > 0) {
                             if (txout.nValue < 0)
                                 strFailReason = _("The transaction amount is too small to pay the fee");
                             else
                                 strFailReason = _("The transaction amount is too small to send after the fee has been deducted");
-                        }
-                        else
+                        } else
                             strFailReason = _("Transaction amount too small");
                         return false;
                     }
-                    if(fpp && recipient.scriptPubKey == fpp->futureRecScript)
-                    {
-                      ftx.lockOutputIndex = txNew.vout.size();
-                      CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
-                      ds << ftx;
-                      txNew.vExtraPayload.assign(ds.begin(), ds.end());
-                      nExtraPayloadSize = txNew.vExtraPayload.size();
+                    if (fpp && recipient.scriptPubKey == fpp->futureRecScript) {
+                        ftx.lockOutputIndex = txNew.vout.size();
+                        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+                        ds << ftx;
+                        txNew.vExtraPayload.assign(ds.begin(), ds.end());
+                        nExtraPayloadSize = txNew.vExtraPayload.size();
                     }
                     txNew.vout.push_back(txout);
                 }
-                if(newasset){
-                   CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
-                      ds << atx;
-                      txNew.vExtraPayload.assign(ds.begin(), ds.end());
-                      nExtraPayloadSize = txNew.vExtraPayload.size(); 
-                } else if(mint){
-                   CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
-                      ds << mtx;
-                      txNew.vExtraPayload.assign(ds.begin(), ds.end());
-                      nExtraPayloadSize = txNew.vExtraPayload.size(); 
+                if (newasset) {
+                    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+                    ds << atx;
+                    txNew.vExtraPayload.assign(ds.begin(), ds.end());
+                    nExtraPayloadSize = txNew.vExtraPayload.size();
+                } else if (mint) {
+                    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+                    ds << mtx;
+                    txNew.vExtraPayload.assign(ds.begin(), ds.end());
+                    nExtraPayloadSize = txNew.vExtraPayload.size();
                 }
 
                 // Choose coins to use
@@ -4335,7 +4299,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                         }
                         vecCoins.insert(vecCoins.end(), setAssetsTmp.begin(), setAssetsTmp.end());
                     }
-                    
                 }
 
                 // Fill vin
@@ -4346,7 +4309,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                 for (const auto& coin : vecCoins) {
                     txNew.vin.emplace_back(coin.outpoint, CScript(), CTxIn::SEQUENCE_FINAL - 1);
                 }
-              
+
                 auto calculateFee = [&](CAmount& nFee) -> bool {
                     // Fill in dummy signatures for fee calculation.
                     int nIn = 0;
@@ -4362,7 +4325,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
 
                         nIn++;
                     }
-                    
+
                     nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
 
                     if (nExtraPayloadSize != 0) {
@@ -4413,14 +4376,14 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                     for (auto asset : mapAssetValue) {
                         if (mapAssetsIn.count(asset.first))
                             mapAssetChange.insert(
-                                    std::make_pair(asset.first, (mapAssetsIn.at(asset.first) - asset.second)));
+                                std::make_pair(asset.first, (mapAssetsIn.at(asset.first) - asset.second)));
                     }
 
                     for (auto assetChange : mapAssetChange) {
                         if (assetChange.second > 0) {
                             CScript scriptAssetChange = assetScriptChange;
                             //unique assets should never have change is this safe?
-                            CAssetTransfer assetTransfer(assetChange.first, assetChange.second); 
+                            CAssetTransfer assetTransfer(assetChange.first, assetChange.second);
 
                             assetTransfer.BuildAssetTransaction(scriptAssetChange);
                             CTxOut newAssetTxOut(0, scriptAssetChange);
@@ -4430,8 +4393,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                     }
                 }
 
-                if (getChange() > 0)
-                {
+                if (getChange() > 0) {
                     //over pay for denominated transactions
                     if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
                         nChangePosInOut = -1;
@@ -4457,28 +4419,22 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
 
                         // Never create dust outputs; if we would, just
                         // add the dust to the fee.
-                        if (IsDust(newTxOut, discard_rate))
-                        {
+                        if (IsDust(newTxOut, discard_rate)) {
                             nFeeRet = nFeePrev;
                             nChangePosInOut = -1;
                             nFeeRet += getChange();
-                        }
-                        else
-                        {
-                            if (nChangePosRequest == -1)
-                            {
+                        } else {
+                            if (nChangePosRequest == -1) {
                                 // Insert change txn at random position:
-                                nChangePosInOut = GetRandInt(txNew.vout.size()+1);
-                            }
-                            else if ((unsigned int)nChangePosRequest > txNew.vout.size())
-                            {
+                                nChangePosInOut = GetRandInt(txNew.vout.size() + 1);
+                            } else if ((unsigned int)nChangePosRequest > txNew.vout.size()) {
                                 strFailReason = _("Change index out of range");
                                 return false;
                             } else {
                                 nChangePosInOut = nChangePosRequest;
                             }
 
-                            std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
+                            std::vector<CTxOut>::iterator position = txNew.vout.begin() + nChangePosInOut;
                             txNew.vout.insert(position, newTxOut);
                         }
                     }
@@ -4508,10 +4464,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                     // If there was a change output added before, we must update its position now
                     if (nChangePosInOut != -1) {
                         int i = 0;
-                        for (const CTxOut& txOut : txNew.vout)
-                        {
-                            if (txOut == newTxOut)
-                            {
+                        for (const CTxOut& txOut : txNew.vout) {
+                            if (txOut == newTxOut) {
                                 nChangePosInOut = i;
                                 break;
                             }
@@ -4555,35 +4509,32 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
         assert(nChangePosInOut != std::numeric_limits<int>::max());
 
         if (nChangePosInOut == -1) reservekey.ReturnKey(); // Return any reserved key if we don't have change
-        if(fpp) {
-        	  ftx.lockOutputIndex = 0;
-        	  // this loop needed because vout may be in a different order then recipient list
-        	  for (const auto& txOut : txNew.vout) {
-				        if(txOut.scriptPubKey == fpp->futureRecScript)
-					          break;
-					      ftx.lockOutputIndex++;
-					  }
-        	  UpdateSpecialTxInputsHash(txNew, ftx);
-        	  SetTxPayload(txNew, ftx);
-        } else if(newasset){
+        if (fpp) {
+            ftx.lockOutputIndex = 0;
+            // this loop needed because vout may be in a different order then recipient list
+            for (const auto& txOut : txNew.vout) {
+                if (txOut.scriptPubKey == fpp->futureRecScript)
+                    break;
+                ftx.lockOutputIndex++;
+            }
+            UpdateSpecialTxInputsHash(txNew, ftx);
+            SetTxPayload(txNew, ftx);
+        } else if (newasset) {
             UpdateSpecialTxInputsHash(txNew, atx);
-        	SetTxPayload(txNew, atx);
-        } else if(mint){
+            SetTxPayload(txNew, atx);
+        } else if (mint) {
             UpdateSpecialTxInputsHash(txNew, mtx);
-        	SetTxPayload(txNew, mtx);
+            SetTxPayload(txNew, mtx);
         }
 
-        if (sign)
-        {
+        if (sign) {
             CTransaction txNewConst(txNew);
             int nIn = 0;
-            for(const auto& coin : vecCoins)
-            {
+            for (const auto& coin : vecCoins) {
                 const CScript& scriptPubKey = coin.txout.scriptPubKey;
                 SignatureData sigdata;
 
-                if (!ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, SIGHASH_ALL), scriptPubKey, sigdata))
-                {
+                if (!ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, SIGHASH_ALL), scriptPubKey, sigdata)) {
                     strFailReason = _("Signing transaction failed");
                     return false;
                 } else {
@@ -4604,9 +4555,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
         CTxMemPoolEntry entry(tx, 0, 0, 0, 0, false, 0, lp);
         CTxMemPool::setEntries setAncestors;
         size_t nLimitAncestors = gArgs.GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
-        size_t nLimitAncestorSize = gArgs.GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT)*1000;
+        size_t nLimitAncestorSize = gArgs.GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
         size_t nLimitDescendants = gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
-        size_t nLimitDescendantSize = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT)*1000;
+        size_t nLimitDescendantSize = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
         std::string errString;
         LOCK(::mempool.cs);
         if (!::mempool.CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize, nLimitDescendants, nLimitDescendantSize, errString)) {
@@ -4616,13 +4567,13 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
     }
 
     LogPrintf("Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
-              nFeeRet, nBytes, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
-              feeCalc.est.pass.start, feeCalc.est.pass.end,
-              100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool),
-              feeCalc.est.pass.withinTarget, feeCalc.est.pass.totalConfirmed, feeCalc.est.pass.inMempool, feeCalc.est.pass.leftMempool,
-              feeCalc.est.fail.start, feeCalc.est.fail.end,
-              100 * feeCalc.est.fail.withinTarget / (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool),
-              feeCalc.est.fail.withinTarget, feeCalc.est.fail.totalConfirmed, feeCalc.est.fail.inMempool, feeCalc.est.fail.leftMempool);
+        nFeeRet, nBytes, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
+        feeCalc.est.pass.start, feeCalc.est.pass.end,
+        100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool),
+        feeCalc.est.pass.withinTarget, feeCalc.est.pass.totalConfirmed, feeCalc.est.pass.inMempool, feeCalc.est.pass.leftMempool,
+        feeCalc.est.fail.start, feeCalc.est.fail.end,
+        100 * feeCalc.est.fail.withinTarget / (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool),
+        feeCalc.est.fail.withinTarget, feeCalc.est.fail.totalConfirmed, feeCalc.est.fail.inMempool, feeCalc.est.fail.leftMempool);
     return true;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1127,7 +1127,7 @@ public:
      * selected by SelectCoins(); Also create the change output, when needed
      * @note passing nChangePosInOut as -1 will result in setting a random position
      */
-    bool CreateTransaction(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, const CCoinControl& coin_control, bool sign = true, int nExtraPayloadSize = 0, FuturePartialPayload* fpp = nullptr, CNewAssetTx* newasset = nullptr, CMintAssetTx* mint = nullptr);
+    bool CreateTransaction(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, const CCoinControl& coin_control, bool sign = true, int nExtraPayloadSize = 0, FuturePartialPayload* fpp = nullptr, CNewAssetTx* newAsset = nullptr, CMintAssetTx* mint = nullptr);
     bool CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm, std::string fromAccount, CReserveKey& reservekey, CConnman* connman, CValidationState& state);
 
     bool CreateCollateralTransaction(CMutableTransaction& txCollateral, std::string& strReason);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -767,7 +767,7 @@ private:
      * all asset coins from coinControl are selected; Never select unconfirmed coins
      * if they are not ours
      */
-    bool SelectAssets(const std::map<std::string, std::vector<COutput> >& mapAvailableAssets, const std::map<std::string, CAmount>& mapAssetTargetValue, std::set<CInputCoin>& setCoinsRet, std::map<std::string, CAmount>& nValueRet) const;
+    bool SelectAssets(const std::map<std::string, std::vector<COutput> >& mapAvailableAssets, const std::map<std::string, CAmount>& mapAssetTargetValue, const std::map<std::string, std::vector<uint16_t>> mapAssetUniqueId, std::set<CInputCoin>& setCoinsRet, std::map<std::string, CAmount>& nValueRet) const;
 
     WalletBatch *encrypted_batch = nullptr;
 
@@ -940,12 +940,22 @@ public:
      */
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
     void AvailableCoins(std::vector<COutput>& vCoins, std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fGetRTM = true, bool fOnlyAssets = false, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void AvailableAssets(std::map<std::string, std::vector<COutput> >& mapAssetCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
+    void AvailableAssets(std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.
      */
     std::map<CTxDestination, std::vector<COutput>> ListCoins() const;
+
+    /**
+     * Return list of available assets and locked assets grouped by non-change output address.
+     */
+    std::map<CTxDestination, std::vector<COutput>> ListAssets() const;
+
+    /**
+     * Return list of assets balances.
+     */
+    std::map<std::string, CAmount> getAssetsBalance(const CCoinControl* coinControl = nullptr, bool fSpendable = false) const;
 
     /**
      * Find non-change parent output.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -513,7 +513,7 @@ public:
 
     void GetAmounts(std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
-    
+
     void GetAmounts(std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter, std::list<CAssetOutputEntry>& assetsReceived, std::list<CAssetOutputEntry>& assetsSent) const;
 
@@ -761,7 +761,7 @@ private:
      */
     bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet,
                     const CCoinControl& coin_control, const CoinSelectionParams& coin_selection_params, bool& bnb_used) const;
-    
+
     /**
      * Select a set of asset coins such that nValueRet >= nTargetValue and at least
      * all asset coins from coinControl are selected; Never select unconfirmed coins
@@ -938,9 +938,9 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
-    void AvailableCoins(std::vector<COutput>& vCoins, std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fGetRTM = true, bool fOnlyAssets = false, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void AvailableAssets(std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fGetRTM = true, bool fOnlyAssets = false, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AvailableAssets(std::map<std::string, std::vector<COutput>>& mapAssetCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.


### PR DESCRIPTION
- adjusted consensus checks for unique assets
- added mempool checks to prevent duplicate assets
- added mempool checks for duplicates mint tx, this is necessary to prevent duplicates uniqueId on unique assets (NFT)
- added more test cases

[QT]
- added Send Asset page
- added Asset control features

Send asset:
![image](https://user-images.githubusercontent.com/28742969/226207249-3b2a8853-3053-494b-9f2a-dbc92fa033b9.png)
Send unique asset:
![image](https://user-images.githubusercontent.com/28742969/226207271-ca59a9e3-80d1-4b31-ac4b-8131db76b9e9.png)
Asset control:
![image](https://user-images.githubusercontent.com/28742969/226207295-7b984ab7-0909-4134-8526-087ff10372a5.png)
