### PR TITLE
Multi thread Headers POW calculation

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -575,7 +575,9 @@ void SetupServerArgs() {
     gArgs.AddArg("-powcachevalidate",
                  "Enable validation of pow hashes from the cache (default: %true). Use of this option will significantly slow down wallet synchronization.",
                  ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-
+    gArgs.AddArg("-powheaderthreads", strprintf(
+            "Set max pow threads to be used while processing headers (default: %d)",
+            DEFAULT_POWHEADERTHREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-addressindex", strprintf(
             "Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)",
             DEFAULT_ADDRESSINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::INDEXING);

--- a/src/validation.h
+++ b/src/validation.h
@@ -144,6 +144,7 @@ static const bool DEFAULT_ADDRESSINDEX = false;
 static const bool DEFAULT_TIMESTAMPINDEX = false;
 static const bool DEFAULT_SPENTINDEX = false;
 static const bool DEFAULT_FUTUREINDEX = false;
+static const int DEFAULT_POWHEADERTHREADS = 8;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;


### PR DESCRIPTION
This pr implement multi thread support to calculate the POW hash reducing block headers sync time significantly.
By default will use a maximum of 8 threads or number of cores the CPU has whichever is less. Can be increased/decreased with `-powheaderthreads` flag

some benchmark from raptoreumd syncing the first 40000 block headers on a quad core i5 4460
![image](https://github.com/Raptor3um/raptoreum/assets/28742969/02b8b098-abdd-46f0-a12f-2fa6e494f56c)