### PR TITLE
avoid updating the balances unnecessarily

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -442,7 +442,7 @@ public:
         return balances;
     }
 
-    bool tryGetBalances(WalletBalances& balances, int& num_blocks) override
+    bool tryGetBalances(WalletBalances& balances) override
     {
         TRY_LOCK(cs_main, locked_chain);
         if (!locked_chain) return false;
@@ -451,7 +451,6 @@ public:
             return false;
         }
         balances = getBalances();
-        num_blocks = ::chainActive.Height();
         return true;
     }
     CAmount getBalance() override

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -204,7 +204,7 @@ public:
 
     virtual std::map<CTxDestination, CAmount> GetAddressBalances() = 0;
     //! Get balances if possible without blocking.
-    virtual bool tryGetBalances(WalletBalances& balances, int& num_blocks) = 0;
+    virtual bool tryGetBalances(WalletBalances& balances) = 0;
 
     //! Get balance.
     virtual CAmount getBalance() = 0;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -81,20 +81,21 @@ void WalletModel::pollBalanceChanged()
         now = GetTimeMillis();
 
     // if we are in-sync, update the UI regardless of last update time
-    if (!ninitialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY_SYNC) {    
-        interfaces::WalletBalances new_balances;
-        int numBlocks = -1;
-        if (!m_wallet->tryGetBalances(new_balances, numBlocks)) {
-            return;
-        }
-        nLastUpdateNotification = now;
+    if (!ninitialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY_SYNC) {
 
-        if(fForceCheckBalanceChanged || numBlocks != cachedNumBlocks || node().coinJoinOptions().getRounds() != cachedCoinJoinRounds)
+        nLastUpdateNotification = now;   
+        
+        if(fForceCheckBalanceChanged || ::chainActive.Height() != cachedNumBlocks || node().coinJoinOptions().getRounds() != cachedCoinJoinRounds)
         {
+            interfaces::WalletBalances new_balances;
+            if (!m_wallet->tryGetBalances(new_balances)) {
+                return;
+            }
+            
             fForceCheckBalanceChanged = false;
 
             // Balance and number of transactions might have changed
-            cachedNumBlocks = numBlocks;
+            cachedNumBlocks = ::chainActive.Height();
             cachedCoinJoinRounds = node().coinJoinOptions().getRounds();
 
             checkBalanceChanged(new_balances);


### PR DESCRIPTION
while watching flockpool fees address that has a large amount of transaction, there is a constant cpu usage of 8-9%, with this changes the cpu usage dropped to almost 0%