### PR TITLE
[asset] add assets pages

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -31,7 +31,9 @@ QT_FORMS_UI = \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
   qt/forms/sendassetsdialog.ui \
+  qt/forms/createassetsdialog.ui \
   qt/forms/sendassetsentry.ui \
+  qt/forms/assetsdialog.ui \
   qt/forms/signverifymessagedialog.ui \
   qt/forms/transactiondescdialog.ui
 
@@ -78,7 +80,9 @@ QT_MOC_CPP = \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sendcoinsentry.cpp \
   qt/moc_sendassetsdialog.cpp \
+  qt/moc_createassetsdialog.cpp \
   qt/moc_sendassetsentry.cpp \
+  qt/moc_assetsdialog.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
   qt/moc_trafficgraphwidget.cpp \
@@ -277,6 +281,8 @@ BITCOIN_QT_WALLET_CPP = \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
   qt/sendassetsdialog.cpp \
+  qt/createassetsdialog.cpp \
+  qt/assetsdialog.cpp \
   qt/sendassetsentry.cpp \
   qt/signverifymessagedialog.cpp \
   qt/smartnodelist.cpp \

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -16,6 +16,8 @@ class CUpdateAssetTx;
 
 class CMintAssetTx;
 
+class UniValue;
+
 struct CAssetOutputEntry;
 struct CBlockAssetUndo;
 
@@ -86,6 +88,8 @@ public:
         ownerAddress = CKeyID();
         collateralAddress = CKeyID();
     }
+
+    void ToJson(UniValue &obj) const;
 };
 
 class CDatabaseAssetData {

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -182,15 +182,8 @@ bool CheckNewAssetTx(const CTransaction &tx, const CBlockIndex *pindexPrev, CVal
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-collateralAddress");
     }
 
-    int hashlen = assetTx.referenceHash.length();
-    //ipfs alway start with 'Qm' and length 46
-    if ((hashlen == 46 && assetTx.referenceHash.substr(0, 2) != "Qm")) {
+    if ((assetTx.referenceHash.length() > 128)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-referenceHash");
-    } else {
-        //hex encoded hash minimum length 40 (160 bits)
-        if (hashlen > 0 && hashlen != 46 && (!IsHex(assetTx.referenceHash) || hashlen < 40 || hashlen > 64)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-assets-referenceHash");
-        }
     }
 
     if (!validateAmount(assetTx.amount, assetTx.decimalPoint)) {

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -107,6 +107,10 @@ inline bool checkNewUniqueAsset(CNewAssetTx &assetTx, CValidationState &state) {
     if (!assetTx.isUnique)
         return true;
 
+    if (assetTx.amount > 500 * COIN) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-assets-amount");
+    }
+
     if (assetTx.decimalPoint > 0) { // alway 0
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-decimalPoint");
     }
@@ -115,7 +119,7 @@ inline bool checkNewUniqueAsset(CNewAssetTx &assetTx, CValidationState &state) {
         return state.DoS(100, false, REJECT_INVALID, "bad-unique-assets-distibution-type");
     }
 
-    if (assetTx.updatable) { // manual mint only?
+    if (assetTx.updatable) {
         return state.DoS(100, false, REJECT_INVALID, "bad-unique-assets-distibution-type");
     }
 
@@ -179,8 +183,14 @@ bool CheckNewAssetTx(const CTransaction &tx, const CBlockIndex *pindexPrev, CVal
     }
 
     int hashlen = assetTx.referenceHash.length();
-    if ((hashlen != 0 && hashlen != 46) || (hashlen == 46 && assetTx.referenceHash.substr(0, 2) != "Qm")) {           
+    //ipfs alway start with 'Qm' and length 46
+    if ((hashlen == 46 && assetTx.referenceHash.substr(0, 2) != "Qm")) {
         return state.DoS(100, false, REJECT_INVALID, "bad-assets-referenceHash");
+    } else {
+        //hex encoded hash minimum length 40 (160 bits)
+        if (hashlen > 0 && hashlen != 46 && (!IsHex(assetTx.referenceHash) || hashlen < 40 || hashlen > 64)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-assets-referenceHash");
+        }
     }
 
     if (!validateAmount(assetTx.amount, assetTx.decimalPoint)) {

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -308,6 +308,21 @@ namespace interfaces {
             return tx;
         }
 
+        bool createTransaction(const std::vector <CRecipient> &recipients,
+                                          CTransactionRef &tx,
+                                          const CCoinControl &coin_control,
+                                          bool sign,
+                                          int &change_pos,
+                                          CAmount &fee,
+                                          std::string &fail_reason,
+                                          int nExtraPayloadSize = 0,
+                                          CNewAssetTx *newAsset = nullptr,
+                                          CMintAssetTx *mint = nullptr) override {
+            LOCK(m_wallet->cs_wallet);
+            return m_wallet->CreateTransaction(recipients, tx, fee, change_pos, fail_reason, coin_control, sign,
+                                             nExtraPayloadSize, nullptr, newAsset ,mint);
+        }
+
         void commitTransaction(CTransactionRef tx, WalletValueMap value_map, WalletOrderForm order_form) override {
             LOCK(m_wallet->cs_wallet);
             CReserveKey m_key(m_wallet.get());
@@ -490,6 +505,14 @@ namespace interfaces {
             }
             return result;
         }
+        void AvailableCoins(std::vector <COutput> &vCoins, bool fOnlySafe, const CCoinControl *coinControl,
+                        const CAmount &nMinimumAmount, const CAmount &nMaximumAmount,
+                        const CAmount &nMinimumSumAmount, const uint64_t nMaximumCount,
+                        const int nMinDepth, const int nMaxDepth)  override {
+            LOCK(m_wallet->cs_wallet);
+            m_wallet->AvailableCoins(vCoins, fOnlySafe, coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount,
+                        nMaximumCount, nMinDepth, nMaxDepth);
+        }
 
         CoinsList listAssets() override {
             LOCK(m_wallet->cs_wallet);
@@ -539,6 +562,19 @@ namespace interfaces {
         AssetBalance getAssetsBalance(const CCoinControl *coinControl, bool fSpendable) override {
             LOCK(m_wallet->cs_wallet);
             return m_wallet->getAssetsBalance(coinControl, fSpendable);
+        }
+
+        std::map<std::string, std::pair<CAmount, CAmount>> getAssetsBalanceAll() override {
+            LOCK(m_wallet->cs_wallet);
+            return m_wallet->getAssetsBalanceAll();
+        }
+
+        std::map <uint256, std::pair<std::string, CKeyID>> getMyAssets() override {
+            LOCK(m_wallet->cs_wallet);
+            std::map <uint256, std::pair<std::string, CKeyID>> result;
+            for (auto it : m_wallet->mapAsset)
+                result.insert(it);
+            return result;
         }
 
         std::vector <WalletTxOut> getCoins(const std::vector <COutPoint> &outputs) override {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -31,12 +31,16 @@ class CKey;
 
 class CWallet;
 
+class COutput;
+
 enum class FeeReason;
 enum class TransactionError;
 enum class WalletCreationStatus;
 enum isminetype : unsigned int;
 struct CRecipient;
 struct FuturePartialPayload;
+class CNewAssetTx;
+class CMintAssetTx;
 struct WalletContext;
 typedef uint8_t isminefilter;
 
@@ -186,6 +190,18 @@ namespace interfaces {
                                                   std::string &fail_reason,
                                                   int nExtraPayloadSize = 0,
                                                   FuturePartialPayload *fpp = nullptr) = 0;
+        
+        //! Create transaction.
+        virtual bool createTransaction(const std::vector <CRecipient> &recipients,
+                                                  CTransactionRef &tx,
+                                                  const CCoinControl &coin_control,
+                                                  bool sign,
+                                                  int &change_pos,
+                                                  CAmount &fee,
+                                                  std::string &fail_reason,
+                                                  int nExtraPayloadSize = 0,
+                                                  CNewAssetTx *newAsset = nullptr,
+                                                  CMintAssetTx *mint = nullptr) = 0;
 
         //! Commit transaction.
         virtual void commitTransaction(CTransactionRef tx, WalletValueMap value_map, WalletOrderForm order_form) = 0;
@@ -270,6 +286,12 @@ namespace interfaces {
 
         virtual CoinsList listCoins() = 0;
 
+        //return AvailableCoins
+        virtual void AvailableCoins(std::vector <COutput> &vCoins, bool fOnlySafe = true, const CCoinControl *coinControl = nullptr,
+                        const CAmount &nMinimumAmount = 1, const CAmount &nMaximumAmount = MAX_MONEY,
+                        const CAmount &nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0,
+                        const int nMinDepth = 0, const int nMaxDepth = 9999999) = 0;
+
         //! Return AvailableAssets + LockedAssets grouped by wallet address.
         //! (put change in one group with wallet address)
         virtual CoinsList listAssets() = 0;
@@ -288,6 +310,11 @@ namespace interfaces {
         using AssetBalance = std::map<std::string, CAmount>;
 
         virtual AssetBalance getAssetsBalance(const CCoinControl *coinControl = nullptr, bool fSpendable = false) = 0;
+
+        virtual std::map<std::string, std::pair<CAmount, CAmount>> getAssetsBalanceAll() = 0;
+
+        //return list of assets that the wallet has ownership
+        virtual std::map <uint256, std::pair<std::string, CKeyID>> getMyAssets() = 0;
 
         //! Return wallet transaction output information.
         virtual std::vector <WalletTxOut> getCoins(const std::vector <COutPoint> &outputs) = 0;

--- a/src/qt/assetcontroldialog.cpp
+++ b/src/qt/assetcontroldialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2015 The BitAsset Core developers
+// Copyright (c) 2011-2015 The Bitcoin Core developers
 // Copyright (c) 2014-2021 The Dash Core developers
 // Copyright (c) 2020-2023 The Raptoreum developers
 // Distributed under the MIT software license, see the accompanying

--- a/src/qt/assetcontroldialog.h
+++ b/src/qt/assetcontroldialog.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2015 The Bitcoin Core developers
+// Copyright (c) 2020-2023 The Raptoreum developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/assetcontroldialog.h
+++ b/src/qt/assetcontroldialog.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2015 The BitAsset Core developers
+// Copyright (c) 2011-2015 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/assetcontroltreewidget.cpp
+++ b/src/qt/assetcontroltreewidget.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2015 The Bitcoin Core developers
+// Copyright (c) 2020-2023 The Raptoreum developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/assetcontroltreewidget.cpp
+++ b/src/qt/assetcontroltreewidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2015 The BitAsset Core developers
+// Copyright (c) 2011-2015 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/assetcontroltreewidget.h
+++ b/src/qt/assetcontroltreewidget.h
@@ -1,9 +1,9 @@
-// Copyright (c) 2011-2014 The BitAsset Core developers
+// Copyright (c) 2011-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITAsset_QT_AssetCONTROLTREEWIDGET_H
-#define BITAsset_QT_AssetCONTROLTREEWIDGET_H
+#ifndef BITCOIN_QT_ASSETCONTROLTREEWIDGET_H
+#define BITCOIN_QT_ASSETCONTROLTREEWIDGET_H
 
 #include <QKeyEvent>
 #include <QTreeWidget>
@@ -18,4 +18,4 @@ protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
 };
 
-#endif // BITAsset_QT_AssetCONTROLTREEWIDGET_H
+#endif // BITCOIN_QT_ASSETCONTROLTREEWIDGET_H

--- a/src/qt/assetcontroltreewidget.h
+++ b/src/qt/assetcontroltreewidget.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2011-2014 The Bitcoin Core developers
+// Copyright (c) 2020-2023 The Raptoreum developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/qt/assetsdialog.cpp
+++ b/src/qt/assetsdialog.cpp
@@ -1,0 +1,439 @@
+// Copyright (c) 2020-2023 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <qt/assetsdialog.h>
+#include <qt/forms/ui_assetsdialog.h>
+
+#include <chainparams.h>
+#include <qt/clientmodel.h>
+#include <clientversion.h>
+#include <coins.h>
+#include <qt/guiutil.h>
+#include <qt/walletmodel.h>
+#include <qt/optionsmodel.h>
+#include <wallet/wallet.h>
+#include <validation.h>
+#include <assets/assets.h>
+#include <assets/assetstype.h>
+#include <qt/bitcoinunits.h>
+
+#include <univalue.h>
+
+#include <QMessageBox>
+#include <QPushButton>
+#include <QTableWidgetItem>
+#include <QtGui/QClipboard>
+
+template<typename T>
+class CAssetListWidgetItem : public QTableWidgetItem {
+    T itemData;
+
+public:
+    explicit CAssetListWidgetItem(const QString &text, const T &data, int type = Type) :
+            QTableWidgetItem(text, type),
+            itemData(data) {}
+
+    bool operator<(const QTableWidgetItem &other) const override {
+        return itemData < ((CAssetListWidgetItem *) &other)->itemData;
+    }
+};
+
+AssetsDialog::AssetsDialog(QWidget *parent) :
+        QDialog(parent),
+        ui(new Ui::AssetsDialog) {
+    ui->setupUi(this);
+
+    GUIUtil::setFont({ui->label_filter_2, ui->assetinfolabel, ui->recentlabel}, GUIUtil::FontWeight::Bold, 16);
+    GUIUtil::setFont({ui->label_6, ui->label_4, ui->label_3, ui->label_4, ui->label_5,
+                        ui->errorLabel}, GUIUtil::FontWeight::Bold, 14);
+    GUIUtil::setFont({ui->idTextLablel, ui->nameTextLabel, ui->typeLabel,
+                        ui->suplyTextLabel}, GUIUtil::FontWeight::Normal, 14);
+
+    int columnNameWidth = 300;
+    int columnIdWidth = 80;
+    int columnBalanceWidth = 120;
+
+    ui->tableWidgetAssets->verticalHeader()->hide();
+    ui->tableWidgetAssets->setColumnWidth(COLUMN_NAME, columnNameWidth);
+    ui->tableWidgetAssets->setColumnWidth(COLUMN_ID, columnIdWidth);
+    ui->tableWidgetAssets->setColumnHidden(COLUMN_ID, true);
+    ui->tableWidgetAssets->setColumnWidth(COLUMN_CONFIRMED, columnBalanceWidth);
+    ui->tableWidgetAssets->setColumnWidth(COLUMN_PENDING, columnBalanceWidth);
+
+    ui->tableWidgetAssets->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    QAction *sendAssetAction = new QAction(tr("Send asset"), this);
+    QAction *copyAssetNameAction = new QAction(tr("Copy asset name"), this);
+    QAction *detailsAction = new QAction(tr("View details"), this);
+    
+    contextMenuAsset = new QMenu(this);
+    contextMenuAsset->addAction(sendAssetAction);
+    contextMenuAsset->addAction(detailsAction);
+
+    connect(ui->tableWidgetAssets, &QTableWidget::customContextMenuRequested, this,
+            &AssetsDialog::showContextMenuAsset);
+    connect(ui->tableWidgetAssets, &QTableWidget::cellClicked, this, &AssetsDialog::Asset_clicked);
+    connect(ui->tableWidgetAssets, &QTableWidget::doubleClicked, this, &AssetsDialog::Asset_details_clicked);
+    connect(sendAssetAction, &QAction::triggered, this, &AssetsDialog::SendAsset_clicked);
+    connect(detailsAction, &QAction::triggered, this, &AssetsDialog::Asset_details_clicked);
+    
+    timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, &AssetsDialog::updateAssetBalanceScheduled);
+    timer->start(1000);
+
+    ui->updateButton->setEnabled(false);
+    ui->mintButton->setEnabled(false);
+    ui->updateButton->setVisible(false);
+    ui->mintButton->setVisible(false);
+    ui->errorLabel->setVisible(false);
+    ui->errorTextLabel->setVisible(false);
+    ui->errorTextLabel->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_INVALID));
+
+    GUIUtil::updateFonts();
+}
+
+AssetsDialog::~AssetsDialog() {
+    delete ui;
+}
+
+void AssetsDialog::setClientModel(ClientModel *model) {
+    this->clientModel = model;
+}
+
+void AssetsDialog::setModel(WalletModel *model) {
+    this->walletModel = model;
+    balanceChanged = true;
+}
+
+void AssetsDialog::showContextMenuAsset(const QPoint &point) {
+    QTableWidgetItem *item = ui->tableWidgetAssets->itemAt(point);
+    if (item) contextMenuAsset->exec(QCursor::pos());
+}
+
+void AssetsDialog::updateAssetBalance(){
+    balanceChanged = true;
+}
+
+void AssetsDialog::updateAssetBalanceScheduled() {
+    if (!walletModel || !clientModel || clientModel->node().shutdownRequested() || !balanceChanged) {
+        return;
+    }
+
+    balanceChanged = false;
+
+    ui->tableWidgetAssets->setSortingEnabled(false);
+    ui->tableWidgetAssets->clearContents();
+    ui->tableWidgetAssets->setRowCount(0);
+
+     std::map<std::string, std::pair<CAmount, CAmount>> assetsbalance = walletModel->wallet().getAssetsBalanceAll();
+    for (auto it : assetsbalance){
+        CAssetMetaData asset;
+        if (!passetsCache->GetAssetMetaData(it.first, asset))
+            continue; //this should never happen
+
+        QTableWidgetItem *name = new CAssetListWidgetItem<QString>(
+                QString::fromStdString(asset.name), QString::fromStdString(asset.name));
+        QTableWidgetItem *asset_Id = new CAssetListWidgetItem<QString>(
+                QString::fromStdString(it.first), QString::fromStdString(it.first));
+        QTableWidgetItem *confirmed = new CAssetListWidgetItem<CAmount>(
+                BitcoinUnits::format(8, it.second.first / BitcoinUnits::factorAsset(MAX_ASSET_UNITS -  asset.decimalPoint) , false, BitcoinUnits::separatorAlways, asset.decimalPoint), it.second.first);
+        QTableWidgetItem *pending = new CAssetListWidgetItem<CAmount>(
+                BitcoinUnits::format(8, it.second.second / BitcoinUnits::factorAsset(MAX_ASSET_UNITS -  asset.decimalPoint) , false, BitcoinUnits::separatorAlways, asset.decimalPoint), it.second.second);
+                
+
+        ui->tableWidgetAssets->insertRow(0);
+        ui->tableWidgetAssets->setItem(0, COLUMN_NAME, name);
+        ui->tableWidgetAssets->setItem(0, COLUMN_ID, asset_Id);
+        ui->tableWidgetAssets->setItem(0, COLUMN_CONFIRMED, confirmed);
+        ui->tableWidgetAssets->setItem(0, COLUMN_PENDING, pending);
+    }
+    //map of assets that the wallet own, this is need for display assets with 0 balance
+    std::map <uint256, std::pair<std::string, CKeyID>> myassets = walletModel->wallet().getMyAssets();
+    for (auto it : myassets){
+        std::string assetId = it.first.ToString();
+
+        auto tmp = assetsbalance.find(assetId);
+        if (tmp != assetsbalance.end() || !walletModel->wallet().isSpendable(it.second.second))
+            continue;
+        
+        QTableWidgetItem *name = new CAssetListWidgetItem<QString>(
+                QString::fromStdString(it.second.first), QString::fromStdString(it.second.first));
+        QTableWidgetItem *asset_Id = new CAssetListWidgetItem<QString>(
+                QString::fromStdString(assetId), QString::fromStdString(assetId));
+        QTableWidgetItem *confirmed = new CAssetListWidgetItem<CAmount>(
+                QString::number(0), 0);
+        QTableWidgetItem *pending = new CAssetListWidgetItem<CAmount>(
+                QString::number(0), 0);
+                
+        ui->tableWidgetAssets->insertRow(0);
+        ui->tableWidgetAssets->setItem(0, COLUMN_NAME, name);
+        ui->tableWidgetAssets->setItem(0, COLUMN_ID, asset_Id);
+        ui->tableWidgetAssets->setItem(0, COLUMN_CONFIRMED, confirmed);
+        ui->tableWidgetAssets->setItem(0, COLUMN_PENDING, pending);
+    }
+
+    ui->tableWidgetAssets->setSortingEnabled(true);
+}
+
+std::string AssetsDialog::GetSelectedAsset() {
+    if (!clientModel) {
+        return "";
+    }
+
+    QItemSelectionModel *selectionModel = ui->tableWidgetAssets->selectionModel();
+    QModelIndexList selected = selectionModel->selectedRows();
+
+    if (selected.count() == 0) return "";
+
+    QModelIndex index = selected.at(0);
+    int nSelectedRow = index.row();
+    return ui->tableWidgetAssets->item(nSelectedRow, COLUMN_ID)->text().toStdString();
+}
+
+void AssetsDialog::SendAsset_clicked() {
+    std::string assetId = GetSelectedAsset();
+
+    if(assetId == "") return;
+    CAssetMetaData asset;
+    if (passetsCache->GetAssetMetaData(assetId, asset))
+        Q_EMIT assetSendClicked(asset.name);
+}
+
+void AssetsDialog::Asset_clicked() {
+    std::string assetId = GetSelectedAsset();
+
+    if(assetId == "") return;
+
+    ui->idTextLablel->setText(QString::fromStdString(assetId));
+    CAssetMetaData asset;
+    if (!passetsCache->GetAssetMetaData(assetId, asset)){
+        ui->errorLabel->setVisible(true);
+        ui->errorTextLabel->setVisible(true);
+        ui->errorTextLabel->setText("Asset metadata not found.\n(Not mined on a block)");
+        ui->nameTextLabel->clear();
+        ui->suplyTextLabel->clear();
+        ui->typeLabel->clear();
+        ui->mintButton->setEnabled(false);
+        ui->updateButton->setEnabled(false);
+        return;      
+    }
+    //hide error labels
+    ui->errorLabel->setVisible(false);
+    ui->errorTextLabel->setVisible(false);
+
+    ui->nameTextLabel->setText(QString::fromStdString(asset.name));
+    ui->typeLabel->setText( asset.isUnique ? "Unique/NFT" : "Root");
+    if (asset.mintCount > 0) {
+        ui->suplyTextLabel->setText(BitcoinUnits::format(8, (asset.amount * asset.mintCount) / 
+                        BitcoinUnits::factorAsset(MAX_ASSET_UNITS -  asset.decimalPoint) , false, 
+                        BitcoinUnits::separatorAlways, asset.decimalPoint));
+    } else {
+        ui->suplyTextLabel->setText("0");
+    }
+    
+    if (walletModel->wallet().isSpendable(asset.ownerAddress)){
+        ui->updateButton->setVisible(true);
+        ui->mintButton->setVisible(true);
+        ui->mintButton->setEnabled(asset.mintCount < asset.maxMintCount ? true : false);
+        ui->updateButton->setEnabled(asset.updatable ? true : false);
+    } else {
+        ui->updateButton->setVisible(false);
+        ui->mintButton->setVisible(false);
+        ui->mintButton->setEnabled(false);
+        ui->updateButton->setEnabled(false);
+    }
+}
+
+void AssetsDialog::Asset_details_clicked() {
+    std::string assetId = GetSelectedAsset();
+
+    if(assetId == "") return;
+
+    CAssetMetaData asset;
+    if (passetsCache->GetAssetMetaData(assetId, asset)) {
+        UniValue json(UniValue::VOBJ);
+        asset.ToJson(json);
+
+        // Title of popup window
+        QString strWindowtitle = tr("Details for asset: %1").arg(
+                QString::fromStdString(asset.name));
+        QString strText = QString::fromStdString(json.write(2));
+
+        QMessageBox::information(this, strWindowtitle, strText);
+    }
+}
+
+void AssetsDialog::on_mintButton_clicked() {
+    if (!walletModel || !walletModel->getOptionsModel())
+        return;
+
+    if (getAssetsFees() == 0) {
+        QMessageBox msgBox;
+        msgBox.setText(QString::fromStdString("Under maintenance, try again later."));
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
+        return;
+    }
+
+    // request unlock only if was locked or unlocked for mixing:
+    // this way we let users unlock by walletpassphrase or by menu
+    // and make many transactions while unlocking through this dialog
+    // will call relock
+    WalletModel::EncryptionStatus encStatus = walletModel->getEncryptionStatus();
+    if (encStatus == walletModel->Locked || encStatus == walletModel->UnlockedForMixingOnly) {
+        WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+        if (!ctx.isValid()) {
+            // Unlock wallet was cancelled
+            return;
+        }
+    }
+
+    std::string assetId = ui->idTextLablel->text().toStdString();
+
+    // get asset metadadta
+    CAssetMetaData tmpAsset;
+    if (!passetsCache->GetAssetMetaData(assetId, tmpAsset)) {
+        QMessageBox msgBox;
+        msgBox.setText("ERROR: Asset metadata not found");
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
+        return;
+    }
+
+    CMintAssetTx mintAsset;
+    mintAsset.assetId = tmpAsset.assetId;
+    mintAsset.fee = getAssetsFees();
+
+    CTxDestination ownerAddress = CTxDestination(tmpAsset.ownerAddress);
+    if (!IsValidDestination(ownerAddress)) {
+        QMessageBox msgBox;
+        msgBox.setText("ERROR: Invalid owner address");
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
+        return;
+    }
+
+    CCoinControl coinControl;
+
+    coinControl.destChange = ownerAddress;
+    coinControl.fRequireAllInputs = false;
+
+    std::vector <COutput> vecOutputs;
+    //select only confirmed inputs, nMinDepth >= 1
+    walletModel->wallet().AvailableCoins(vecOutputs, true, nullptr, 1, MAX_MONEY , MAX_MONEY, 0, 1);
+
+    for (const auto &out: vecOutputs) {
+        CTxDestination txDest;
+        if (ExtractDestination(out.tx->tx->vout[out.i].scriptPubKey, txDest) && txDest == ownerAddress) {
+            coinControl.Select(COutPoint(out.tx->tx->GetHash(), out.i));
+        }
+    }
+
+    if (!coinControl.HasSelected()) {
+        return;
+    }
+
+    CTransactionRef wtx;
+    CAmount nFee;
+    int nChangePos = -1;
+    std::string strFailReason;
+    std::vector <CRecipient> vecSend;
+
+    if (tmpAsset.isUnique) {
+        uint32_t endid = (tmpAsset.circulatingSupply + tmpAsset.amount) / COIN;
+        //build unique outputs using current supply as start unique id
+        for (int id = tmpAsset.circulatingSupply / COIN; id < endid; ++id) {
+            // Get the script for the target address
+            CScript scriptPubKey = GetScriptForDestination(
+                    DecodeDestination(EncodeDestination(tmpAsset.targetAddress)));
+            // Update the scriptPubKey with the transfer asset information
+            CAssetTransfer assetTransfer(tmpAsset.assetId, 1 * COIN, id);
+            assetTransfer.BuildAssetTransaction(scriptPubKey);
+
+            CRecipient recipient = {scriptPubKey, 0, false};
+            vecSend.push_back(recipient);
+        }
+    } else {
+        // Get the script for the target address
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(EncodeDestination(tmpAsset.targetAddress)));
+        // Update the scriptPubKey with the transfer asset information
+        CAssetTransfer assetTransfer(tmpAsset.assetId, tmpAsset.amount);
+        assetTransfer.BuildAssetTransaction(scriptPubKey);
+
+        CRecipient recipient = {scriptPubKey, 0, false};
+        vecSend.push_back(recipient);
+    }
+    int Payloadsize;
+
+    if (!walletModel->wallet().createTransaction(vecSend, wtx, coinControl, true, nChangePos, nFee, strFailReason,
+                                Payloadsize, nullptr, &mintAsset)) {
+        //handle creation error
+        QMessageBox msgBox;
+        msgBox.setText(QString::fromStdString(strFailReason));
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
+        return;
+    }
+    QString questionString = tr("Mint details:");
+    questionString.append("<hr />");
+    questionString.append(tr("Name: %1 <br>").arg(QString::fromStdString(tmpAsset.name)));
+    questionString.append(tr("Amount: %1").arg(QString::number(tmpAsset.amount / COIN)));
+    // Display message box
+    nFee += tmpAsset.fee * COIN;
+    if (nFee > 0) {
+        // append fee string if a fee is required
+        questionString.append(
+                "<hr /><span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>");
+        questionString.append(BitcoinUnits::formatHtmlWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), nFee));
+        questionString.append("</span> ");
+        questionString.append(tr("are added as transaction fee.<hr />"));
+    }
+    MintAssetConfirmationDialog confirmationDialog(tr("Confirm Asset Mint"),
+                                                   questionString, 3, this);
+    confirmationDialog.exec();
+    QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
+    if (retval != QMessageBox::Yes) {
+        return;
+    }
+    walletModel->wallet().commitTransaction(wtx, {}, {});
+
+    //disable mint button
+    if (tmpAsset.mintCount + 1 >= tmpAsset.maxMintCount)
+            ui->mintButton->setEnabled(false);
+}
+
+MintAssetConfirmationDialog::MintAssetConfirmationDialog(const QString &title, const QString &text, int _secDelay,
+                                                         QWidget *parent) :
+        QMessageBox(QMessageBox::Question, title, text, QMessageBox::Yes | QMessageBox::Cancel, parent),
+        secDelay(_secDelay) {
+    GUIUtil::updateFonts();
+    setDefaultButton(QMessageBox::Cancel);
+    yesButton = button(QMessageBox::Yes);
+    updateYesButton();
+    connect(&countDownTimer, SIGNAL(timeout()), this, SLOT(countDown()));
+}
+
+int MintAssetConfirmationDialog::exec() {
+    updateYesButton();
+    countDownTimer.start(1000);
+    return QMessageBox::exec();
+}
+
+void MintAssetConfirmationDialog::countDown() {
+    secDelay--;
+    updateYesButton();
+
+    if (secDelay <= 0) {
+        countDownTimer.stop();
+    }
+}
+
+void MintAssetConfirmationDialog::updateYesButton() {
+    if (secDelay > 0) {
+        yesButton->setEnabled(false);
+        yesButton->setText(tr("Yes") + " (" + QString::number(secDelay) + ")");
+    } else {
+        yesButton->setEnabled(true);
+        yesButton->setText(tr("Yes"));
+    }
+}

--- a/src/qt/assetsdialog.h
+++ b/src/qt/assetsdialog.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2020-2023 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_QT_ASSETSDIALOG_H
+#define BITCOIN_QT_ASSETSDIALOG_H
+
+#include <primitives/transaction.h>
+#include <sync.h>
+#include <util/system.h>
+
+#include <QMenu>
+#include <QTimer>
+#include <QMessageBox>
+#include <QDialog>
+
+#define ASSETSDIALOG_UPDATE_SECONDS 3
+#define ASSETSDIALOG_FILTER_COOLDOWN_SECONDS 3
+
+namespace Ui {
+    class AssetsDialog;
+}
+
+class ClientModel;
+
+class WalletModel;
+
+QT_BEGIN_NAMESPACE
+class QModelIndex;
+QT_END_NAMESPACE
+
+/** Smartnode Manager page widget */
+class AssetsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit AssetsDialog(QWidget *parent = 0);
+
+    ~AssetsDialog();
+
+    enum {
+        COLUMN_NAME,
+        COLUMN_ID,
+        COLUMN_CONFIRMED,
+        COLUMN_PENDING,
+    };
+
+    void setClientModel(ClientModel *clientModel);
+
+    void setModel(WalletModel *walletModel);
+
+    void updateAssetBalance();
+
+    Q_SIGNALS:
+    void assetSendClicked(const std::string &assetId);
+
+private:
+    QMenu *contextMenuAsset;
+
+    QTimer *timer;
+    Ui::AssetsDialog *ui;
+    ClientModel *clientModel{nullptr};
+    WalletModel *walletModel{nullptr};
+
+    bool balanceChanged{true};
+
+    std::string GetSelectedAsset();
+
+    Q_SIGNALS:
+        void doubleClicked(const QModelIndex&);
+
+private
+    Q_SLOTS:
+
+        void on_mintButton_clicked();
+
+        void showContextMenuAsset(const QPoint&);
+
+        void updateAssetBalanceScheduled();
+
+        void Asset_clicked();
+
+        void Asset_details_clicked();
+
+        void SendAsset_clicked();
+
+};
+
+class MintAssetConfirmationDialog : public QMessageBox {
+    Q_OBJECT
+
+public:
+    MintAssetConfirmationDialog(const QString &title, const QString &text, int secDelay = 0, QWidget *parent = 0);
+
+    int exec();
+
+private
+    Q_SLOTS:
+            void countDown();
+
+    void updateYesButton();
+
+private:
+    QAbstractButton *yesButton;
+    QTimer countDownTimer;
+    int secDelay;
+};
+
+#endif // BITCOIN_QT_ASSETSDIALOG_H

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -98,7 +98,10 @@ public:
     }
 
     void setValue(const CAmount &value) {
-        setText(BitcoinUnits::format(currentUnit, value, false, BitcoinUnits::separatorAlways, assetUnit));
+        if (assetUnit >= 0)
+            setText(BitcoinUnits::format(currentUnit, value / BitcoinUnits::factorAsset(MAX_ASSET_UNITS -  assetUnit) , false, BitcoinUnits::separatorAlways, assetUnit));
+        else
+            setText(BitcoinUnits::format(currentUnit, value, false, BitcoinUnits::separatorAlways, assetUnit));
         Q_EMIT valueChanged();
     }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -162,7 +162,9 @@ private:
     QToolBar *appToolBar = nullptr;
     QToolButton *overviewButton = nullptr;
     QToolButton *sendCoinsButton = nullptr;
-    QToolButton *sendAssetsButton;
+    QToolButton *sendAssetsButton  = nullptr;
+    QToolButton *createAssetsButton  = nullptr;
+    QToolButton *myAssetsButton  = nullptr;
     QToolButton *coinJoinCoinsButton = nullptr;
     QToolButton *receiveCoinsButton = nullptr;
     QToolButton *historyButton = nullptr;
@@ -170,7 +172,8 @@ private:
     QAction *appToolBarLogoAction = nullptr;
     QAction *quitAction = nullptr;
     QAction *sendCoinsMenuAction = nullptr;
-    QAction *sendAssetsMenuAction;
+    QAction *sendAssetsMenuAction = nullptr;
+    QAction *createAssetsMenuAction = nullptr;
     QAction *coinJoinCoinsMenuAction = nullptr;
     QAction *usedSendingAddressesAction = nullptr;
     QAction *usedReceivingAddressesAction = nullptr;
@@ -369,6 +372,10 @@ public
             void gotoSendCoinsPage(QString addr = "");
             /** Switch to send assets page */
             void gotoSendAssetsPage(QString addr = "");
+            /** Switch to create assets page */
+            void gotoCreateAssetsPage();
+            /** Switch to my assets page */
+            void gotoMyAssetsPage();
             /** Switch to CoinJoin coins page */
             void gotoCoinJoinCoinsPage(QString addr = "");
 

--- a/src/qt/createassetsdialog.cpp
+++ b/src/qt/createassetsdialog.cpp
@@ -386,7 +386,7 @@ bool CreateAssetsDialog::validateInputs() {
     }
 
     std::string ipfshash = ui->ipfsText->text().toStdString();
-    if ( ipfshash.length() > 128)) {
+    if (ipfshash.length() > 128) {
         retval = false;
         ui->ipfsText->setValid(false);
     }

--- a/src/qt/createassetsdialog.cpp
+++ b/src/qt/createassetsdialog.cpp
@@ -1,0 +1,781 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Copyright (c) 2014-2021 The Dash Core developers
+// Copyright (c) 2020-2023 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/createassetsdialog.h>
+#include <qt/forms/ui_createassetsdialog.h>
+
+#include <qt/addresstablemodel.h>
+#include <qt/bitcoinunits.h>
+#include <qt/clientmodel.h>
+#include <qt/coincontroldialog.h>
+#include <qt/guiutil.h>
+#include <qt/optionsmodel.h>
+#include <qt/sendassetsentry.h>
+
+#include <chainparams.h>
+#include <interfaces/node.h>
+#include <key_io.h>
+#include <wallet/coincontrol.h>
+#include <ui_interface.h>
+#include <txmempool.h>
+#include <policy/fees.h>
+#include <wallet/fees.h>
+#include <wallet/wallet.h>
+#include <future/fee.h>
+#include <spork.h>
+#include <validation.h>
+#include <assets/assets.h>
+#include <assets/assetstype.h>
+
+#include <QFontMetrics>
+#include <QScrollBar>
+#include <QSettings>
+#include <QTextDocument>
+
+#define SEND_CONFIRM_DELAY   3
+
+CreateAssetsDialog::CreateAssetsDialog(QWidget *parent) :
+        QDialog(parent),
+        ui(new Ui::CreateAssetsDialog),
+        clientModel(nullptr),
+        model(nullptr),
+        m_coin_control(new CCoinControl),
+        fFeeMinimized(true) {
+    ui->setupUi(this);
+
+    GUIUtil::setFont({ui->labelCoinControlFeatures,
+                      ui->labelCoinControlInsuffFunds,
+                      ui->labelCoinControlQuantityText,
+                      ui->labelCoinControlBytesText,
+                      ui->labelCoinControlAmountText,
+                      ui->labelCoinControlLowOutputText,
+                      ui->labelCoinControlFeeText,
+                      ui->labelCoinControlAfterFeeText,
+                      ui->labelCoinControlChangeText,
+                      ui->labelFeeHeadline,
+                      ui->fallbackFeeWarningLabel
+                     }, GUIUtil::FontWeight::Bold);
+
+    GUIUtil::setFont({ui->labelBalance,
+                      ui->labelBalanceText
+                     }, GUIUtil::FontWeight::Bold, 14);
+
+    GUIUtil::setFont({ui->labelCoinControlFeatures
+                     }, GUIUtil::FontWeight::Bold, 16);
+
+    GUIUtil::setFont({ui->assetNameLabel,
+                      ui->addressLabel,
+                      ui->unitsLabel,
+                      ui->typeLabel,
+                      ui->quantityLabel,
+                      ui->targetLabel,
+                      ui->mintLabel,
+                      ui->ipfsLabel,
+                      ui->uniqueBox,
+                      ui->updatableBox,
+                      ui->IssueFrequencyLabel}, GUIUtil::FontWeight::Normal, 15);
+
+    GUIUtil::setupAddressWidget(ui->lineEditCoinControlChange, this);
+    GUIUtil::setupAddressWidget(ui->owneraddressText, this);
+    GUIUtil::setupAddressWidget(ui->targetaddressText, this);
+
+    GUIUtil::updateFonts();
+
+    connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+    connect(ui->availabilityButton, SIGNAL(clicked()), this, SLOT(checkAvailabilityClicked()));
+    connect(ui->uniqueBox, SIGNAL(clicked()), this, SLOT(onUniqueChanged()));
+
+    // Coin Control
+    connect(ui->pushButtonCoinControl, SIGNAL(clicked()), this, SLOT(CoinControlButtonClicked()));
+    connect(ui->checkBoxCoinControlChange, SIGNAL(stateChanged(int)), this, SLOT(CoinControlChangeChecked(int)));
+    connect(ui->lineEditCoinControlChange, SIGNAL(textEdited(
+    const QString &)), this, SLOT(CoinControlChangeEdited(
+    const QString &)));
+
+    // Coin Control: clipboard actions
+    QAction *clipboardQuantityAction = new QAction(tr("Copy quantity"), this);
+    QAction *clipboardAmountAction = new QAction(tr("Copy amount"), this);
+    QAction *clipboardFeeAction = new QAction(tr("Copy fee"), this);
+    QAction *clipboardAfterFeeAction = new QAction(tr("Copy after fee"), this);
+    QAction *clipboardBytesAction = new QAction(tr("Copy bytes"), this);
+    QAction *clipboardLowOutputAction = new QAction(tr("Copy dust"), this);
+    QAction *clipboardChangeAction = new QAction(tr("Copy change"), this);
+    connect(clipboardQuantityAction, SIGNAL(triggered()), this, SLOT(CoinControlClipboardQuantity()));
+    connect(clipboardAmountAction, SIGNAL(triggered()), this, SLOT(CoinControlClipboardAmount()));
+    connect(clipboardFeeAction, SIGNAL(triggered()), this, SLOT(CoinControlClipboardFee()));
+    connect(clipboardAfterFeeAction, SIGNAL(triggered()), this, SLOT(CoinControlClipboardAfterFee()));
+    connect(clipboardBytesAction, SIGNAL(triggered()), this, SLOT(CoinControlClipboardBytes()));
+    connect(clipboardLowOutputAction, SIGNAL(triggered()), this, SLOT(CoinControlClipboardLowOutput()));
+    connect(clipboardChangeAction, SIGNAL(triggered()), this, SLOT(CoinControlClipboardChange()));
+    ui->labelCoinControlQuantity->addAction(clipboardQuantityAction);
+    ui->labelCoinControlAmount->addAction(clipboardAmountAction);
+    ui->labelCoinControlFee->addAction(clipboardFeeAction);
+    ui->labelCoinControlAfterFee->addAction(clipboardAfterFeeAction);
+    ui->labelCoinControlBytes->addAction(clipboardBytesAction);
+    ui->labelCoinControlLowOutput->addAction(clipboardLowOutputAction);
+    ui->labelCoinControlChange->addAction(clipboardChangeAction);
+
+    // init transaction fee section
+    QSettings settings;
+    if (!settings.contains("fFeeSectionMinimized"))
+        settings.setValue("fFeeSectionMinimized", true);
+    if (!settings.contains("nFeeRadio") && settings.contains("nTransactionFee") &&
+        settings.value("nTransactionFee").toLongLong() > 0) // compatibility
+        settings.setValue("nFeeRadio", 1); // custom
+    if (!settings.contains("nFeeRadio"))
+        settings.setValue("nFeeRadio", 0); // recommended
+    if (!settings.contains("nSmartFeeSliderPosition"))
+        settings.setValue("nSmartFeeSliderPosition", 0);
+    if (!settings.contains("nTransactionFee"))
+        settings.setValue("nTransactionFee", (qint64) DEFAULT_PAY_TX_FEE);
+    if (!settings.contains("fPayOnlyMinFee"))
+        settings.setValue("fPayOnlyMinFee", false);
+
+    ui->groupFee->setId(ui->radioSmartFee, 0);
+    ui->groupFee->setId(ui->radioCustomFee, 1);
+    ui->groupFee->button((int) std::max(0, std::min(1, settings.value("nFeeRadio").toInt())))->setChecked(true);
+    ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
+    ui->checkBoxMinimumFee->setChecked(settings.value("fPayOnlyMinFee").toBool());
+    minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
+
+    ui->createAssetButton->setText(tr("C&reate Asset"));
+    ui->createAssetButton->setToolTip(tr("Confirm the create asset action"));
+
+    ui->IssueFrequencyBox->setEnabled(false);
+    ui->IssueFrequencyBox->setToolTip(tr("Disabled. Not in use"));
+    ui->distributionBox->setEnabled(false);
+    ui->distributionBox->setToolTip(tr("Manual only until other types are developed"));
+    ui->openIpfsButton->hide();
+
+    m_coin_control->UseCoinJoin(false);
+}
+
+void CreateAssetsDialog::setClientModel(ClientModel *_clientModel) {
+    this->clientModel = _clientModel;
+
+    if (_clientModel) {
+        connect(_clientModel, SIGNAL(numBlocksChanged(int, QDateTime, QString, double, bool)), this,
+                SLOT(updateSmartFeeLabel()));
+    }
+}
+
+void CreateAssetsDialog::setModel(WalletModel *_model) {
+    this->model = _model;
+
+    if (_model && _model->getOptionsModel()) {
+        interfaces::WalletBalances balances = _model->wallet().getBalances();
+        setBalance(balances);
+        connect(_model, SIGNAL(balanceChanged(interfaces::WalletBalances)), this,
+                SLOT(setBalance(interfaces::WalletBalances)));
+        connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+        updateDisplayUnit();
+
+        // Coin Control
+        connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(CoinControlUpdateLabels()));
+        connect(_model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this,
+                SLOT(CoinControlFeatureChanged(bool)));
+        ui->frameCoinControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
+        CoinControlUpdateLabels();
+
+        // fee section
+        for (const int n: confTargets) {
+            ui->confTargetSelector->addItem(tr("%1 (%2 blocks)").arg(
+                    GUIUtil::formatNiceTimeOffset(n * Params().GetConsensus().nPowTargetSpacing)).arg(n));
+        }
+        connect(ui->confTargetSelector, SIGNAL(currentIndexChanged(int)), this, SLOT(updateSmartFeeLabel()));
+        connect(ui->confTargetSelector, SIGNAL(currentIndexChanged(int)), this, SLOT(CoinControlUpdateLabels()));
+        connect(ui->groupFee, SIGNAL(buttonClicked(int)), this, SLOT(updateFeeSectionControls()));
+        connect(ui->groupFee, SIGNAL(buttonClicked(int)), this, SLOT(CoinControlUpdateLabels()));
+        connect(ui->customFee, SIGNAL(valueChanged()), this, SLOT(CoinControlUpdateLabels()));
+        connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(setMinimumFee()));
+        connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(updateFeeSectionControls()));
+        connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(CoinControlUpdateLabels()));
+
+        updateFeeSectionControls();
+        updateMinFeeLabel();
+        updateSmartFeeLabel();
+
+        // set the smartfee-sliders default value (wallets default conf.target or last stored value)
+        QSettings settings;
+        if (settings.value("nSmartFeeSliderPosition").toInt() != 0) {
+            // migrate nSmartFeeSliderPosition to nConfTarget
+            // nConfTarget is available since 0.15 (replaced nSmartFeeSliderPosition)
+            int nConfirmTarget = 25 - settings.value("nSmartFeeSliderPosition").toInt(); // 25 == old slider range
+            settings.setValue("nConfTarget", nConfirmTarget);
+            settings.remove("nSmartFeeSliderPosition");
+        }
+        if (settings.value("nConfTarget").toInt() == 0)
+            ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(model->wallet().getConfirmTarget()));
+        else
+            ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(settings.value("nConfTarget").toInt()));
+    }
+}
+
+CreateAssetsDialog::~CreateAssetsDialog() {
+    QSettings settings;
+    settings.setValue("fFeeSectionMinimized", fFeeMinimized);
+    settings.setValue("nFeeRadio", ui->groupFee->checkedId());
+    settings.setValue("nConfTarget", getConfTargetForIndex(ui->confTargetSelector->currentIndex()));
+    settings.setValue("nTransactionFee", (qint64) ui->customFee->value());
+    settings.setValue("fPayOnlyMinFee", ui->checkBoxMinimumFee->isChecked());
+
+    delete ui;
+}
+
+bool CreateAssetsDialog::filladdress(QString address, CKeyID &field) {
+    CTxDestination dest = DecodeDestination(address.toStdString());
+    if (IsValidDestination(dest)) {
+        const CKeyID *keyID = boost::get<CKeyID>(&dest);
+        field = *keyID;
+        return true;
+    }
+    return false;
+}
+
+static QString GetDistributionType(int t) {
+    switch (t) {
+        case 0:
+            return "manual";
+        case 1:
+            return "coinbase";
+        case 2:
+            return "address";
+        case 3:
+            return "schedule";
+    }
+    return "invalid";
+}
+
+void CreateAssetsDialog::on_createAssetButton_clicked() {
+    if (!model || !model->getOptionsModel() || !validateInputs())
+        return;
+
+    if (getAssetsFees() == 0) {
+        QMessageBox msgBox;
+        msgBox.setText(QString::fromStdString("Under maintenance, try again later."));
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
+        return;
+    }
+
+    // request unlock only if was locked or unlocked for mixing:
+    // this way we let users unlock by walletpassphrase or by menu
+    // and make many transactions while unlocking through this dialog
+    // will call relock
+    WalletModel::EncryptionStatus encStatus = model->getEncryptionStatus();
+    if (encStatus == model->Locked || encStatus == model->UnlockedForMixingOnly) {
+        WalletModel::UnlockContext ctx(model->requestUnlock());
+        if (!ctx.isValid()) {
+            // Unlock wallet was cancelled
+            return;
+        }
+    }
+
+    CNewAssetTx assetTx;
+    assetTx.name = ui->assetnameText->text().toStdString();
+
+    assetTx.referenceHash = ui->ipfsText->text().toStdString();
+
+    if (!filladdress(ui->owneraddressText->text(), assetTx.ownerAddress) ||
+        !filladdress(ui->targetaddressText->text(), assetTx.targetAddress)){
+        return;
+    }
+
+    if (ui->uniqueBox->isChecked()) {
+        assetTx.isUnique = true;
+        assetTx.updatable = false;
+        assetTx.decimalPoint = 0; //alway 0
+        assetTx.type = 0;
+    } else {
+        assetTx.isUnique = false;
+        assetTx.type = 0; //change this later
+        assetTx.decimalPoint = ui->unitBox->value();
+    }
+    assetTx.amount = ui->quantitySpinBox->value() * COIN;
+    assetTx.maxMintCount = ui->maxmintSpinBox->value();
+    assetTx.issueFrequency = ui->IssueFrequencyBox->value();
+
+    CTransactionRef newTx;
+    CAmount nFee;
+    int nChangePos = -1;
+    std::string strFailReason;
+    std::vector <CRecipient> vecSend;
+    assetTx.fee = getAssetsFees();
+    int Payloadsize;
+
+    if (!model->wallet().createTransaction(vecSend, newTx, *m_coin_control, true, nChangePos, nFee, strFailReason,
+                                Payloadsize, &assetTx)) {
+        //handle creation error
+        QMessageBox msgBox;
+        msgBox.setText(QString::fromStdString(strFailReason));
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
+        return;
+    }
+    QString questionString = tr("Asset details:");
+    questionString.append("<hr />");
+    questionString.append(tr("Name: %1 <br>").arg(QString::fromStdString(assetTx.name)));
+    questionString.append(tr("Isunique: %1 <br>").arg(assetTx.isUnique ? "true": "false"));
+    questionString.append(tr("Updatable: %1 <br>").arg(assetTx.updatable ? "true": "false"));
+    questionString.append(tr("Decimalpoint: %1 <br>").arg(QString::number(assetTx.decimalPoint)));
+    questionString.append(tr("ReferenceHash: %1 <br>").arg(QString::fromStdString(assetTx.referenceHash)));
+    questionString.append(tr("MaxMintCount: %1 <br>").arg(QString::number(assetTx.maxMintCount)));
+    questionString.append(tr("Owner: %1 <hr />").arg(QString::fromStdString(EncodeDestination(assetTx.ownerAddress))));
+    questionString.append(tr("Distribution:<hr />"));
+    questionString.append(tr("Type: %1 <br>").arg(GetDistributionType(assetTx.type)));
+    questionString.append(tr("Target: %1 <br>").arg(QString::fromStdString(EncodeDestination(assetTx.targetAddress))));
+    questionString.append(tr("IssueFrequency: %1 <br>").arg(QString::number(assetTx.issueFrequency)));
+    questionString.append(tr("Amount: %1").arg(QString::number(assetTx.amount / COIN)));
+    // Display message box
+    nFee += assetTx.fee * COIN;
+    if (nFee > 0) {
+        // append fee string if a fee is required
+        questionString.append(
+                "<hr /><span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>");
+        questionString.append(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), nFee));
+        questionString.append("</span> ");
+        questionString.append(tr("are added as transaction fee.<hr />"));
+    }
+    CreateAssetConfirmationDialog confirmationDialog(tr("Confirm Asset Creation"),
+                                                   questionString, SEND_CONFIRM_DELAY, this);
+    confirmationDialog.exec();
+    QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
+    if (retval != QMessageBox::Yes) {
+        return;
+    }
+    model->wallet().commitTransaction(newTx, {}, {});
+}
+
+void CreateAssetsDialog::onUniqueChanged() {
+    if (ui->uniqueBox->isChecked()) {    
+        ui->updatableBox->setEnabled(false);
+        ui->updatableBox->setChecked(false);
+        ui->updatableBox->setStyleSheet("");
+        ui->unitBox->setValue(0);
+        ui->unitBox->setEnabled(false);
+        ui->unitBox->setStyleSheet("");  
+    } else {
+        ui->updatableBox->setEnabled(true);
+        ui->updatableBox->setStyleSheet("");
+        ui->unitBox->setValue(0);
+        ui->unitBox->setEnabled(true);
+        ui->unitBox->setStyleSheet("");  
+    }
+}
+
+bool CreateAssetsDialog::validateInputs() {
+    bool retval{true};
+
+    std::string assetname = ui->assetnameText->text().toStdString();
+    //check if asset name is valid
+    if (!IsAssetNameValid(assetname)) {
+        retval = false;
+        ui->assetnameText->setValid(false);
+    }
+    // check if asset already exist
+    std::string assetId;
+    if (passetsCache->GetAssetId(assetname, assetId)) {
+        CAssetMetaData tmpAsset;
+        if (passetsCache->GetAssetMetaData(assetId, tmpAsset)) {
+            retval = false;
+            ui->assetnameText->setValid(false);
+        }
+    }
+
+    std::string ipfshash = ui->ipfsText->text().toStdString();
+    int hashlen = ipfshash.length();
+    //ipfs alway start with 'Qm' and length 46
+    if ((hashlen == 46 && ipfshash.substr(0, 2) != "Qm")) {
+        retval = false;
+        ui->ipfsText->setValid(false);
+    } else {
+        //hex encoded hash minimum length 40 (160 bits)
+        if (hashlen > 0 && hashlen != 46 && (!IsHex(ipfshash) || hashlen < 40 || hashlen > 64)) {
+            retval = false;
+            ui->ipfsText->setValid(false);
+        }
+    }
+
+    if (!model->validateAddress(ui->owneraddressText->text())) {
+        ui->owneraddressText->setValid(false);
+        retval = false;
+    }
+
+    if (!model->validateAddress(ui->targetaddressText->text())) {
+        ui->targetaddressText->setValid(false);
+        retval = false;
+    }
+    
+    //sanity checks, should never fail
+    if (ui->uniqueBox->isChecked()) {    
+        if (ui->updatableBox->isChecked()) {
+            ui->updatableBox->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_INVALID));
+            retval = false;
+        }
+
+        if (ui->unitBox->value() > 0){
+            ui->unitBox->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_INVALID));
+            retval = false;
+        }  
+    }
+
+    if (ui->unitBox->value() < 0 || ui->unitBox->value() > 8){
+        ui->assetnameText->setValid(false);
+        retval = false;
+    }
+
+    if (ui->maxmintSpinBox->value() < 0 || ui->maxmintSpinBox->value() > 65535){
+        ui->maxmintSpinBox->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_INVALID));
+        retval = false;
+    }
+
+    if (ui->quantitySpinBox->value() < 0 || ui->quantitySpinBox->value() > MAX_MONEY / COIN){
+        ui->quantitySpinBox->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_INVALID));
+        retval = false;
+    }
+
+    return retval;
+}
+
+void CreateAssetsDialog::clear() {
+    // Clear Coin Control settings
+    m_coin_control->UnSelectAll();
+    ui->checkBoxCoinControlChange->setChecked(false);
+    ui->lineEditCoinControlChange->clear();
+    ui->assetnameText->clear();
+    ui->owneraddressText->clear();
+    ui->ipfsText->clear();
+    ui->targetaddressText->clear();
+    ui->unitBox->setValue(0);
+    ui->quantitySpinBox->setValue(0);
+    ui->maxmintSpinBox->setValue(1);
+    ui->IssueFrequencyBox->setValue(0);
+    ui->uniqueBox->setChecked(false);
+    ui->updatableBox->setChecked(false);
+    
+    CoinControlUpdateLabels();
+
+    updateTabsAndLabels();
+}
+
+void CreateAssetsDialog::updateTabsAndLabels() {
+    setupTabChain(0);
+    CoinControlUpdateLabels();
+}
+
+QWidget *CreateAssetsDialog::setupTabChain(QWidget *prev) {
+    QWidget::setTabOrder(prev, ui->createAssetButton);
+    QWidget::setTabOrder(ui->createAssetButton, ui->clearButton);
+    return ui->clearButton;
+}
+
+void CreateAssetsDialog::setBalance(const interfaces::WalletBalances &balances) {
+    if (model && model->getOptionsModel()) {
+        CAmount bal = balances.balance;
+        ui->labelBalanceText->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), bal));
+    }
+}
+
+void CreateAssetsDialog::updateDisplayUnit() {
+    setBalance(model->wallet().getBalances());
+    CoinControlUpdateLabels();
+    ui->customFee->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
+    updateMinFeeLabel();
+    updateSmartFeeLabel();
+}
+
+void CreateAssetsDialog::minimizeFeeSection(bool fMinimize) {
+    ui->labelFeeMinimized->setVisible(fMinimize);
+    ui->buttonChooseFee->setVisible(fMinimize);
+    ui->buttonMinimizeFee->setVisible(!fMinimize);
+    ui->frameFeeSelection->setVisible(!fMinimize);
+    ui->horizontalLayoutSmartFee->setContentsMargins(0, (fMinimize ? 0 : 6), 0, 0);
+    fFeeMinimized = fMinimize;
+}
+
+void CreateAssetsDialog::on_buttonChooseFee_clicked() {
+    minimizeFeeSection(false);
+}
+
+void CreateAssetsDialog::on_buttonMinimizeFee_clicked() {
+    updateFeeMinimizedLabel();
+    minimizeFeeSection(true);
+}
+
+void CreateAssetsDialog::setMinimumFee() {
+    ui->customFee->setValue(model->wallet().getRequiredFee(1000));
+}
+
+void CreateAssetsDialog::updateFeeSectionControls() {
+    ui->confTargetSelector->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelSmartFee->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelSmartFee2->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelSmartFee3->setEnabled(ui->radioSmartFee->isChecked());
+    ui->labelFeeEstimation->setEnabled(ui->radioSmartFee->isChecked());
+    ui->checkBoxMinimumFee->setEnabled(ui->radioCustomFee->isChecked());
+    ui->labelMinFeeWarning->setEnabled(ui->radioCustomFee->isChecked());
+    ui->labelCustomPerKilobyte->setEnabled(ui->radioCustomFee->isChecked() && !ui->checkBoxMinimumFee->isChecked());
+    ui->customFee->setEnabled(ui->radioCustomFee->isChecked() && !ui->checkBoxMinimumFee->isChecked());
+}
+
+void CreateAssetsDialog::updateFeeMinimizedLabel() {
+    if (!model || !model->getOptionsModel())
+        return;
+
+    if (ui->radioSmartFee->isChecked())
+        ui->labelFeeMinimized->setText(ui->labelSmartFee->text());
+    else {
+        ui->labelFeeMinimized->setText(
+                BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), ui->customFee->value()) +
+                "/kB");
+    }
+}
+
+void CreateAssetsDialog::updateMinFeeLabel() {
+    if (model && model->getOptionsModel())
+        ui->checkBoxMinimumFee->setText(tr("Pay only the required fee of %1").arg(
+                BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(),
+                                             model->wallet().getRequiredFee(1000)) + "/kB")
+        );
+}
+
+void CreateAssetsDialog::updateCoinControlState(CCoinControl &ctrl) {
+    if (ui->radioCustomFee->isChecked()) {
+        ctrl.m_feerate = CFeeRate(ui->customFee->value());
+    } else {
+        ctrl.m_feerate.reset();
+    }
+    // Avoid using global defaults when sending money from the GUI
+    // Either custom fee will be used or if not selected, the confirmation target from dropdown box
+    ctrl.m_confirm_target = getConfTargetForIndex(ui->confTargetSelector->currentIndex());
+}
+
+void CreateAssetsDialog::updateSmartFeeLabel() {
+    if (!model || !model->getOptionsModel())
+        return;
+    updateCoinControlState(*m_coin_control);
+    m_coin_control->m_feerate.reset(); // Explicitly use only fee estimation rate for smart fee labels
+    int returned_target;
+    FeeReason reason;
+    CFeeRate feeRate = CFeeRate(model->wallet().getMinimumFee(1000, *m_coin_control, &returned_target, &reason));
+
+    ui->labelSmartFee->setText(
+            BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), feeRate.GetFeePerK()) + "/kB");
+
+    if (reason == FeeReason::FALLBACK) {
+        ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
+        ui->labelFeeEstimation->setText("");
+        ui->fallbackFeeWarningLabel->setVisible(true);
+    } else {
+        ui->labelSmartFee2->hide();
+        ui->labelFeeEstimation->setText(tr("Estimated to begin confirmation within %n block(s).", "", returned_target));
+        ui->fallbackFeeWarningLabel->setVisible(false);
+    }
+
+    updateFeeMinimizedLabel();
+}
+
+// Coin Control: copy label "Quantity" to clipboard
+void CreateAssetsDialog::CoinControlClipboardQuantity() {
+    GUIUtil::setClipboard(ui->labelCoinControlQuantity->text());
+}
+
+// Coin Control: copy label "Amount" to clipboard
+void CreateAssetsDialog::CoinControlClipboardAmount() {
+    GUIUtil::setClipboard(ui->labelCoinControlAmount->text().left(ui->labelCoinControlAmount->text().indexOf(" ")));
+}
+
+// Coin Control: copy label "Fee" to clipboard
+void CreateAssetsDialog::CoinControlClipboardFee() {
+    GUIUtil::setClipboard(
+            ui->labelCoinControlFee->text().left(ui->labelCoinControlFee->text().indexOf(" ")).replace(ASYMP_UTF8,
+                                                                                                         ""));
+}
+
+// Coin Control: copy label "After fee" to clipboard
+void CreateAssetsDialog::CoinControlClipboardAfterFee() {
+    GUIUtil::setClipboard(
+            ui->labelCoinControlAfterFee->text().left(ui->labelCoinControlAfterFee->text().indexOf(" ")).replace(
+                    ASYMP_UTF8, ""));
+}
+
+// Coin Control: copy label "Bytes" to clipboard
+void CreateAssetsDialog::CoinControlClipboardBytes() {
+    GUIUtil::setClipboard(ui->labelCoinControlBytes->text().replace(ASYMP_UTF8, ""));
+}
+
+// Coin Control: copy label "Dust" to clipboard
+void CreateAssetsDialog::CoinControlClipboardLowOutput() {
+    GUIUtil::setClipboard(ui->labelCoinControlLowOutput->text());
+}
+
+// Coin Control: copy label "Change" to clipboard
+void CreateAssetsDialog::CoinControlClipboardChange() {
+    GUIUtil::setClipboard(
+            ui->labelCoinControlChange->text().left(ui->labelCoinControlChange->text().indexOf(" ")).replace(
+                    ASYMP_UTF8, ""));
+}
+
+// Coin Control: settings menu - Coin Control enabled/disabled by user
+void CreateAssetsDialog::CoinControlFeatureChanged(bool checked) {
+    ui->frameCoinControl->setVisible(checked);
+
+    if (!checked && model) { // Coin Control features disabled
+        m_coin_control->SetNull(false);
+    }
+
+    CoinControlUpdateLabels();
+}
+
+// Coin Control: button inputs -> show actual Coin Control dialog
+void CreateAssetsDialog::CoinControlButtonClicked() {
+    CoinControlDialog dlg(*m_coin_control, model, this);
+    dlg.exec();
+    CoinControlUpdateLabels();
+}
+
+// Coin Control: checkbox custom change address
+void CreateAssetsDialog::CoinControlChangeChecked(int state) {
+    if (state == Qt::Unchecked) {
+        m_coin_control->destChange = CNoDestination();
+        ui->labelCoinControlChangeLabel->clear();
+    } else
+        // use this to re-validate an already entered address
+        CoinControlChangeEdited(ui->lineEditCoinControlChange->text());
+
+    ui->lineEditCoinControlChange->setEnabled((state == Qt::Checked));
+}
+
+// Coin Control: custom change address changed
+void CreateAssetsDialog::CoinControlChangeEdited(const QString &text) {
+    if (model && model->getAddressTableModel()) {
+        // Default to no change address until verified
+        m_coin_control->destChange = CNoDestination();
+        ui->labelCoinControlChangeLabel->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+
+        const CTxDestination dest = DecodeDestination(text.toStdString());
+
+        if (text.isEmpty()) // Nothing entered
+        {
+            ui->labelCoinControlChangeLabel->setText("");
+        } else if (!IsValidDestination(dest)) // Invalid address
+        {
+            ui->labelCoinControlChangeLabel->setText(tr("Warning: Invalid Raptoreum address"));
+        } else // Valid address
+        {
+            if (!model->wallet().isSpendable(dest)) {
+                ui->labelCoinControlChangeLabel->setText(tr("Warning: Unknown change address"));
+
+                // confirmation dialog
+                QMessageBox::StandardButton btnRetVal = QMessageBox::question(this, tr("Confirm custom change address"),
+                                                                              tr("The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?"),
+                                                                              QMessageBox::Yes | QMessageBox::Cancel,
+                                                                              QMessageBox::Cancel);
+
+                if (btnRetVal == QMessageBox::Yes)
+                    m_coin_control->destChange = dest;
+                else {
+                    ui->lineEditCoinControlChange->setText("");
+                    ui->labelCoinControlChangeLabel->setStyleSheet(
+                            GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_PRIMARY));
+                    ui->labelCoinControlChangeLabel->setText("");
+                }
+            } else // Known change address
+            {
+                ui->labelCoinControlChangeLabel->setStyleSheet(
+                        GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_PRIMARY));
+
+                // Query label
+                QString associatedLabel = model->getAddressTableModel()->labelForAddress(text);
+                if (!associatedLabel.isEmpty())
+                    ui->labelCoinControlChangeLabel->setText(associatedLabel);
+                else
+                    ui->labelCoinControlChangeLabel->setText(tr("(no label)"));
+
+                m_coin_control->destChange = dest;
+            }
+        }
+    }
+}
+
+// Coin Control: update labels
+void CreateAssetsDialog::CoinControlUpdateLabels() {
+    if (!model || !model->getOptionsModel())
+        return;
+
+    updateCoinControlState(*m_coin_control);
+
+    // set pay amounts
+    CoinControlDialog::payAmounts.clear();
+    CoinControlDialog::fSubtractFeeFromAmount = false;
+
+    if (m_coin_control->HasSelected()) {
+        // actual Coin Control calculation
+        CoinControlDialog::updateLabels(*m_coin_control, model, this);
+
+        // show Coin Control stats
+        ui->labelCoinControlAutomaticallySelected->hide();
+        ui->widgetCoinControl->show();
+    } else {
+        // hide Coin Control stats
+        ui->labelCoinControlAutomaticallySelected->show();
+        ui->widgetCoinControl->hide();
+        ui->labelCoinControlInsuffFunds->hide();
+    }
+}
+
+void CreateAssetsDialog::checkAvailabilityClicked()
+{
+    std::string assetname = ui->assetnameText->text().toStdString();
+    //check if asset name is valid
+    if (!IsAssetNameValid(assetname)) {
+        ui->assetnameText->setValid(false);
+    }
+    // check if asset already exist
+    std::string assetId;
+    if (passetsCache->GetAssetId(assetname, assetId)) {
+        CAssetMetaData tmpAsset;
+        if (passetsCache->GetAssetMetaData(assetId, tmpAsset)) {
+            ui->assetnameText->setValid(false);
+        }
+    }
+}
+
+CreateAssetConfirmationDialog::CreateAssetConfirmationDialog(const QString &title, const QString &text, int _secDelay,
+                                                         QWidget *parent) :
+        QMessageBox(QMessageBox::Question, title, text, QMessageBox::Yes | QMessageBox::Cancel, parent),
+        secDelay(_secDelay) {
+    GUIUtil::updateFonts();
+    setDefaultButton(QMessageBox::Cancel);
+    yesButton = button(QMessageBox::Yes);
+    updateYesButton();
+    connect(&countDownTimer, SIGNAL(timeout()), this, SLOT(countDown()));
+}
+
+int CreateAssetConfirmationDialog::exec() {
+    updateYesButton();
+    countDownTimer.start(1000);
+    return QMessageBox::exec();
+}
+
+void CreateAssetConfirmationDialog::countDown() {
+    secDelay--;
+    updateYesButton();
+
+    if (secDelay <= 0) {
+        countDownTimer.stop();
+    }
+}
+
+void CreateAssetConfirmationDialog::updateYesButton() {
+    if (secDelay > 0) {
+        yesButton->setEnabled(false);
+        yesButton->setText(tr("Yes") + " (" + QString::number(secDelay) + ")");
+    } else {
+        yesButton->setEnabled(true);
+        yesButton->setText(tr("Yes"));
+    }
+}

--- a/src/qt/createassetsdialog.cpp
+++ b/src/qt/createassetsdialog.cpp
@@ -386,17 +386,9 @@ bool CreateAssetsDialog::validateInputs() {
     }
 
     std::string ipfshash = ui->ipfsText->text().toStdString();
-    int hashlen = ipfshash.length();
-    //ipfs alway start with 'Qm' and length 46
-    if ((hashlen == 46 && ipfshash.substr(0, 2) != "Qm")) {
+    if ( ipfshash.length() > 128)) {
         retval = false;
         ui->ipfsText->setValid(false);
-    } else {
-        //hex encoded hash minimum length 40 (160 bits)
-        if (hashlen > 0 && hashlen != 46 && (!IsHex(ipfshash) || hashlen < 40 || hashlen > 64)) {
-            retval = false;
-            ui->ipfsText->setValid(false);
-        }
     }
 
     if (!model->validateAddress(ui->owneraddressText->text())) {

--- a/src/qt/createassetsdialog.h
+++ b/src/qt/createassetsdialog.h
@@ -1,0 +1,153 @@
+// Copyright (c) 2023 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RAPTOREUM_QT_CREATEASSETSDIALOG_H
+#define RAPTOREUM_QT_CREATEASSETSDIALOG_H
+
+#include <qt/walletmodel.h>
+
+#include <QDialog>
+#include <QMessageBox>
+#include <QShowEvent>
+#include <QString>
+#include <QTimer>
+
+class CCoinControl;
+
+class ClientModel;
+
+namespace Ui {
+    class CreateAssetsDialog;
+}
+
+QT_BEGIN_NAMESPACE
+class QUrl;
+QT_END_NAMESPACE
+
+/** Dialog for creating assets */
+class CreateAssetsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit CreateAssetsDialog(QWidget *parent = 0);
+
+    ~CreateAssetsDialog();
+
+    void setClientModel(ClientModel *clientModel);
+
+    void setModel(WalletModel *model);
+
+    /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases (issue https://bugreports.qt-project.org/browse/QTBUG-10907).
+     */
+    QWidget *setupTabChain(QWidget *prev);
+
+public
+    Q_SLOTS:
+    void clear();
+
+    void updateTabsAndLabels();
+
+    void setBalance(const interfaces::WalletBalances &balances);
+
+    Q_SIGNALS:
+            void coinsSent(
+    const uint256 &txid
+    );
+
+private:
+    Ui::CreateAssetsDialog *ui;
+    ClientModel *clientModel;
+    WalletModel *model;
+    std::unique_ptr <CCoinControl> m_coin_control;
+
+    bool validateInputs();
+
+    bool filladdress(QString address, CKeyID &field);
+
+    bool fFeeMinimized;
+
+    void minimizeFeeSection(bool fMinimize);
+
+    void updateFeeMinimizedLabel();
+
+    // Update the passed in CCoinControl with state from the GUI
+    void updateCoinControlState(CCoinControl &ctrl);
+
+private
+    Q_SLOTS:
+    void checkAvailabilityClicked();
+
+    void on_createAssetButton_clicked();
+
+    void onUniqueChanged();
+
+    void on_buttonChooseFee_clicked();
+
+    void on_buttonMinimizeFee_clicked();
+
+    void updateDisplayUnit();
+
+    void CoinControlFeatureChanged(bool);
+
+    void CoinControlButtonClicked();
+
+    void CoinControlChangeChecked(int);
+
+    void CoinControlChangeEdited(const QString &);
+
+    void CoinControlUpdateLabels();
+
+    void CoinControlClipboardQuantity();
+
+    void CoinControlClipboardAmount();
+
+    void CoinControlClipboardFee();
+
+    void CoinControlClipboardAfterFee();
+
+    void CoinControlClipboardBytes();
+
+    void CoinControlClipboardLowOutput();
+
+    void CoinControlClipboardChange();
+
+    void setMinimumFee();
+
+    void updateFeeSectionControls();
+
+    void updateMinFeeLabel();
+
+    void updateSmartFeeLabel();
+
+    Q_SIGNALS:
+            // Fired when a message should be reported to the user
+            void message(
+    const QString &title,
+    const QString &message,
+    unsigned int style
+    );
+};
+
+
+class CreateAssetConfirmationDialog : public QMessageBox {
+    Q_OBJECT
+
+public:
+    CreateAssetConfirmationDialog(const QString &title, const QString &text, int secDelay = 0, QWidget *parent = 0);
+
+    int exec();
+
+private
+    Q_SLOTS:
+            void countDown();
+
+    void updateYesButton();
+
+private:
+    QAbstractButton *yesButton;
+    QTimer countDownTimer;
+    int secDelay;
+};
+
+#endif // RAPTOREUM_QT_CREATEASSETSDIALOG_H

--- a/src/qt/forms/assetsdialog.ui
+++ b/src/qt/forms/assetsdialog.ui
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AssetsDialog</class>
+ <widget class="QWidget" name="AssetsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1049</width>
+    <height>703</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="topLayout">
+   <property name="leftMargin">
+    <number>20</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>20</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="1" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_filter_2">
+             <property name="font">
+              <font>
+               <pointsize>14</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Asset balance</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTableWidget" name="tableWidgetAssets">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+             <property name="sortingEnabled">
+              <bool>true</bool>
+             </property>
+             <attribute name="horizontalHeaderStretchLastSection">
+              <bool>true</bool>
+             </attribute>
+             <attribute name="verticalHeaderVisible">
+              <bool>false</bool>
+             </attribute>
+             <column>
+              <property name="text">
+               <string>Asset</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>asset id</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Available</string>
+              </property>
+             </column>
+             <column>
+              <property name="text">
+               <string>Pending</string>
+              </property>
+             </column>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,0,0">
+           <item>
+            <widget class="QFrame" name="detailframe">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>380</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::Panel</enum>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_2">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,0,0">
+                <item>
+                 <widget class="QLabel" name="assetinfolabel">
+                  <property name="maximumSize">
+                   <size>
+                    <width>350</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Asset Info</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QGridLayout" name="gridLayout">
+                  <item row="2" column="3">
+                   <widget class="QLabel" name="label_7">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QLabel" name="nameTextLabel">
+                    <property name="text">
+                     <string notr="true"/>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignCenter</set>
+                    </property>
+                    <property name="textInteractionFlags">
+                     <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_5">
+                    <property name="text">
+                     <string>Suply:</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="3">
+                   <widget class="QLabel" name="assetname">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="2">
+                   <widget class="QLabel" name="suplyTextLabel">
+                    <property name="text">
+                     <string notr="true"/>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_6">
+                    <property name="text">
+                     <string>Id:</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_4">
+                    <property name="text">
+                     <string>Name:</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QLabel" name="idTextLablel">
+                    <property name="text">
+                     <string notr="true"/>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignCenter</set>
+                    </property>
+                    <property name="textInteractionFlags">
+                     <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QLabel" name="typeLabel">
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_3">
+                    <property name="text">
+                     <string>Type:</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="3">
+                   <widget class="QLabel" name="label_8">
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="2">
+                   <layout class="QHBoxLayout" name="horizontalLayout_3">
+                    <item>
+                     <widget class="QLabel" name="errorTextLabel">
+                      <property name="text">
+                       <string/>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignCenter</set>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="errorLabel">
+                    <property name="text">
+                     <string>Warning:</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="2">
+                   <spacer name="horizontalSpacer">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout">
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="mintButton">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="text">
+                     <string>Mint</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="updateButton">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="text">
+                     <string>Update</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="recentlabel">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>14</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::RightToLeft</enum>
+             </property>
+             <property name="text">
+              <string>Recent transactions</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="listWidget">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>380</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/createassetsdialog.ui
+++ b/src/qt/forms/createassetsdialog.ui
@@ -1,0 +1,1533 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CreateAssetsDialog</class>
+ <widget class="QDialog" name="CreateAssetsDialog">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>980</width>
+    <height>861</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Asset Creation Form</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
+  </property>
+  <property name="modal">
+   <bool>false</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,0">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>8</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frameCoinControl">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayoutCoinControl" stretch="0,0,0,0,0">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <property name="leftMargin">
+         <number>10</number>
+        </property>
+        <property name="topMargin">
+         <number>10</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl1">
+          <property name="bottomMargin">
+           <number>15</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="labelCoinControlFeatures">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">font-weight:bold;</string>
+            </property>
+            <property name="text">
+             <string>Coin Control Features</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl2" stretch="0,0,0,0">
+          <property name="spacing">
+           <number>8</number>
+          </property>
+          <property name="bottomMargin">
+           <number>10</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="pushButtonCoinControl">
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
+            <property name="text">
+             <string>Inputs...</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelCoinControlAutomaticallySelected">
+            <property name="text">
+             <string>automatically selected</string>
+            </property>
+            <property name="margin">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelCoinControlInsuffFunds">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color:red;font-weight:bold;</string>
+            </property>
+            <property name="text">
+             <string>Insufficient funds!</string>
+            </property>
+            <property name="margin">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacerCoinControl">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>1</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QWidget" name="widgetCoinControl" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayoutCoinControl5">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayoutCoinControl3" stretch="0,0,0,1">
+             <property name="spacing">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>10</number>
+             </property>
+             <item>
+              <layout class="QFormLayout" name="formLayoutCoinControl1">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>10</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelCoinControlQuantityText">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Quantity:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelCoinControlQuantity">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="labelCoinControlBytesText">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Bytes:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="labelCoinControlBytes">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QFormLayout" name="formLayoutCoinControl2">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelCoinControlAmountText">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Amount:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelCoinControlAmount">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RTM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="labelCoinControlLowOutputText">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Dust:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="labelCoinControlLowOutput">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">no</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QFormLayout" name="formLayoutCoinControl3">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelCoinControlFeeText">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Fee:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelCoinControlFee">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RTM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QFormLayout" name="formLayoutCoinControl4">
+               <property name="horizontalSpacing">
+                <number>10</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>14</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelCoinControlAfterFeeText">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>After Fee:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="labelCoinControlAfterFee">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RTM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="labelCoinControlChangeText">
+                 <property name="font">
+                  <font>
+                   <weight>75</weight>
+                   <bold>true</bold>
+                  </font>
+                 </property>
+                 <property name="text">
+                  <string>Change:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="labelCoinControlChange">
+                 <property name="cursor">
+                  <cursorShape>IBeamCursor</cursorShape>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::ActionsContextMenu</enum>
+                 </property>
+                 <property name="text">
+                  <string notr="true">0.00 RTM</string>
+                 </property>
+                 <property name="textInteractionFlags">
+                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl4" stretch="0,0,0">
+          <property name="spacing">
+           <number>12</number>
+          </property>
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <property name="topMargin">
+           <number>5</number>
+          </property>
+          <property name="rightMargin">
+           <number>5</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="checkBoxCoinControlChange">
+            <property name="toolTip">
+             <string>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</string>
+            </property>
+            <property name="text">
+             <string>Custom change address</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QValidatedLineEdit" name="lineEditCoinControlChange">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelCoinControlChangeLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="margin">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacerCoinControl">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>800</width>
+            <height>1</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>960</width>
+        <height>388</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,1">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QFrame" name="frameAssetData">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="2">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QValidatedLineEdit" name="assetnameText">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;a-z A-Z 0-9 and space&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="maxLength">
+               <number>128</number>
+              </property>
+              <property name="placeholderText">
+               <string>The name of the asset you would like to create</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="availabilityButton">
+              <property name="text">
+               <string>Check Availabilty</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="assetNameLabel">
+            <property name="text">
+             <string>Asset Name:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_10">
+            <item>
+             <widget class="QValidatedLineEdit" name="owneraddressText">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;RTM address that will own this asset&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="placeholderText">
+               <string>The RTM address that own this asset</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="6" column="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QValidatedLineEdit" name="ipfsText">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;[Optional] The ipfs/file hash that contains information about the asset&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="maxLength">
+               <number>64</number>
+              </property>
+              <property name="placeholderText">
+               <string>The ipfs/file hash that is associated with the asset being created (e.g. QmU4h365LYMHx...)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="openIpfsButton">
+              <property name="text">
+               <string>Browse IPFS</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="10" column="0">
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="1" column="0">
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QCheckBox" name="uniqueBox">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make this asset unique also known as NFT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Unique Asset</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="typeLabel">
+              <property name="text">
+               <string>Distribution Type:</string>
+              </property>
+              <property name="margin">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="mintLabel">
+              <property name="text">
+               <string>Mint count:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="14" column="0">
+           <widget class="QLabel" name="targetLabel">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The RTM address that will receive the minted asset&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Target Address:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_13">
+            <item>
+             <widget class="QValidatedLineEdit" name="targetaddressText">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The RTM address that will receive the minted asset&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="placeholderText">
+               <string>The RTM address that will receive the minted asset</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="10" column="2">
+           <layout class="QGridLayout" name="gridLayout">
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>20</number>
+            </property>
+            <item row="1" column="2">
+             <widget class="QDoubleSpinBox" name="quantitySpinBox">
+              <property name="toolTip">
+               <string>The number of assets that will be created</string>
+              </property>
+              <property name="decimals">
+               <number>0</number>
+              </property>
+              <property name="minimum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>21000000000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="updatableBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the owner of this asset will be able to update the asset in the future&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Updatable</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="quantityLabel">
+              <property name="text">
+               <string>Quantity:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="unitsLabel">
+              <property name="text">
+               <string> Decimal point:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QSpinBox" name="unitBox">
+              <property name="toolTip">
+               <string>How divisble the assets will be (e.g. 8 = 1.00000000, 2 = 1.00)</string>
+              </property>
+              <property name="maximum">
+               <number>8</number>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QLabel" name="unitExampleLabel">
+              <property name="text">
+               <string>e.g. 1</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QComboBox" name="distributionBox">
+              <item>
+               <property name="text">
+                <string>Manual</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Coinbase</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>schedule</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Addresss</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="1" column="3">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="2" column="0">
+             <widget class="QSpinBox" name="maxmintSpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>124</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of times this asset can be minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+              <property name="value">
+               <number>1</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="IssueFrequencyLabel">
+              <property name="text">
+               <string>Issue frequency:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QSpinBox" name="IssueFrequencyBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The frequency that this asset will be minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="ipfsLabel">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;[Optional] The ipfs/file hash that contains information about the asset&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>IPFS/file hash:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="addressLabel">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;RTM address that will own this asset&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Owner Address:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>338</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frameFee">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayoutFee2" stretch="0,0,0">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>10</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayoutFee1">
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayoutFee7">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <item>
+               <spacer name="verticalSpacerSmartFee">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>1</width>
+                  <height>4</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayoutSmartFee">
+                <property name="spacing">
+                 <number>10</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="labelFeeHeadline">
+                  <property name="text">
+                   <string>Transaction Fee:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="labelFeeMinimized">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="buttonChooseFee">
+                  <property name="text">
+                   <string>Choose...</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>1</width>
+                  <height>1</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="fallbackFeeWarningLabel">
+              <property name="font">
+               <font>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</string>
+              </property>
+              <property name="text">
+               <string>Note: Not enough data for fee estimation, using the fallback fee instead.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonMinimizeFee">
+            <property name="toolTip">
+             <string>collapse fee-settings</string>
+            </property>
+            <property name="text">
+             <string>Hide</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QFrame" name="frameFeeSelection">
+          <layout class="QVBoxLayout" name="verticalLayoutFee12">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QGridLayout" name="gridLayoutFee">
+             <property name="topMargin">
+              <number>10</number>
+             </property>
+             <property name="bottomMargin">
+              <number>4</number>
+             </property>
+             <property name="horizontalSpacing">
+              <number>10</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>4</number>
+             </property>
+             <item row="1" column="1">
+              <layout class="QVBoxLayout" name="verticalLayoutFee8">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee13">
+                 <item>
+                  <widget class="QLabel" name="labelCustomPerKilobyte">
+                   <property name="toolTip">
+                    <string>If the custom fee is set to 1000 satoshis and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 satoshis in fee, while &quot;total at least&quot; pays 1000 satoshis. For transactions bigger than a kilobyte both pay by kilobyte.</string>
+                   </property>
+                   <property name="text">
+                    <string>per kilobyte</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="BitcoinAmountField" name="customFee"/>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_6">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee8">
+                 <item>
+                  <widget class="QCheckBox" name="checkBoxMinimumFee">
+                   <property name="toolTip">
+                    <string>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for neoxa transactions than the network can process.</string>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelMinFeeWarning">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="toolTip">
+                    <string>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for neoxa transactions than the network can process.</string>
+                   </property>
+                   <property name="text">
+                    <string>(read the tooltip)</string>
+                   </property>
+                   <property name="margin">
+                    <number>5</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_7">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="0">
+              <layout class="QVBoxLayout" name="verticalLayoutFee4" stretch="0,1">
+               <item>
+                <widget class="QRadioButton" name="radioSmartFee">
+                 <property name="text">
+                  <string>Recommended:</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">groupFee</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item row="1" column="0">
+              <layout class="QVBoxLayout" name="verticalLayoutFee9" stretch="0,1">
+               <item>
+                <widget class="QRadioButton" name="radioCustomFee">
+                 <property name="text">
+                  <string>C&amp;ustom:</string>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">groupFee</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="1">
+              <layout class="QVBoxLayout" name="verticalLayoutFee3" stretch="0,0,1">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>2</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee12">
+                 <item>
+                  <widget class="QLabel" name="labelSmartFee">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="margin">
+                    <number>2</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelFeeEstimation">
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelSmartFee2">
+                   <property name="text">
+                    <string>(Smart fee not initialized yet. This usually takes a few blocks...)</string>
+                   </property>
+                   <property name="margin">
+                    <number>2</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_8">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee9">
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayoutFee6">
+                   <item>
+                    <widget class="QLabel" name="labelSmartFee3">
+                     <property name="text">
+                      <string>Confirmation time target:</string>
+                     </property>
+                     <property name="margin">
+                      <number>2</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_3">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>1</width>
+                       <height>1</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayoutFee5">
+                   <property name="rightMargin">
+                    <number>30</number>
+                   </property>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayoutConfTarget">
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QComboBox" name="confTargetSelector"/>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacerConfTarget">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacerFee">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>5</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
+     <item>
+      <widget class="QPushButton" name="createAssetButton">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>C&amp;reate Asset</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearButton">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <property name="spacing">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="labelBalance">
+         <property name="layoutDirection">
+          <enum>Qt::RightToLeft</enum>
+         </property>
+         <property name="text">
+          <string>Balance:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelBalanceText">
+         <property name="layoutDirection">
+          <enum>Qt::RightToLeft</enum>
+         </property>
+         <property name="text">
+          <string>123.456 RTM</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qt/qvalidatedlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QLineEdit</extends>
+   <header>qt/bitcoinamountfield.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="groupFee">
+   <property name="exclusive">
+    <bool>true</bool>
+   </property>
+  </buttongroup>
+ </buttongroups>
+</ui>

--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -897,6 +897,10 @@ QWidget#RPCConsole { /* RPC Console Dialog Box */
     background-color: #323233;
 }
 
+QWidget#RPCConsole #detailWidget{
+    background-color: #323233;
+}
+
 RPCConsole QTableView {
     color: #c7c7c7;
 }
@@ -929,6 +933,24 @@ SendCoinsEntry
 ******************************************************/
 
 /***** No dark.css specific coloring here yet *****/
+
+/******************************************************
+SendCoinsDialog
+******************************************************/
+
+QDialog#SendAssetssDialog .QFrame#frameCoinControl,
+QDialog#SendAssetsDialog #scrollArea {
+    border-color: #39393b;
+}
+
+/******************************************************
+SendCoinsDialog
+******************************************************/
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl,
+QDialog#CreateAssetsDialog #scrollArea {
+    border-color: #39393b;
+}
 
 /******************************************************
 SignVerifyMessageDialog

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -876,8 +876,6 @@ QToolBar {
     padding: 0;
     margin: 0;
     spacing: 0;
-    min-height: 50px;
-    max-height: 50px;
 }
 
 QToolBar > QToolButton {
@@ -1926,6 +1924,65 @@ QStackedWidget#SendAssetsEntry .QToolButton#deleteButton_is {
 }
 
 QStackedWidget#SendAssetsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
+}
+
+/******************************************************
+CreateAssetsDialog
+******************************************************/
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl,
+QDialog#CreateAssetsDialog #scrollArea  { /* Coin Control Section */
+    border-bottom: 1px solid red;
+}
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl .QPushButton#pushButtonCoinControl { /* Coin Control Inputs Button */
+}
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures { /* Coin Control Header */
+}
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl { /* Coin Control Inputs */
+}
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl > .QLabel { /* Coin Control Inputs Labels */
+    padding: 2px;
+}
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoinControlChange { /* Custom Change Address */
+}
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlChangeLabel { /* Custom Change Address Validation Label */
+    margin-right: 112px;
+}
+
+QDialog#CreateAssetsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlInsuffFunds { /* Insufficient Funds Label */
+    color: #a84832;
+}
+
+QDialog#CreateAssetsDialog .QScrollArea#scrollArea .QWidget#scrollAreaWidgetContents { /* Send To Widget */
+    background-color: #00000000;
+}
+
+QDialog#CreateAssetsDialog QLabel#labelBalanceText,
+QDialog#CreateAssetsDialog QLabel#labelBalance {
+    qproperty-alignment: 'AlignLeading | AlignLeft';
+    min-height: 20px;
+    max-height: 20px;
+}
+
+QDialog#CreateAssetsDialog QLabel#labelBalance {
+    margin-right: 10px;
+}
+
+QDialog#CreateAssetsDialog QPushButton#createAssetButton {
+    margin-left: 10px;
+}
+
+/******************************************************
+AssetsDialog
+******************************************************/
+QDialog#AssetsDialog QListWidget#listWidget {
+    background-color: #00000000;
 }
 
 /******************************************************

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -881,6 +881,10 @@ QWidget#RPCConsole { /* RPC Console Dialog Box */
     background-color: #f2f2f4;
 }
 
+QWidget#RPCConsole #detailWidget{
+    background-color: #f2f2f4;
+}
+
 RPCConsole QTableView {
     color: #555;
 }

--- a/src/qt/sendassetsdialog.cpp
+++ b/src/qt/sendassetsdialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2015 The BitAsset Core developers
+// Copyright (c) 2011-2015 The Bitcoin Core developers
 // Copyright (c) 2014-2021 The Dash Core developers
 // Copyright (c) 2020-2023 The Raptoreum developers
 // Distributed under the MIT software license, see the accompanying
@@ -917,6 +917,15 @@ void SendAssetsDialog::updateAssetList() {
         if (entry) {
             entry->updateAssetList();
         }
+    }
+}
+
+void SendAssetsDialog::focusAsset(const std::string assetId) {
+    clear();
+    SendAssetsEntry *entry = qobject_cast<SendAssetsEntry *>(ui->entries->itemAt(0)->widget());
+    if (entry) {
+        entry->focusAsset(assetId);
+        entry->setFocus();
     }
 }
 

--- a/src/qt/sendassetsdialog.h
+++ b/src/qt/sendassetsdialog.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITAsset_QT_SENDAssetSDIALOG_H
-#define BITAsset_QT_SENDAssetSDIALOG_H
+#ifndef RAPTOREUM_QT_SENDASSETSDIALOG_H
+#define RAPTOREUM_QT_SENDASSETSDIALOG_H
 
 #include <qt/walletmodel.h>
 
@@ -31,7 +31,7 @@ QT_BEGIN_NAMESPACE
 class QUrl;
 QT_END_NAMESPACE
 
-/** Dialog for sending bitAssets */
+/** Dialog for sending assets */
 class SendAssetsDialog : public QDialog {
     Q_OBJECT
 
@@ -147,6 +147,8 @@ private
 
     void updateSmartFeeLabel();
 
+    void focusAsset(const std::string assetId);
+
     Q_SIGNALS:
             // Fired when a message should be reported to the user
             void message(
@@ -177,4 +179,4 @@ private:
     int secDelay;
 };
 
-#endif // BITAsset_QT_SENDAssetSDIALOG_H
+#endif // RAPTOREUM_QT_SENDASSETSDIALOG_H

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -264,6 +264,14 @@ void SendAssetsEntry::setAmount(const CAmount &amount) {
     ui->payAmount->setValue(amount);
 }
 
+void SendAssetsEntry::focusAsset(const std::string assetId) {
+    int index = ui->assetList->findText(QString::fromStdString(assetId));
+    if (index >= 0) {
+        assetName.clear();
+        ui->assetList->setCurrentIndex(index);
+    }
+}
+
 bool SendAssetsEntry::isClear() {
     return ui->payTo->text().isEmpty();
 }
@@ -346,12 +354,12 @@ void SendAssetsEntry::onAssetSelected(QString name) {
             bal = assetsbalance[assetId];
     }
 
-    //update balance
-    ui->AssetBalance->setText(BitcoinUnits::formatWithCustomName(name, bal));
-
     CAssetMetaData assetdata;
     if (!passetsCache->GetAssetMetaData(assetId, assetdata))
         return;
+
+    //update balance
+    ui->AssetBalance->setText(BitcoinUnits::formatWithCustomName(name, bal, assetdata.decimalPoint));
 
     if (assetdata.isUnique) {
 

--- a/src/qt/sendassetsentry.h
+++ b/src/qt/sendassetsentry.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITAsset_QT_SENDAssetSENTRY_H
-#define BITAsset_QT_SENDAssetSENTRY_H
+#ifndef RAPTOREUM_QT_SENDAASSETSENTRY_H
+#define RAPTOREUM_QT_SENDAASSETSENTRY_H
 
 #include <qt/walletmodel.h>
 
@@ -22,7 +22,7 @@ namespace Ui {
 }
 
 /**
- * A single entry in the dialog for sending bitAssets.
+ * A single entry in the dialog for sending assets.
  * Stacked widget, with different UIs for payment requests
  * with a strong payee identity.
  */
@@ -50,6 +50,8 @@ public:
     void setAddress(const QString &address);
 
     void setAmount(const CAmount &amount);
+
+    void focusAsset(const std::string assetId);
 
     void SetFutureVisible(const bool visible);
 
@@ -118,4 +120,4 @@ private:
     void ClearAssetOptions();
 };
 
-#endif // BITAsset_QT_SENDAssetSENTRY_H
+#endif // RAPTOREUM_QT_SENDAASSETSENTRY_H

--- a/src/qt/smartnodelist.cpp
+++ b/src/qt/smartnodelist.cpp
@@ -62,6 +62,7 @@ SmartnodeList::SmartnodeList(QWidget *parent) :
     int columnOwnerWidth = 130;
     int columnVotingWidth = 130;
 
+    ui->tableWidgetSmartnodesDIP3->verticalHeader()->hide();
     ui->tableWidgetSmartnodesDIP3->setColumnWidth(COLUMN_SERVICE, columnAddressWidth);
     ui->tableWidgetSmartnodesDIP3->setColumnWidth(COLUMN_STATUS, columnStatusWidth);
     ui->tableWidgetSmartnodesDIP3->setColumnWidth(COLUMN_POSE, columnPoSeScoreWidth);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -157,6 +157,18 @@ void WalletFrame::gotoSendAssetsPage(QString addr) {
         i.value()->gotoSendAssetsPage(addr);
 }
 
+void WalletFrame::gotoCreateAssetsPage() {
+    QMap<WalletModel *, WalletView *>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->gotoCreateAssetsPage();
+}
+
+void WalletFrame::gotoMyAssetsPage() {
+    QMap<WalletModel *, WalletView *>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->gotoMyAssetsPage();
+}
+
 void WalletFrame::gotoCoinJoinCoinsPage(QString addr) {
     QMap<WalletModel *, WalletView *>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -91,9 +91,15 @@ public
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
 
-    /** Switch to send coins page */
+    /** Switch to send assets page */
     void gotoSendAssetsPage(QString addr = "");
 
+    /** Switch to create assets page */
+    void gotoCreateAssetsPage();
+    
+    /** Switch to my assets page */
+    void gotoMyAssetsPage();
+    
     /** Switch to CoinJoin coins page */
     void gotoCoinJoinCoinsPage(QString addr = "");
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -23,6 +23,10 @@ class SendCoinsDialog;
 
 class SendAssetsDialog;
 
+class CreateAssetsDialog;
+
+class AssetsDialog;
+
 class SendCoinsRecipient;
 
 class TransactionView;
@@ -82,6 +86,8 @@ private:
     ReceiveCoinsDialog *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
     SendAssetsDialog *sendAssetsPage;
+    CreateAssetsDialog *createAssetsPage;
+    AssetsDialog *myAssetsPage;
     SendCoinsDialog *coinJoinCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
@@ -112,6 +118,12 @@ public
     /** Switch to send assets page */
     void gotoSendAssetsPage(QString addr = "");
 
+    /** Switch to create assets page */
+    void gotoCreateAssetsPage();
+    
+    /** Switch to my assets page */
+    void gotoMyAssetsPage();
+    
     /** Switch to CoinJoin coins page */
     void gotoCoinJoinCoinsPage(QString addr = "");
 

--- a/src/rpc/rpcassets.cpp
+++ b/src/rpc/rpcassets.cpp
@@ -134,11 +134,9 @@ UniValue createasset(const JSONRPCRequest &request) {
     const UniValue &referenceHash = find_value(asset, "referenceHash");
     if (!referenceHash.isNull()) {
         std::string ref = referenceHash.get_str();
-        if (ref.length() != 0) {
-            if (ref.length() != 46)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: Invalid referenceHash (must be 46 characters)");
-            if (ref.substr(0, 2) != "Qm")
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: invalid referenceHash (must start with Qm)");
+        if (ref.length() > 0) {
+            if (ref.length() > 128)
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: Invalid referenceHash (max length 128)");
             assetTx.referenceHash = ref;
         }
     }

--- a/src/rpc/rpcassets.cpp
+++ b/src/rpc/rpcassets.cpp
@@ -79,6 +79,10 @@ UniValue createasset(const JSONRPCRequest &request) {
                                  "\"issueFrequency\":0, \"amount\":10000,\"ownerAddress\":\"yRyiTCKfqMG2dQ9oUvs932TjN1R1MNUTWM\"}'")
         );
 
+    if (getAssetsFees() == 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: Under maintenance, try again later.");
+    }
+
     std::shared_ptr <CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet *const pwallet = wallet.get();
@@ -184,8 +188,8 @@ UniValue createasset(const JSONRPCRequest &request) {
     const UniValue &amount = find_value(asset, "amount");
     if (!amount.isNull()) {
         CAmount a = amount.get_int64();
-        if (a <= 0 || a > MAX_MONEY || (assetTx.isUnique && a > 500 * COIN))
-            throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+        if (a <= 0 || a > MAX_MONEY || (assetTx.isUnique && a > 500))
+            throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Invalid amount. Max amount %i", assetTx.isUnique ? 500 : MAX_MONEY));
         assetTx.amount = a * COIN;
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: missing amount");
@@ -255,6 +259,10 @@ UniValue mintasset(const JSONRPCRequest &request) {
                                  "773cf7e057127048711d16839e4612ffb0f1599aef663d96e60f5190eb7de9a9" "yZBvV16YFvPx11qP2XhCRDi7y2e1oSMpKH" "1000")
 
         );
+
+    if (getAssetsFees() == 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: Under maintenance, try again later.");
+    }
 
     std::shared_ptr <CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -533,24 +541,7 @@ UniValue assetdetails(const JSONRPCRequest &request) {
     }
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("Asset_id", tmpAsset.assetId);
-    result.pushKV("Asset_name", tmpAsset.name);
-    result.pushKV("Circulating_supply", tmpAsset.circulatingSupply / COIN);
-    result.pushKV("MintCount", tmpAsset.mintCount);
-    result.pushKV("maxMintCount", tmpAsset.maxMintCount);
-    result.pushKV("owner", EncodeDestination(tmpAsset.ownerAddress));
-    result.pushKV("Isunique", tmpAsset.isUnique);
-    result.pushKV("Updatable", tmpAsset.updatable);
-    result.pushKV("Decimalpoint", (int) tmpAsset.decimalPoint);
-    result.pushKV("ReferenceHash", tmpAsset.referenceHash);
-    UniValue dist(UniValue::VOBJ);
-    dist.pushKV("Type", GetDistributionType(tmpAsset.type));
-    dist.pushKV("TargetAddress", EncodeDestination(tmpAsset.targetAddress));
-    //tmp.pushKV("collateralAddress", EncodeDestination(tmpAsset.collateralAddress));
-    dist.pushKV("IssueFrequency", tmpAsset.issueFrequency);
-    dist.pushKV("Amount", tmpAsset.amount / COIN);
-    result.pushKV("Distribution", dist);
-
+    tmpAsset.ToJson(result);
     return result;
 }
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1514,24 +1514,19 @@ UniValue protx_diff(const JSONRPCRequest &request) {
                "Set of commands to execute ProTx related actions.\n"
                "To get help on individual commands, use \"help protx command\".\n"
                "\nAvailable commands:\n"
+               #ifdef ENABLE_WALLET
                "  register          - Create and send ProTx to network\n"
                "  register_fund     - Fund, create and send ProTx to network\n"
                "  register_prepare  - Create an unsigned ProTx\n"
                "  register_submit   - Sign and submit a ProTx\n"
                "  quick_setup       - register_prepare, signmessage and register_submit in one command\n"
-               #ifdef ENABLE_WALLET
-               "  register          - Create and send ProTx to network\n"
-        "  register_fund     - Fund, create and send ProTx to network\n"
-        "  register_prepare  - Create an unsigned ProTx\n"
-        "  register_submit   - Sign and submit a ProTx\n"
-        "  quick_setup       - register_prepare, signmessage and register_submit in one command\n"
                #endif
                "  list              - List ProTxs\n"
                "  info              - Return information about a ProTx\n"
                #ifdef ENABLE_WALLET
                "  update_service    - Create and send ProUpServTx to network\n"
-        "  update_registrar  - Create and send ProUpRegTx to network\n"
-        "  revoke            - Create and send ProUpRevTx to network\n"
+               "  update_registrar  - Create and send ProUpRegTx to network\n"
+               "  revoke            - Create and send ProUpRevTx to network\n"
                #endif
                "  diff              - Calculate a diff and a proof between two smartnode lists\n",
                {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -968,6 +968,9 @@ public:
     std::map <uint256, CWalletTx> mapWallet
     GUARDED_BY(cs_wallet);
 
+    std::map <uint256, std::pair<std::string, CKeyID>> mapAsset
+    GUARDED_BY(cs_wallet);
+
     typedef std::multimap<int64_t, CWalletTx *> TxItems;
     TxItems wtxOrdered;
 
@@ -1033,10 +1036,15 @@ public:
     std::map <CTxDestination, std::vector<COutput>> ListAssets() const;
 
     /**
-     * Return list of assets balances.
+     * Return list of assets confirmed balances.
      */
     std::map <std::string, CAmount>
     getAssetsBalance(const CCoinControl *coinControl = nullptr, bool fSpendable = false) const;
+
+    /**
+     * Return list of assets balances confirmed, pending.
+     */
+    std::map <std::string, std::pair<CAmount, CAmount>> getAssetsBalanceAll() const;
 
     /**
      * Find non-change parent output.


### PR DESCRIPTION
**Assets**
added assets page show assets balance
added create assets page

**Others**
removed duplicated text on protx help
fixed background color on peers details
hide vertical header in smartnode list
Toolbar orientation changed to fit more pages

create asset page
![Captura de tela de 2023-08-10 23-06-04](https://github.com/Raptor3um/raptoreum/assets/28742969/17ef6ffe-2dfc-466e-ab02-67dd704bf7f2)

assets balance page
![Captura de tela de 2023-08-10 23-17-04](https://github.com/Raptor3um/raptoreum/assets/28742969/ba443ec2-b36d-45af-a1ae-531f747eee85)
