### PR TITLE
Fix potential crash during sync

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -131,8 +131,7 @@ bool CDeterministicMNList::IsMNValid(const CDeterministicMNCPtr &dmn, int height
 }
 
 bool CDeterministicMNList::IsMNValid(const CDeterministicMNCPtr &dmn) {
-    int height = ::ChainActive().Tip() == nullptr ? 0 : ::ChainActive().Tip()->nHeight;
-    return IsMNValid(dmn, height);
+    return IsMNValid(dmn, ::ChainActive().AtomicHeight());
 }
 
 bool CDeterministicMNList::IsMNPoSeBanned(const CDeterministicMNCPtr &dmn) {


### PR DESCRIPTION
Fixed an issue where Qt code could access a core object without a lock.  If it changed during the call, it can cause the program to crash.