### PR TITLE
Update required Debian build packages

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -12,7 +12,7 @@ Run the following commands to install required packages:
 
 ##### Debian/Ubuntu:
 ```bash
-$ sudo apt-get install curl build-essential libtool autotools-dev automake pkg-config python3 bsdmainutils
+$ sudo apt-get install curl build-essential libtool autotools-dev automake pkg-config python3 bsdmainutils bison
 ```
 
 ##### Fedora:


### PR DESCRIPTION
libxkbcommon requires `yacc` which is not available by default in the currently shown packages in Ubuntu 20.04.