### PR TITLE
auto hide the toolbar menu

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -20,6 +20,7 @@ QT_FORMS_UI = \
   qt/forms/helpmessagedialog.ui \
   qt/forms/intro.ui \
   qt/forms/modaloverlay.ui \
+  qt/forms/toolbaroverlay.ui \
   qt/forms/smartnodelist.ui \
   qt/forms/qrdialog.ui \
   qt/forms/openuridialog.ui \
@@ -61,6 +62,7 @@ QT_MOC_CPP = \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
   qt/moc_modaloverlay.cpp \
+  qt/moc_toolbaroverlay.cpp \
   qt/moc_smartnodelist.cpp \
   qt/moc_notificator.cpp \
   qt/moc_openuridialog.cpp \
@@ -138,6 +140,7 @@ BITCOIN_QT_H = \
   qt/macnotificationhandler.h \
   qt/macos_appnap.h \
   qt/modaloverlay.h \
+  qt/toolbaroverlay.h \
   qt/networkstyle.h \
   qt/notificator.h \
   qt/openuridialog.h \
@@ -245,6 +248,7 @@ BITCOIN_QT_BASE_CPP = \
   qt/guiutil.cpp \
   qt/intro.cpp \
   qt/modaloverlay.cpp \
+  qt/toolbaroverlay.cpp \
   qt/networkstyle.cpp \
   qt/notificator.cpp \
   qt/optionsdialog.cpp \

--- a/src/qt/assetsdialog.cpp
+++ b/src/qt/assetsdialog.cpp
@@ -330,6 +330,10 @@ void AssetsDialog::on_mintButton_clicked() {
     }
 
     if (!coinControl.HasSelected()) {
+        QMessageBox msgBox;
+        msgBox.setText(QString::fromStdString(strprintf("Error: No funds at specified address %s", EncodeDestination(ownerAddress))));
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.exec();
         return;
     }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -51,6 +51,8 @@ class HelpMessageDialog;
 
 class ModalOverlay;
 
+class ToolbarOverlay;
+
 namespace interfaces {
     class Handler;
 
@@ -214,7 +216,10 @@ private:
     RPCConsole *rpcConsole = nullptr;
     HelpMessageDialog *helpMessageDialog = nullptr;
     ModalOverlay *modalOverlay = nullptr;
+    ToolbarOverlay *toolbarOverlay = nullptr;
     QButtonGroup *tabGroup = nullptr;
+
+    int nWidth = 0;
 
 #ifdef Q_OS_MAC
     CAppNapInhibitor* m_app_nap_inhibitor = nullptr;

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -102,7 +102,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="pageMain">
       <layout class="QVBoxLayout" name="verticalLayout_Main">
@@ -282,6 +282,19 @@
            </property>
            <property name="text">
             <string notr="true">Enable CoinJoin features</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="hideToolbar">
+           <property name="toolTip">
+            <string>Automatic hide the toolbar menu interface</string>
+           </property>
+           <property name="text">
+            <string>Auto hide toolbar menu</string>
+           </property>
+           <property name="tristate">
+            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/src/qt/forms/toolbaroverlay.ui
+++ b/src/qt/forms/toolbaroverlay.ui
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ToolbarOverlay</class>
+ <widget class="QWidget" name="ToolbarOverlay">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>94</width>
+    <height>749</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>200</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -231,6 +231,8 @@ void OptionsDialog::setModel(OptionsModel *_model) {
     /* Wallet */
     connect(ui->showSmartnodesTab, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     connect(ui->spendZeroConfChange, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
+    connect(ui->hideToolbar, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
+    
     /* Network */
     connect(ui->allowIncoming, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     connect(ui->connectSocks, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
@@ -294,6 +296,7 @@ void OptionsDialog::setMapper() {
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->coinJoinRounds, OptionsModel::CoinJoinRounds);
     mapper->addMapping(ui->coinJoinAmount, OptionsModel::CoinJoinAmount);
+    mapper->addMapping(ui->hideToolbar, OptionsModel::HideToolbar);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -148,6 +148,9 @@ void OptionsModel::Init(bool resetSettings) {
     if (!settings.contains("digits"))
         settings.setValue("digits", "2");
 
+    if (!settings.contains("fHideToolbar"))
+        settings.setValue("fHideToolbar", true);
+
     // CoinJoin
     if (!settings.contains("fCoinJoinEnabled")) {
         settings.setValue("fCoinJoinEnabled", true);
@@ -400,6 +403,8 @@ QVariant OptionsModel::data(const QModelIndex &index, int role) const {
                     return settings.value("nCoinJoinAmount");
                 case CoinJoinMultiSession:
                     return settings.value("fCoinJoinMultiSession");
+                case HideToolbar:
+                    return settings.value("fHideToolbar");
 #endif
             case DisplayUnit:
                 return nDisplayUnit;
@@ -539,6 +544,12 @@ bool OptionsModel::setData(const QModelIndex &index, const QVariant &value, int 
                 case ShowSmartnodesTab:
                     if (settings.value("fShowSmartnodesTab") != value) {
                         settings.setValue("fShowSmartnodesTab", value);
+                        setRestartRequired(true);
+                    }
+                    break;
+                case HideToolbar:
+                    if (settings.value("fHideToolbar") != value) {
+                        settings.setValue("fHideToolbar", value);
                         setRestartRequired(true);
                     }
                     break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -56,6 +56,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         ShowSmartnodesTab,     // bool
+        HideToolbar,          //bool
         CoinJoinEnabled,     // bool
         ShowAdvancedCJUI,       // bool
         ShowCoinJoinPopups,  // bool
@@ -65,6 +66,7 @@ public:
         CoinJoinMultiSession,// bool
         Listen,                 // bool
         OptionIDRowCount,
+        
     };
 
     void Init(bool resetSettings = false);

--- a/src/qt/sendassetsdialog.cpp
+++ b/src/qt/sendassetsdialog.cpp
@@ -497,6 +497,10 @@ SendAssetsEntry *SendAssetsDialog::addEntry() {
     updateTabsAndLabels();
     if (model)
         entry->updateAssetList();
+
+    //update fonts every time a entry is added
+    GUIUtil::updateFonts();
+
     return entry;
 }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -514,6 +514,8 @@ SendCoinsEntry *SendCoinsDialog::addEntry() {
         bar->setSliderPosition(bar->maximum());
 
     updateTabsAndLabels();
+    //update fonts every time a entry is added
+    GUIUtil::updateFonts();
     return entry;
 }
 

--- a/src/qt/toolbaroverlay.cpp
+++ b/src/qt/toolbaroverlay.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Copyright (c) 2020-2023 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/toolbaroverlay.h>
+#include <qt/forms/ui_toolbaroverlay.h>
+
+#include <qt/guiutil.h>
+
+#include <chainparams.h>
+
+#include <QResizeEvent>
+#include <QPropertyAnimation>
+
+ToolbarOverlay::ToolbarOverlay(bool enable_wallet, QWidget *parent) :
+        QWidget(parent),
+        ui(new Ui::ToolbarOverlay),
+        layerIsVisible(false) {
+    ui->setupUi(this);
+
+    if (parent) {
+        parent->installEventFilter(this);
+        raise();
+    }
+    timer = new QTimer();
+    timer->setSingleShot(true);
+    connect(timer, &QTimer::timeout, this, &ToolbarOverlay::timeout);
+
+    setVisible(false);
+}
+
+ToolbarOverlay::~ToolbarOverlay() {
+    delete ui;
+}
+
+void ToolbarOverlay::timeout() {
+    if (!layerIsVisible)
+        return;
+
+    setGeometry( width(), 0, width(), height());
+
+    QPropertyAnimation *animation = new QPropertyAnimation(this, "pos");
+    animation->setDuration(300);
+    animation->setStartValue(QPoint(0, 0));
+    animation->setEndValue(QPoint(-this->width(), 0));
+    animation->setEasingCurve(QEasingCurve::OutQuad);
+    animation->start(QAbstractAnimation::DeleteWhenStopped);
+    layerIsVisible = false;
+}
+
+void ToolbarOverlay::addtoolbar(QToolBar *toolbar) {
+    ui->verticalLayout_2->addWidget(toolbar);
+}
+
+void ToolbarOverlay::setMaxWidth(int width) {
+    resize(width, height());
+    setMaximumWidth(width);
+}
+
+bool ToolbarOverlay::eventFilter(QObject *obj, QEvent *ev) {
+    if (obj == parent()) {
+        if (ev->type() == QEvent::Resize) {
+            QResizeEvent *rev = static_cast<QResizeEvent *>(ev);
+            resize(rev->size());
+            if (!layerIsVisible)
+                setGeometry(0, height(), width(), height());
+
+        } else if (ev->type() == QEvent::ChildAdded) {
+            raise();
+        } 
+    }
+    return QWidget::eventFilter(obj, ev);
+}
+
+//! Tracks parent widget changes
+bool ToolbarOverlay::event(QEvent *ev) {
+    if (ev->type() == QEvent::ParentAboutToChange) {
+        if (parent()) parent()->removeEventFilter(this);
+    } else if (ev->type() == QEvent::ParentChange) {
+        if (parent()) {
+            parent()->installEventFilter(this);
+            raise();
+        }
+    }
+    return QWidget::event(ev);
+}
+void ToolbarOverlay::cancelHide() {
+    if (layerIsVisible)
+        timer->stop();
+}
+void ToolbarOverlay::showHide(bool hide) {
+    if ((layerIsVisible && !hide) || (!layerIsVisible && hide))
+        return;
+
+    if (!isVisible() && !hide)
+        setVisible(true);
+
+    if(!hide){
+        setGeometry( hide ? 0 : width(), 0, width(), height());
+
+        QPropertyAnimation *animation = new QPropertyAnimation(this, "pos");
+        animation->setDuration(300);
+        animation->setStartValue(QPoint(-this->width(), 0));
+        animation->setEndValue(QPoint(0, 0));
+        animation->setEasingCurve(QEasingCurve::OutQuad);
+        animation->start(QAbstractAnimation::DeleteWhenStopped);
+        layerIsVisible = !hide;
+    } else {
+        timer->start(500);
+    }
+}

--- a/src/qt/toolbaroverlay.h
+++ b/src/qt/toolbaroverlay.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Copyright (c) 2020-2023 The Raptoreum developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_ToolbarOverlay_H
+#define BITCOIN_QT_ToolbarOverlay_H
+
+#include <QDateTime>
+#include <QWidget>
+#include <QToolBar>
+#include <QTimer>
+
+namespace Ui {
+    class ToolbarOverlay;
+}
+
+/** Modal overlay to display information about the chain-sync state */
+class ToolbarOverlay : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ToolbarOverlay(bool enable_wallet, QWidget *parent);
+
+    ~ToolbarOverlay();
+
+public
+    Q_SLOTS:
+    // will show or hide the modal layer
+    void showHide(bool hide = false);
+
+    void addtoolbar(QToolBar *toolbar);
+
+    void setMaxWidth(int width);
+
+    void cancelHide();
+
+    bool isLayerVisible() const { return layerIsVisible; }
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *ev) override;
+
+    bool event(QEvent *ev) override;
+
+private:
+    Ui::ToolbarOverlay *ui;
+    bool layerIsVisible;
+    QTimer *timer;
+
+private
+    Q_SLOTS:
+
+    void timeout();
+};
+
+#endif // BITCOIN_QT_ToolbarOverlay_H


### PR DESCRIPTION
added option to automatic hide the toolbar menu, default enabled, can be disabled under `Settings -> options -> wallet`
fixed a font issue on send pages when `Add Recipient` or `Clear All` is clicked
