### PR TITLE
fixes various

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -4,9 +4,9 @@
 # in-tree.
 #
 # Example use:
-# $ valgrind --suppressions=contrib/valgrind.supp src/test/test_dash
+# $ valgrind --suppressions=contrib/valgrind.supp src/test/test_raptoreum
 # $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
-#       --show-leak-kinds=all src/test/test_dash --log_level=test_suite
+#       --show-leak-kinds=all src/test/test_raporeum --log_level=test_suite
 {
    Suppress libstdc++ warning - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65434
    Memcheck:Leak

--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -152,7 +152,7 @@ be detected in descriptors up to 501 characters, and up to 3 errors in longer
 ones. For larger numbers of errors, or other types of errors, there is a
 roughly 1 in a trillion chance of not detecting the errors.
 
-All RPCs in Dash Core will include the checksum in their output. Only
+All RPCs in Raptoreum Core will include the checksum in their output. Only
 certain RPCs require checksums on input, including `deriveaddress` and
 `importmulti`. The checksum for a descriptor without one can be computed
 using the `getdescriptorinfo` RPC.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -241,9 +241,9 @@ which includes known Valgrind warnings in our dependencies that cannot be fixed
 in-tree. Example use:
 
 ```shell
-$ valgrind --suppressions=contrib/valgrind.supp src/test/test_dash
+$ valgrind --suppressions=contrib/valgrind.supp src/test/test_raptoreum
 $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
-      --show-leak-kinds=all src/test/test_dash --log_level=test_suite
+      --show-leak-kinds=all src/test/test_raptoreu --log_level=test_suite
 $ valgrind -v --leak-check=full src/raptoreumd -printtoconsole
 ```
 
@@ -260,7 +260,7 @@ To enable LCOV report generation during test runs:
 make
 make cov
 
-# A coverage report will now be accessible at `./test_dash.coverage/index.html`.
+# A coverage report will now be accessible at `./test_raptoreum.coverage/index.html`.
 ```
 
 **Sanitizers**
@@ -287,14 +287,14 @@ Some examples:
 
 Valgrind is a programming tool for memory debugging, memory leak detection, and
 profiling. The repo contains a Valgrind suppressions file
-([`valgrind.supp`](https://github.com/dashpay/dash/blob/master/contrib/valgrind.supp))
+([`valgrind.supp`](https://github.com/raptoreumpay/raptoreum/blob/master/contrib/valgrind.supp))
 which includes known Valgrind warnings in our dependencies that cannot be fixed
 in-tree. Example use:
 
 ```shell
-$ valgrind --suppressions=contrib/valgrind.supp src/test/test_dash
+$ valgrind --suppressions=contrib/valgrind.supp src/test/test_raptoreum
 $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
-      --show-leak-kinds=all src/test/test_dash --log_level=test_suite
+      --show-leak-kinds=all src/test/test_raptoreum --log_level=test_suite
 $ valgrind -v --leak-check=full src/raptoreumd -printtoconsole
 ```
 
@@ -311,7 +311,7 @@ To enable LCOV report generation during test runs:
 make
 make cov
 
-# A coverage report will now be accessible at `./test_dash.coverage/index.html`.
+# A coverage report will now be accessible at `./test_raptoreum.coverage/index.html`.
 ```
 
 Locking/mutex usage notes

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -287,7 +287,7 @@ Some examples:
 
 Valgrind is a programming tool for memory debugging, memory leak detection, and
 profiling. The repo contains a Valgrind suppressions file
-([`valgrind.supp`](https://github.com/raptoreumpay/raptoreum/blob/master/contrib/valgrind.supp))
+([`valgrind.supp`](https://github.com/Raptor3um/raptoreum/blob/master/contrib/valgrind.supp))
 which includes known Valgrind warnings in our dependencies that cannot be fixed
 in-tree. Example use:
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -137,9 +137,9 @@ configured. For cookie authentication the user running raptoreumd must have writ
 to the `CookieAuthFile` specified in Tor configuration. In some cases this is
 preconfigured and the creation of a hidden service is automatic. If permission problems
 are seen with `-debug=tor` they can be resolved by adding both the user running Tor and
-the user running dashd to the same group and setting permissions appropriately. On
-Debian-based systems the user running dashd can be added to the debian-tor group,
-which has the appropriate permissions. Before starting dashd you will need to re-login
+the user running raptoreumd to the same group and setting permissions appropriately. On
+Debian-based systems the user running raptoreumd can be added to the debian-tor group,
+which has the appropriate permissions. Before starting raptoreumd you will need to re-login
 to allow debian-tor group to be applied. Otherwise you will see the following notice: "tor:
 Authentication cookie /run/tor/control.authcookie could not be opened (check permissions)"
 on debug.log.

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -8,7 +8,7 @@ Transifex is setup to monitor the GitHub repo for updates, and when code contain
 
 Multiple language support is critical in assisting Raptoreum’s global adoption, and growth. One of Raptoreum’s greatest strengths is cross-border money transfers, any help making that easier is greatly appreciated.
 
-See the [Transifex Raptoreum project](https://www.transifex.com/projects/p/raptoreum/) to assist in translations. You should also join the translation mailing list for announcements - see details below.
+See the [Transifex Raptoreum project](https://explore.transifex.com/feathered-inc/) to assist in translations. You should also join the translation mailing list for announcements - see details below.
 
 ### Writing code with translations
 We use automated scripts to help extract translations in both Qt, and non-Qt source files. It is rarely necessary to manually edit the files in `src/qt/locale/`. The translation source files must adhere to the following format:
@@ -44,7 +44,7 @@ git commit
 ### Creating a Transifex account
 Visit the [Transifex Signup](https://www.transifex.com/signup/) page to create an account. Take note of your username and password, as they will be required to configure the command-line tool.
 
-You can find the Raptoreum translation project at [https://www.transifex.com/projects/p/raptoreum/](https://www.transifex.com/projects/p/raptoreum/).
+You can find the Raptoreum translation project at [https://explore.transifex.com/feathered-inc/](https://explore.transifex.com/feathered-inc/).
 
 ### Installing the Transifex client command-line tool
 The client it used to fetch updated translations. If you are having problems, or need more details, see [http://docs.transifex.com/developer/client/setup](http://docs.transifex.com/developer/client/setup)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -4,14 +4,14 @@ export LC_ALL=C
 set -e
 
 # Get Tor service IP if running
-if [[ "$1" == "dashd" ]]; then
-  # Because dashd only accept torcontrol= host as an ip only, we resolve it here and add to config
+if [[ "$1" == "raptoreumd" ]]; then
+  # Because raptoreumd only accept torcontrol= host as an ip only, we resolve it here and add to config
   if [[ "$TOR_CONTROL_HOST" ]] && [[ "$TOR_CONTROL_PORT" ]] && [[ "$TOR_PROXY_PORT" ]]; then
     TOR_IP=$(getent hosts $TOR_CONTROL_HOST | cut -d ' ' -f 1)
-    echo "proxy=$TOR_IP:$TOR_PROXY_PORT" >> "$HOME/.dashcore/dash.conf"
-    echo "Added "proxy=$TOR_IP:$TOR_PROXY_PORT" to $HOME/.dashcore/dash.conf"
-    echo "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" >> "$HOME/.dashcore/dash.conf"
-    echo "Added "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" to $HOME/.dashcore/dash.conf"
+    echo "proxy=$TOR_IP:$TOR_PROXY_PORT" >> "$HOME/.raptoreumcore/raptoreum.conf"
+    echo "Added "proxy=$TOR_IP:$TOR_PROXY_PORT" to $HOME/.raptoreumcore/raptoreum.conf"
+    echo "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" >> "$HOME/.raptoreumcore/raptoreum.conf"
+    echo "Added "torcontrol=$TOR_IP:$TOR_CONTROL_PORT" to $HOME/.raptoreumcore/raptoreum.conf"
     echo -e "\n"
   else
     echo "Tor control credentials not provided"

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -885,7 +885,7 @@ void CRegTestParams::UpdateBudgetParametersFromArgs(const ArgsManager &args) {
     std::vector <std::string> vParams;
     boost::split(vParams, strParams, boost::is_any_of(":"));
     if (vParams.size() != 3) {
-        throw std::runtime_error("Budget parameters malformed, expecting <masternode>:<budget>:<superblock>");
+        throw std::runtime_error("Budget parameters malformed, expecting <smartnode>:<budget>:<superblock>");
     }
     int nSmartnodePaymentsStartBlock, nBudgetPaymentsStartBlock, nSuperblockStartBlock;
     if (!ParseInt32(vParams[0], &nSmartnodePaymentsStartBlock)) {

--- a/src/coinjoin/coinjoin-client.h
+++ b/src/coinjoin/coinjoin-client.h
@@ -115,7 +115,7 @@ private:
 
     LOCKS_EXCLUDED(cs_coinjoin);
 
-    /// Process Masternode updates about the progress of mixing
+    /// Process smartnode updates about the progress of mixing
     void ProcessPoolStateUpdate(CCoinJoinStatusUpdate psssup);
 
     // Set the 'state' value, with some logging and capturing when the state changed
@@ -181,7 +181,7 @@ public:
  */
 class CCoinJoinClientManager {
 private:
-    // Keep track of the used Masternodes
+    // Keep track of the used Smartnodes
     std::vector <COutPoint> vecSmartnodesUsed;
 
     mutable Mutex cs_deqsessions;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -64,7 +64,7 @@ namespace interfaces {
         virtual size_t getInstantSentLockCount() = 0;
     };
 
-//! Interface for the src/masternode part of a raptoreum node (raptoreumd process).
+//! Interface for the src/smartnode part of a raptoreum node (raptoreumd process).
     namespace Smartnode {
         class Sync {
         public:
@@ -289,10 +289,10 @@ namespace interfaces {
         //! Return interface for accessing llmq related handler.
         virtual LLMQ &llmq() = 0;
 
-        //! Return interface for accessing masternode related handler.
+        //! Return interface for accessing smartnode related handler.
         virtual Smartnode::Sync &smartnodeSync() = 0;
 
-        //! Return interface for accessing masternode related handler.
+        //! Return interface for accessing smartnode related handler.
         virtual CoinJoin::Options &coinJoinOptions() = 0;
 
         //! Register handler for init messages.
@@ -355,7 +355,7 @@ namespace interfaces {
 
         virtual std::unique_ptr <Handler> handleNotifyHeaderTip(NotifyHeaderTipFn fn) = 0;
 
-        //! Register handler for masternode list update messages.
+        //! Register handler for smartnode list update messages.
         using NotifySmartnodeListChangedFn = std::function<void(const CDeterministicMNList &newList)>;
 
         virtual std::unique_ptr <Handler> handleNotifySmartnodeListChanged(NotifySmartnodeListChangedFn fn) = 0;

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -624,7 +624,7 @@ namespace llmq {
             auto verifiedProRegTxHash = pFrom->GetVerifiedProRegTxHash();
             if ((!fSmartnodeMode && !CLLMQUtils::IsWatchQuorumsEnabled()) || pFrom == nullptr ||
                 (verifiedProRegTxHash.IsNull() && !pFrom->qwatch)) {
-                errorHandler("Not a verified masternode or a qwatch connection");
+                errorHandler("Not a verified smartnode or a qwatch connection");
                 return;
             }
 

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -778,7 +778,7 @@
          </property>
          <property name="text">
           <string>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/raptoreum/</string>
+https://explore.transifex.com/feathered-inc/</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/src/qt/locale/raptoreum_en.ts
+++ b/src/qt/locale/raptoreum_en.ts
@@ -701,12 +701,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
+        <location line="+196"/>
         <source>Details for asset: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+113"/>
         <source>Mint details:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1631,7 +1631,7 @@
 <context>
     <name>CreateAssetConfirmationDialog</name>
     <message>
-        <location filename="../createassetsdialog.cpp" line="+885"/>
+        <location filename="../createassetsdialog.cpp" line="+877"/>
         <location line="+3"/>
         <source>Yes</source>
         <translation type="unfinished">Yes</translation>
@@ -1926,7 +1926,7 @@
     <message>
         <location line="+27"/>
         <location line="+13"/>
-        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for raptoreum transactions than the network can process.</source>
+        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for Raptoreum transactions than the network can process.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1956,7 +1956,7 @@
     </message>
     <message>
         <location line="+106"/>
-        <location filename="../createassetsdialog.cpp" line="-736"/>
+        <location filename="../createassetsdialog.cpp" line="-728"/>
         <source>C&amp;reate Asset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2031,7 +2031,7 @@
         <translation type="unfinished">%1 (%2 blocks)</translation>
     </message>
     <message>
-        <location line="+156"/>
+        <location line="+154"/>
         <source>Asset details:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2107,7 +2107,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+212"/>
+        <location line="+209"/>
         <source>Pay only the required fee of %1</source>
         <translation type="unfinished">Pay only the required fee of %1</translation>
     </message>
@@ -2704,7 +2704,13 @@
         <translation>Use separate SOCKS&amp;5 proxy to reach peers via Tor hidden services:</translation>
     </message>
     <message>
-        <location line="+272"/>
+        <location line="+141"/>
+        <source>Language missing or translation incomplete? Help contributing translations here:
+https://explore.transifex.com/feathered-inc/</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+131"/>
         <source>Options set in this dialog are overriden by the command_line or in the configuration file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2854,14 +2860,7 @@
         <translation>The user interface language can be set here. This setting will take effect after restarting %1.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <source>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/raptoreum/</source>
-        <translation>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/raptoreum/</translation>
-    </message>
-    <message>
-        <location line="+26"/>
+        <location line="+47"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unit to show amounts in:</translation>
     </message>
@@ -6643,7 +6642,7 @@ https://www.transifex.com/projects/p/raptoreum/</translation>
 <context>
     <name>UpdateAssetConfirmationDialog</name>
     <message>
-        <location filename="../updateassetsdialog.cpp" line="+714"/>
+        <location filename="../updateassetsdialog.cpp" line="+681"/>
         <location line="+3"/>
         <source>Yes</source>
         <translation type="unfinished">Yes</translation>
@@ -6822,7 +6821,7 @@ https://www.transifex.com/projects/p/raptoreum/</translation>
     <message>
         <location line="+27"/>
         <location line="+13"/>
-        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for raptoreum transactions than the network can process.</source>
+        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for Raptoreum transactions than the network can process.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6852,7 +6851,7 @@ https://www.transifex.com/projects/p/raptoreum/</translation>
     </message>
     <message>
         <location line="+106"/>
-        <location filename="../updateassetsdialog.cpp" line="-614"/>
+        <location filename="../updateassetsdialog.cpp" line="-581"/>
         <source>U&amp;pdate Asset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6892,7 +6891,7 @@ https://www.transifex.com/projects/p/raptoreum/</translation>
         <translation type="unfinished">%1 (%2 blocks)</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+224"/>
         <source>Updating asset: %1&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7243,11 +7242,6 @@ https://www.transifex.com/projects/p/raptoreum/</translation>
     <message>
         <location line="+2"/>
         <source>Warning: The Network does not appear to fully agree! Some miners addear to experiencing issues.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Warning: Unknown block versions being mined! It&apos;s possible unknown rules are in effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8198,7 +8192,7 @@ https://www.transifex.com/projects/p/raptoreum/</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Warning: unknown new rules activated (versionbit %i)</source>
+        <source>Warning: unknown new rules activated: Expected: 0x%08x, Actual: 0x%08x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/raptoreum_en.xlf
+++ b/src/qt/locale/raptoreum_en.xlf
@@ -723,41 +723,41 @@
       <trans-unit id="_msg134">
         <source xml:space="preserve">Details for asset: %1</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
       <trans-unit id="_msg135">
         <source xml:space="preserve">Mint details:</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
       </trans-unit>
       <trans-unit id="_msg136">
         <source xml:space="preserve">Name: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
       </trans-unit>
       <trans-unit id="_msg137">
         <source xml:space="preserve">Amount: %1</source>
         <target xml:space="preserve" state="needs-review-translation">Amount: %1
  {1?}</target>
-        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
       </trans-unit>
       <trans-unit id="_msg138">
         <source xml:space="preserve">are added as transaction fee.&lt;hr /&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
       </trans-unit>
       <trans-unit id="_msg139">
         <source xml:space="preserve">Confirm Asset Mint</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="MintAssetConfirmationDialog">
       <trans-unit id="_msg140">
         <source xml:space="preserve">Yes</source>
         <target xml:space="preserve" state="needs-review-translation">Yes</target>
-        <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -1794,8 +1794,8 @@
       <trans-unit id="_msg335">
         <source xml:space="preserve">Yes</source>
         <target xml:space="preserve" state="needs-review-translation">Yes</target>
-        <context-group purpose="location"><context context-type="linenumber">885</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">888</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">877</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">880</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="CreateAssetsDialog">
@@ -1857,86 +1857,86 @@
       <trans-unit id="_msg347">
         <source xml:space="preserve">Asset details:</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
       </trans-unit>
       <trans-unit id="_msg348">
         <source xml:space="preserve">Name: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
       </trans-unit>
       <trans-unit id="_msg349">
         <source xml:space="preserve">Isunique: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
       </trans-unit>
       <trans-unit id="_msg350">
         <source xml:space="preserve">Updatable: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
       <trans-unit id="_msg351">
         <source xml:space="preserve">Decimalpoint: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
       </trans-unit>
       <trans-unit id="_msg352">
         <source xml:space="preserve">ReferenceHash: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
       </trans-unit>
       <trans-unit id="_msg353">
         <source xml:space="preserve">MaxMintCount: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
       </trans-unit>
       <trans-unit id="_msg354">
         <source xml:space="preserve">Owner: %1 &lt;hr /&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
       </trans-unit>
       <trans-unit id="_msg355">
         <source xml:space="preserve">Distribution:&lt;hr /&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
       </trans-unit>
       <trans-unit id="_msg356">
         <source xml:space="preserve">Type: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
       </trans-unit>
       <trans-unit id="_msg357">
         <source xml:space="preserve">Target: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
       </trans-unit>
       <trans-unit id="_msg358">
         <source xml:space="preserve">IssueFrequency: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
       <trans-unit id="_msg359">
         <source xml:space="preserve">Amount: %1</source>
         <target xml:space="preserve" state="needs-review-translation">Amount: %1
  {1?}</target>
-        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
       </trans-unit>
       <trans-unit id="_msg360">
         <source xml:space="preserve">are added as transaction fee.&lt;hr /&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
       </trans-unit>
       <trans-unit id="_msg361">
         <source xml:space="preserve">Confirm Asset Creation</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
       </trans-unit>
       <trans-unit id="_msg362">
         <source xml:space="preserve">Pay only the required fee of %1</source>
         <target xml:space="preserve" state="needs-review-translation">Pay only the required fee of %1</target>
-        <context-group purpose="location"><context context-type="linenumber">599</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">594</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">634</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">629</context></context-group>
         <trans-unit id="_msg363[0]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
           <target xml:space="preserve" state="needs-review-translation">Estimated to begin confirmation within %n block.</target>
@@ -1949,27 +1949,27 @@
       <trans-unit id="_msg364">
         <source xml:space="preserve">Warning: Invalid Raptoreum address</source>
         <target xml:space="preserve" state="needs-review-translation">Warning: Invalid Raptoreum address</target>
-        <context-group purpose="location"><context context-type="linenumber">726</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">721</context></context-group>
       </trans-unit>
       <trans-unit id="_msg365">
         <source xml:space="preserve">Warning: Unknown change address</source>
         <target xml:space="preserve" state="needs-review-translation">Warning: Unknown change address</target>
-        <context-group purpose="location"><context context-type="linenumber">730</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">725</context></context-group>
       </trans-unit>
       <trans-unit id="_msg366">
         <source xml:space="preserve">Confirm custom change address</source>
         <target xml:space="preserve" state="needs-review-translation">Confirm custom change address</target>
-        <context-group purpose="location"><context context-type="linenumber">733</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">728</context></context-group>
       </trans-unit>
       <trans-unit id="_msg367">
         <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
         <target xml:space="preserve" state="needs-review-translation">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</target>
-        <context-group purpose="location"><context context-type="linenumber">734</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">729</context></context-group>
       </trans-unit>
       <trans-unit id="_msg368">
         <source xml:space="preserve">(no label)</source>
         <target xml:space="preserve" state="needs-review-translation">(no label)</target>
-        <context-group purpose="location"><context context-type="linenumber">756</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -2260,7 +2260,7 @@
         <context-group purpose="location"><context context-type="linenumber">1185</context></context-group>
       </trans-unit>
       <trans-unit id="_msg425">
-        <source xml:space="preserve">Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for raptoreum transactions than the network can process.</source>
+        <source xml:space="preserve">Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for Raptoreum transactions than the network can process.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">1212</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1225</context></context-group>
@@ -2920,161 +2920,160 @@
         <context-group purpose="location"><context context-type="linenumber">639</context></context-group>
       </trans-unit>
       <trans-unit id="_msg544">
+        <source xml:space="preserve">Language missing or translation incomplete? Help contributing translations here:
+https://explore.transifex.com/feathered-inc/</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg545">
         <source xml:space="preserve">Options set in this dialog are overriden by the command_line or in the configuration file:</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">911</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg545" approved="yes">
+      <trans-unit id="_msg546" approved="yes">
         <source xml:space="preserve">Hide the icon from the system tray.</source>
         <target xml:space="preserve">Hide the icon from the system tray.</target>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg546" approved="yes">
+      <trans-unit id="_msg547" approved="yes">
         <source xml:space="preserve">&amp;Hide tray icon</source>
         <target xml:space="preserve">&amp;Hide tray icon</target>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg547" approved="yes">
+      <trans-unit id="_msg548" approved="yes">
         <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <target xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</target>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg548" approved="yes">
+      <trans-unit id="_msg549" approved="yes">
         <source xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items.&lt;br/&gt;%s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
         <target xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items.&lt;br/&gt;%s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</target>
         <context-group purpose="location"><context context-type="linenumber">844</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">857</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg549" approved="yes">
+      <trans-unit id="_msg550" approved="yes">
         <source xml:space="preserve">&amp;Third party transaction URLs</source>
         <target xml:space="preserve">&amp;Third party transaction URLs</target>
         <context-group purpose="location"><context context-type="linenumber">847</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg550" approved="yes">
+      <trans-unit id="_msg551" approved="yes">
         <source xml:space="preserve">Whether to show coin control features or not.</source>
         <target xml:space="preserve">Whether to show coin control features or not.</target>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg551" approved="yes">
+      <trans-unit id="_msg552" approved="yes">
         <source xml:space="preserve">Automatically start %1 after logging in to the system.</source>
         <target xml:space="preserve">Automatically start %1 after logging in to the system.</target>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg552" approved="yes">
+      <trans-unit id="_msg553" approved="yes">
         <source xml:space="preserve">&amp;Start %1 on system login</source>
         <target xml:space="preserve">&amp;Start %1 on system login</target>
         <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg553" approved="yes">
+      <trans-unit id="_msg554" approved="yes">
         <source xml:space="preserve">Enable coin &amp;control features</source>
         <target xml:space="preserve">Enable coin &amp;control features</target>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg554" approved="yes">
+      <trans-unit id="_msg555" approved="yes">
         <source xml:space="preserve">&amp;Spend unconfirmed change</source>
         <target xml:space="preserve">&amp;Spend unconfirmed change</target>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg555" approved="yes">
+      <trans-unit id="_msg556" approved="yes">
         <source xml:space="preserve">This setting determines the amount of individual smartnodes that an input will be mixed through.&lt;br/&gt;More rounds of mixing gives a higher degree of privacy, but also costs more in fees.</source>
         <target xml:space="preserve">This setting determines the amount of individual smartnodes that an input will be mixed through.&lt;br/&gt;More rounds of mixing gives a higher degree of privacy, but also costs more in fees.</target>
         <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg556" approved="yes">
+      <trans-unit id="_msg557" approved="yes">
         <source xml:space="preserve">&amp;Network</source>
         <target xml:space="preserve">&amp;Network</target>
         <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg557" approved="yes">
+      <trans-unit id="_msg558" approved="yes">
         <source xml:space="preserve">Map port using &amp;UPnP</source>
         <target xml:space="preserve">Map port using &amp;UPnP</target>
         <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg558" approved="yes">
+      <trans-unit id="_msg559" approved="yes">
         <source xml:space="preserve">Proxy &amp;IP:</source>
         <target xml:space="preserve">Proxy &amp;IP:</target>
         <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">648</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg559" approved="yes">
+      <trans-unit id="_msg560" approved="yes">
         <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <target xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</target>
         <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">673</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg560" approved="yes">
+      <trans-unit id="_msg561" approved="yes">
         <source xml:space="preserve">&amp;Port:</source>
         <target xml:space="preserve">&amp;Port:</target>
         <context-group purpose="location"><context context-type="linenumber">523</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">680</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg561" approved="yes">
+      <trans-unit id="_msg562" approved="yes">
         <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
         <target xml:space="preserve">Port of the proxy (e.g. 9050)</target>
         <context-group purpose="location"><context context-type="linenumber">548</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">705</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg562" approved="yes">
+      <trans-unit id="_msg563" approved="yes">
         <source xml:space="preserve">Used for reaching peers via:</source>
         <target xml:space="preserve">Used for reaching peers via:</target>
         <context-group purpose="location"><context context-type="linenumber">572</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg563" approved="yes">
+      <trans-unit id="_msg564" approved="yes">
         <source xml:space="preserve">IPv4</source>
         <target xml:space="preserve">IPv4</target>
         <context-group purpose="location"><context context-type="linenumber">588</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg564" approved="yes">
+      <trans-unit id="_msg565" approved="yes">
         <source xml:space="preserve">IPv6</source>
         <target xml:space="preserve">IPv6</target>
         <context-group purpose="location"><context context-type="linenumber">601</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg565" approved="yes">
+      <trans-unit id="_msg566" approved="yes">
         <source xml:space="preserve">Tor</source>
         <target xml:space="preserve">Tor</target>
         <context-group purpose="location"><context context-type="linenumber">614</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg566" approved="yes">
+      <trans-unit id="_msg567" approved="yes">
         <source xml:space="preserve">Connect to the Raptoreum network through a separate SOCKS5 proxy for Tor hidden services.</source>
         <target xml:space="preserve">Connect to the Raptoreum network through a separate SOCKS5 proxy for Tor hidden services.</target>
         <context-group purpose="location"><context context-type="linenumber">636</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg567" approved="yes">
+      <trans-unit id="_msg568" approved="yes">
         <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
         <target xml:space="preserve">Show only a tray icon after minimizing the window.</target>
         <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg568" approved="yes">
+      <trans-unit id="_msg569" approved="yes">
         <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
         <target xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</target>
         <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg569" approved="yes">
+      <trans-unit id="_msg570" approved="yes">
         <source xml:space="preserve">M&amp;inimize on close</source>
         <target xml:space="preserve">M&amp;inimize on close</target>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg570" approved="yes">
+      <trans-unit id="_msg571" approved="yes">
         <source xml:space="preserve">&amp;Display</source>
         <target xml:space="preserve">&amp;Display</target>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg571" approved="yes">
+      <trans-unit id="_msg572" approved="yes">
         <source xml:space="preserve">User Interface &amp;language:</source>
         <target xml:space="preserve">User Interface &amp;language:</target>
         <context-group purpose="location"><context context-type="linenumber">746</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg572" approved="yes">
+      <trans-unit id="_msg573" approved="yes">
         <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <target xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</target>
         <context-group purpose="location"><context context-type="linenumber">759</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg573" approved="yes">
-        <source xml:space="preserve">Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/raptoreum/</source>
-        <target xml:space="preserve">Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/raptoreum/</target>
-        <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
       </trans-unit>
       <trans-unit id="_msg574" approved="yes">
         <source xml:space="preserve">&amp;Unit to show amounts in:</source>
@@ -6847,8 +6846,8 @@ https://www.transifex.com/projects/p/raptoreum/</target>
       <trans-unit id="_msg1256">
         <source xml:space="preserve">Yes</source>
         <target xml:space="preserve" state="needs-review-translation">Yes</target>
-        <context-group purpose="location"><context context-type="linenumber">714</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">684</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="UpdateAssetsDialog">
@@ -6875,70 +6874,70 @@ https://www.transifex.com/projects/p/raptoreum/</target>
       <trans-unit id="_msg1261">
         <source xml:space="preserve">Updating asset: %1&lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1262">
         <source xml:space="preserve">transfer ownership from: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1263">
         <source xml:space="preserve">To: %1 &lt;hr /&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1264">
         <source xml:space="preserve">Updatable: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1265">
         <source xml:space="preserve">ReferenceHash: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1266">
         <source xml:space="preserve">Target: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1267">
         <source xml:space="preserve">Distribution Type: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1268">
         <source xml:space="preserve">Amount: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1269">
         <source xml:space="preserve">MaxMintCount: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1270">
         <source xml:space="preserve">IssueFrequency: %1 &lt;br&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1271">
         <source xml:space="preserve">are added as transaction fee.&lt;hr /&gt;</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">448</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1272">
         <source xml:space="preserve">Confirm Asset Update</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1273">
         <source xml:space="preserve">Pay only the required fee of %1</source>
         <target xml:space="preserve" state="needs-review-translation">Pay only the required fee of %1</target>
-        <context-group purpose="location"><context context-type="linenumber">580</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">615</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">582</context></context-group>
         <trans-unit id="_msg1274[0]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
           <target xml:space="preserve" state="needs-review-translation">Estimated to begin confirmation within %n block.</target>
@@ -7121,7 +7120,7 @@ https://www.transifex.com/projects/p/raptoreum/</target>
         <context-group purpose="location"><context context-type="linenumber">652</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1308">
-        <source xml:space="preserve">Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for raptoreum transactions than the network can process.</source>
+        <source xml:space="preserve">Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for Raptoreum transactions than the network can process.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">692</context></context-group>
@@ -7440,1020 +7439,1015 @@ https://www.transifex.com/projects/p/raptoreum/</target>
         <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1368">
-        <source xml:space="preserve">Warning: Unknown block versions being mined! It&apos;s possible unknown rules are in effect</source>
+        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1369">
-        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -timestampindex</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1370">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -timestampindex</source>
+        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1371">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <source xml:space="preserve">%d of last 100 blocks have unexpected version</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1372">
-        <source xml:space="preserve">%d of last 100 blocks have unexpected version</source>
+        <source xml:space="preserve">%s can&apos;t be lower than %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1373">
+        <source xml:space="preserve">%s failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1374">
+        <source xml:space="preserve">%s is idle.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1373">
-        <source xml:space="preserve">%s can&apos;t be lower than %s</source>
+      <trans-unit id="_msg1375">
+        <source xml:space="preserve">%s is not a valid backup folder!</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1374">
-        <source xml:space="preserve">%s failed</source>
+      <trans-unit id="_msg1376">
+        <source xml:space="preserve">%s is set very high!</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1375">
-        <source xml:space="preserve">%s is idle.</source>
+      <trans-unit id="_msg1377">
+        <source xml:space="preserve">%s request incomplete: %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1376">
-        <source xml:space="preserve">%s is not a valid backup folder!</source>
+      <trans-unit id="_msg1378">
+        <source xml:space="preserve">-devnet can only be specified once</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1377">
-        <source xml:space="preserve">%s is set very high!</source>
+      <trans-unit id="_msg1379">
+        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1378">
-        <source xml:space="preserve">%s request incomplete: %s</source>
+      <trans-unit id="_msg1380">
+        <source xml:space="preserve">-port must be specified when -devnet and -listen are specified</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1379">
-        <source xml:space="preserve">-devnet can only be specified once</source>
+      <trans-unit id="_msg1381">
+        <source xml:space="preserve">-rpcport must be specified when -devnet and -server are specified</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1380">
-        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
+      <trans-unit id="_msg1382">
+        <source xml:space="preserve">Already have that input.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1381">
-        <source xml:space="preserve">-port must be specified when -devnet and -listen are specified</source>
+      <trans-unit id="_msg1383">
+        <source xml:space="preserve">Asset Transfer amounts must be greater than 0</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1382">
-        <source xml:space="preserve">-rpcport must be specified when -devnet and -server are specified</source>
+      <trans-unit id="_msg1384">
+        <source xml:space="preserve">Asset owner key not in wallet</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1383">
-        <source xml:space="preserve">Already have that input.</source>
+      <trans-unit id="_msg1385">
+        <source xml:space="preserve">Automatic backups disabled</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1384">
-        <source xml:space="preserve">Asset Transfer amounts must be greater than 0</source>
+      <trans-unit id="_msg1386">
+        <source xml:space="preserve">Can&apos;t find random Smartnode.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1385">
-        <source xml:space="preserve">Asset owner key not in wallet</source>
+      <trans-unit id="_msg1387">
+        <source xml:space="preserve">Can&apos;t mix while sync in progress.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1386">
-        <source xml:space="preserve">Automatic backups disabled</source>
+      <trans-unit id="_msg1388">
+        <source xml:space="preserve">Can&apos;t mix: no compatible inputs found!</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1387">
-        <source xml:space="preserve">Can&apos;t find random Smartnode.</source>
+      <trans-unit id="_msg1389">
+        <source xml:space="preserve">Cannot downgrade wallet</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1388">
-        <source xml:space="preserve">Can&apos;t mix while sync in progress.</source>
+      <trans-unit id="_msg1390">
+        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1389">
-        <source xml:space="preserve">Can&apos;t mix: no compatible inputs found!</source>
+      <trans-unit id="_msg1391">
+        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1390">
-        <source xml:space="preserve">Cannot downgrade wallet</source>
+      <trans-unit id="_msg1392">
+        <source xml:space="preserve">Change index out of range</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1391">
-        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+      <trans-unit id="_msg1393">
+        <source xml:space="preserve">Collateral not valid.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1392">
-        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
+      <trans-unit id="_msg1394">
+        <source xml:space="preserve">Config settings for %s only applied on %s network when in [%s] section.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1393">
-        <source xml:space="preserve">Change index out of range</source>
+      <trans-unit id="_msg1395">
+        <source xml:space="preserve">Copyright (C)</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1394">
-        <source xml:space="preserve">Collateral not valid.</source>
+      <trans-unit id="_msg1396">
+        <source xml:space="preserve">Corrupted block database detected</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1395">
-        <source xml:space="preserve">Config settings for %s only applied on %s network when in [%s] section.</source>
+      <trans-unit id="_msg1397">
+        <source xml:space="preserve">Could not find asmap file %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1396">
-        <source xml:space="preserve">Copyright (C)</source>
+      <trans-unit id="_msg1398">
+        <source xml:space="preserve">Could not parse asmap file %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1397">
-        <source xml:space="preserve">Corrupted block database detected</source>
+      <trans-unit id="_msg1399">
+        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1398">
-        <source xml:space="preserve">Could not find asmap file %s</source>
+      <trans-unit id="_msg1400">
+        <source xml:space="preserve">Done loading</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1399">
-        <source xml:space="preserve">Could not parse asmap file %s</source>
-        <target xml:space="preserve"></target>
+      <trans-unit id="_msg1401">
+        <source xml:space="preserve">ERROR! Failed to create automatic backup</source>
+        <target xml:space="preserve" state="needs-review-translation">ERROR! Failed to create automatic backup</target>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1400">
-        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
+      <trans-unit id="_msg1402">
+        <source xml:space="preserve">Entries are full.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1401">
-        <source xml:space="preserve">Done loading</source>
+      <trans-unit id="_msg1403">
+        <source xml:space="preserve">Entry exceeds maximum size.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1402">
-        <source xml:space="preserve">ERROR! Failed to create automatic backup</source>
-        <target xml:space="preserve" state="needs-review-translation">ERROR! Failed to create automatic backup</target>
+      <trans-unit id="_msg1404">
+        <source xml:space="preserve">Error initializing block database</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1403">
-        <source xml:space="preserve">Entries are full.</source>
+      <trans-unit id="_msg1405">
+        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1404">
-        <source xml:space="preserve">Entry exceeds maximum size.</source>
+      <trans-unit id="_msg1406">
+        <source xml:space="preserve">Error loading %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1405">
-        <source xml:space="preserve">Error initializing block database</source>
+      <trans-unit id="_msg1407">
+        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1406">
-        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
+      <trans-unit id="_msg1408">
+        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1407">
-        <source xml:space="preserve">Error loading %s</source>
+      <trans-unit id="_msg1409">
+        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1408">
-        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
+      <trans-unit id="_msg1410">
+        <source xml:space="preserve">Error loading %s: You can&apos;t disable HD on an already existing HD wallet</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1409">
-        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
+      <trans-unit id="_msg1411">
+        <source xml:space="preserve">Error loading block database</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1410">
-        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
+      <trans-unit id="_msg1412">
+        <source xml:space="preserve">Error loading wallet %s. Duplicate -wallet filename specified.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1411">
-        <source xml:space="preserve">Error loading %s: You can&apos;t disable HD on an already existing HD wallet</source>
+      <trans-unit id="_msg1413">
+        <source xml:space="preserve">Error opening block database</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1412">
-        <source xml:space="preserve">Error loading block database</source>
+      <trans-unit id="_msg1414">
+        <source xml:space="preserve">Error reading from database, shutting down.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1413">
-        <source xml:space="preserve">Error loading wallet %s. Duplicate -wallet filename specified.</source>
+      <trans-unit id="_msg1415">
+        <source xml:space="preserve">Error upgrading chainstate database</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1414">
-        <source xml:space="preserve">Error opening block database</source>
+      <trans-unit id="_msg1416">
+        <source xml:space="preserve">Error upgrading evo database</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1415">
-        <source xml:space="preserve">Error reading from database, shutting down.</source>
-        <target xml:space="preserve"></target>
+      <trans-unit id="_msg1417">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve" state="needs-review-translation">Error</target>
         <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1416">
-        <source xml:space="preserve">Error upgrading chainstate database</source>
+      <trans-unit id="_msg1418">
+        <source xml:space="preserve">Error: A fatal internal error occurred, see debug.log for details</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1417">
-        <source xml:space="preserve">Error upgrading evo database</source>
+      <trans-unit id="_msg1419">
+        <source xml:space="preserve">Error: Disk space is low for %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1418">
-        <source xml:space="preserve">Error</source>
-        <target xml:space="preserve" state="needs-review-translation">Error</target>
+      <trans-unit id="_msg1420">
+        <source xml:space="preserve">Error: Disk space is low!</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1419">
-        <source xml:space="preserve">Error: A fatal internal error occurred, see debug.log for details</source>
+      <trans-unit id="_msg1421">
+        <source xml:space="preserve">Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1420">
-        <source xml:space="preserve">Error: Disk space is low for %s</source>
+      <trans-unit id="_msg1422">
+        <source xml:space="preserve">Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1421">
-        <source xml:space="preserve">Error: Disk space is low!</source>
+      <trans-unit id="_msg1423">
+        <source xml:space="preserve">Exceeded max tries.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1422">
-        <source xml:space="preserve">Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
+      <trans-unit id="_msg1424">
+        <source xml:space="preserve">Failed to clear fulfilled requests cache at</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1423">
-        <source xml:space="preserve">Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
+      <trans-unit id="_msg1425">
+        <source xml:space="preserve">Failed to clear governance cache at</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1424">
-        <source xml:space="preserve">Exceeded max tries.</source>
+      <trans-unit id="_msg1426">
+        <source xml:space="preserve">Failed to clear smartnode cache at</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1425">
-        <source xml:space="preserve">Failed to clear fulfilled requests cache at</source>
+      <trans-unit id="_msg1427">
+        <source xml:space="preserve">Failed to commit EvoDB</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1426">
-        <source xml:space="preserve">Failed to clear governance cache at</source>
+      <trans-unit id="_msg1428">
+        <source xml:space="preserve">Failed to create backup %s!</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1427">
-        <source xml:space="preserve">Failed to clear smartnode cache at</source>
+      <trans-unit id="_msg1429">
+        <source xml:space="preserve">Failed to create backup, error: %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1428">
-        <source xml:space="preserve">Failed to commit EvoDB</source>
+      <trans-unit id="_msg1430">
+        <source xml:space="preserve">Failed to delete backup, error: %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1429">
-        <source xml:space="preserve">Failed to create backup %s!</source>
+      <trans-unit id="_msg1431">
+        <source xml:space="preserve">Failed to find mixing queue to join</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1430">
-        <source xml:space="preserve">Failed to create backup, error: %s</source>
+      <trans-unit id="_msg1432">
+        <source xml:space="preserve">Failed to get root metadata</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1431">
-        <source xml:space="preserve">Failed to delete backup, error: %s</source>
+      <trans-unit id="_msg1433">
+        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1432">
-        <source xml:space="preserve">Failed to find mixing queue to join</source>
+      <trans-unit id="_msg1434">
+        <source xml:space="preserve">Failed to load Assets Database</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1433">
-        <source xml:space="preserve">Failed to get root metadata</source>
+      <trans-unit id="_msg1435">
+        <source xml:space="preserve">Failed to load POW cache from</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1434">
-        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
+      <trans-unit id="_msg1436">
+        <source xml:space="preserve">Failed to load fulfilled requests cache from</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1435">
-        <source xml:space="preserve">Failed to load Assets Database</source>
+      <trans-unit id="_msg1437">
+        <source xml:space="preserve">Failed to load governance cache from</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1436">
-        <source xml:space="preserve">Failed to load POW cache from</source>
+      <trans-unit id="_msg1438">
+        <source xml:space="preserve">Failed to load smartnode cache from</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1437">
-        <source xml:space="preserve">Failed to load fulfilled requests cache from</source>
+      <trans-unit id="_msg1439">
+        <source xml:space="preserve">Failed to load sporks cache from</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1438">
-        <source xml:space="preserve">Failed to load governance cache from</source>
+      <trans-unit id="_msg1440">
+        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1439">
-        <source xml:space="preserve">Failed to load smartnode cache from</source>
+      <trans-unit id="_msg1441">
+        <source xml:space="preserve">Failed to sign special tx</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1440">
-        <source xml:space="preserve">Failed to load sporks cache from</source>
+      <trans-unit id="_msg1442">
+        <source xml:space="preserve">Failed to start a new mixing queue</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1441">
-        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
+      <trans-unit id="_msg1443">
+        <source xml:space="preserve">Found enough users, signing ( waiting %s )</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1442">
-        <source xml:space="preserve">Failed to sign special tx</source>
+      <trans-unit id="_msg1444">
+        <source xml:space="preserve">Found enough users, signing ...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1443">
-        <source xml:space="preserve">Failed to start a new mixing queue</source>
+      <trans-unit id="_msg1445">
+        <source xml:space="preserve">Importing...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1444">
-        <source xml:space="preserve">Found enough users, signing ( waiting %s )</source>
+      <trans-unit id="_msg1446">
+        <source xml:space="preserve">Incompatible mode.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1445">
-        <source xml:space="preserve">Found enough users, signing ...</source>
+      <trans-unit id="_msg1447">
+        <source xml:space="preserve">Incompatible version.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1446">
-        <source xml:space="preserve">Importing...</source>
+      <trans-unit id="_msg1448">
+        <source xml:space="preserve">Incorrect -rescan mode, falling back to default value</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1447">
-        <source xml:space="preserve">Incompatible mode.</source>
+      <trans-unit id="_msg1449">
+        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1448">
-        <source xml:space="preserve">Incompatible version.</source>
-        <target xml:space="preserve"></target>
+      <trans-unit id="_msg1450">
+        <source xml:space="preserve">Information</source>
+        <target xml:space="preserve" state="needs-review-translation">Information</target>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1449">
-        <source xml:space="preserve">Incorrect -rescan mode, falling back to default value</source>
+      <trans-unit id="_msg1451">
+        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1450">
-        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
+      <trans-unit id="_msg1452">
+        <source xml:space="preserve">Input is not valid.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1451">
-        <source xml:space="preserve">Information</source>
-        <target xml:space="preserve" state="needs-review-translation">Information</target>
+      <trans-unit id="_msg1453">
+        <source xml:space="preserve">Inputs vs outputs size mismatch.</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1452">
-        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
+      <trans-unit id="_msg1454">
+        <source xml:space="preserve">Insufficient Unique asset funds</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1453">
-        <source xml:space="preserve">Input is not valid.</source>
+      <trans-unit id="_msg1455">
+        <source xml:space="preserve">Insufficient asset funds</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1454">
-        <source xml:space="preserve">Inputs vs outputs size mismatch.</source>
+      <trans-unit id="_msg1456">
+        <source xml:space="preserve">Insufficient funds.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1455">
-        <source xml:space="preserve">Insufficient Unique asset funds</source>
+      <trans-unit id="_msg1457">
+        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1456">
-        <source xml:space="preserve">Insufficient asset funds</source>
+      <trans-unit id="_msg1458">
+        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1457">
-        <source xml:space="preserve">Insufficient funds.</source>
+      <trans-unit id="_msg1459">
+        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1458">
-        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
+      <trans-unit id="_msg1460">
+        <source xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1459">
-        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
+      <trans-unit id="_msg1461">
+        <source xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1460">
-        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+      <trans-unit id="_msg1462">
+        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1461">
-        <source xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</source>
+      <trans-unit id="_msg1463">
+        <source xml:space="preserve">Invalid minimum number of spork signers specified with -minsporkkeys</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1462">
-        <source xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
+      <trans-unit id="_msg1464">
+        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1463">
-        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+      <trans-unit id="_msg1465">
+        <source xml:space="preserve">Invalid script detected.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1464">
-        <source xml:space="preserve">Invalid minimum number of spork signers specified with -minsporkkeys</source>
+      <trans-unit id="_msg1466">
+        <source xml:space="preserve">Invalid smartnodeblsprivkey. Please see documentation.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1465">
-        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
+      <trans-unit id="_msg1467">
+        <source xml:space="preserve">Invalid spork address specified with -sporkaddr</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1466">
-        <source xml:space="preserve">Invalid script detected.</source>
+      <trans-unit id="_msg1468">
+        <source xml:space="preserve">Keypool ran out, please call keypoolrefill first</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1467">
-        <source xml:space="preserve">Invalid smartnodeblsprivkey. Please see documentation.</source>
+      <trans-unit id="_msg1469">
+        <source xml:space="preserve">Last queue was created too recently.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1468">
-        <source xml:space="preserve">Invalid spork address specified with -sporkaddr</source>
+      <trans-unit id="_msg1470">
+        <source xml:space="preserve">Last successful action was too recent.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1469">
-        <source xml:space="preserve">Keypool ran out, please call keypoolrefill first</source>
+      <trans-unit id="_msg1471">
+        <source xml:space="preserve">Loading P2P addresses...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1470">
-        <source xml:space="preserve">Last queue was created too recently.</source>
+      <trans-unit id="_msg1472">
+        <source xml:space="preserve">Loading POW cache...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1471">
-        <source xml:space="preserve">Last successful action was too recent.</source>
+      <trans-unit id="_msg1473">
+        <source xml:space="preserve">Loading banlist...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1472">
-        <source xml:space="preserve">Loading P2P addresses...</source>
+      <trans-unit id="_msg1474">
+        <source xml:space="preserve">Loading block index...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1473">
-        <source xml:space="preserve">Loading POW cache...</source>
+      <trans-unit id="_msg1475">
+        <source xml:space="preserve">Loading fulfilled requests cache...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1474">
-        <source xml:space="preserve">Loading banlist...</source>
+      <trans-unit id="_msg1476">
+        <source xml:space="preserve">Loading governance cache...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1475">
-        <source xml:space="preserve">Loading block index...</source>
+      <trans-unit id="_msg1477">
+        <source xml:space="preserve">Loading smartnode cache...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1476">
-        <source xml:space="preserve">Loading fulfilled requests cache...</source>
+      <trans-unit id="_msg1478">
+        <source xml:space="preserve">Loading sporks cache...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1477">
-        <source xml:space="preserve">Loading governance cache...</source>
+      <trans-unit id="_msg1479">
+        <source xml:space="preserve">Loading wallet... (%3.2f %%)</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1478">
-        <source xml:space="preserve">Loading smartnode cache...</source>
+      <trans-unit id="_msg1480">
+        <source xml:space="preserve">Loading wallet...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1479">
-        <source xml:space="preserve">Loading sporks cache...</source>
+      <trans-unit id="_msg1481">
+        <source xml:space="preserve">Lock is already in place.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1480">
-        <source xml:space="preserve">Loading wallet... (%3.2f %%)</source>
+      <trans-unit id="_msg1482">
+        <source xml:space="preserve">Missing input transaction information.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1481">
-        <source xml:space="preserve">Loading wallet...</source>
+      <trans-unit id="_msg1483">
+        <source xml:space="preserve">Mixing in progress...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1482">
-        <source xml:space="preserve">Lock is already in place.</source>
+      <trans-unit id="_msg1484">
+        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1483">
-        <source xml:space="preserve">Missing input transaction information.</source>
+      <trans-unit id="_msg1485">
+        <source xml:space="preserve">No Smartnodes detected.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1484">
-        <source xml:space="preserve">Mixing in progress...</source>
+      <trans-unit id="_msg1486">
+        <source xml:space="preserve">No compatible Smartnode found.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1485">
-        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
+      <trans-unit id="_msg1487">
+        <source xml:space="preserve">No errors detected.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1486">
-        <source xml:space="preserve">No Smartnodes detected.</source>
+      <trans-unit id="_msg1488">
+        <source xml:space="preserve">No matching denominations found for mixing.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1487">
-        <source xml:space="preserve">No compatible Smartnode found.</source>
+      <trans-unit id="_msg1489">
+        <source xml:space="preserve">Not compatible with existing transactions.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1488">
-        <source xml:space="preserve">No errors detected.</source>
+      <trans-unit id="_msg1490">
+        <source xml:space="preserve">Not enough file descriptors available.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1489">
-        <source xml:space="preserve">No matching denominations found for mixing.</source>
+      <trans-unit id="_msg1491">
+        <source xml:space="preserve">Not enough funds to mix.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1490">
-        <source xml:space="preserve">Not compatible with existing transactions.</source>
+      <trans-unit id="_msg1492">
+        <source xml:space="preserve">Not in the Smartnode list.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1491">
-        <source xml:space="preserve">Not enough file descriptors available.</source>
+      <trans-unit id="_msg1493">
+        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1492">
-        <source xml:space="preserve">Not enough funds to mix.</source>
+      <trans-unit id="_msg1494">
+        <source xml:space="preserve">Prune mode is incompatible with -disablegovernance=false.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1493">
-        <source xml:space="preserve">Not in the Smartnode list.</source>
+      <trans-unit id="_msg1495">
+        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1494">
-        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
+      <trans-unit id="_msg1496">
+        <source xml:space="preserve">Pruning blockstore...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1495">
-        <source xml:space="preserve">Prune mode is incompatible with -disablegovernance=false.</source>
+      <trans-unit id="_msg1497">
+        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1496">
-        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
+      <trans-unit id="_msg1498">
+        <source xml:space="preserve">Replaying blocks...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1497">
-        <source xml:space="preserve">Pruning blockstore...</source>
+      <trans-unit id="_msg1499">
+        <source xml:space="preserve">Rescanning...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1498">
-        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
+      <trans-unit id="_msg1500">
+        <source xml:space="preserve">Root asset key not in wallet</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1499">
-        <source xml:space="preserve">Replaying blocks...</source>
+      <trans-unit id="_msg1501">
+        <source xml:space="preserve">Section [%s] is not recognized.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1500">
-        <source xml:space="preserve">Rescanning...</source>
+      <trans-unit id="_msg1502">
+        <source xml:space="preserve">Session not complete!</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1501">
-        <source xml:space="preserve">Root asset key not in wallet</source>
+      <trans-unit id="_msg1503">
+        <source xml:space="preserve">Session timed out.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1502">
-        <source xml:space="preserve">Section [%s] is not recognized.</source>
+      <trans-unit id="_msg1504">
+        <source xml:space="preserve">Signing transaction failed</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1503">
-        <source xml:space="preserve">Session not complete!</source>
+      <trans-unit id="_msg1505">
+        <source xml:space="preserve">Smartnode queue is full.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1504">
-        <source xml:space="preserve">Session timed out.</source>
+      <trans-unit id="_msg1506">
+        <source xml:space="preserve">Smartnode:</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1505">
-        <source xml:space="preserve">Signing transaction failed</source>
+      <trans-unit id="_msg1507">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1506">
-        <source xml:space="preserve">Smartnode queue is full.</source>
+      <trans-unit id="_msg1508">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1507">
-        <source xml:space="preserve">Smartnode:</source>
+      <trans-unit id="_msg1509">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1508">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
+      <trans-unit id="_msg1510">
+        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1509">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
+      <trans-unit id="_msg1511">
+        <source xml:space="preserve">Starting network threads...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1510">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
+      <trans-unit id="_msg1512">
+        <source xml:space="preserve">Submitted to smartnode, waiting in queue %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1511">
-        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
+      <trans-unit id="_msg1513">
+        <source xml:space="preserve">Synchronization finished</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1512">
-        <source xml:space="preserve">Starting network threads...</source>
+      <trans-unit id="_msg1514">
+        <source xml:space="preserve">Synchronizing blockchain...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1513">
-        <source xml:space="preserve">Submitted to smartnode, waiting in queue %s</source>
+      <trans-unit id="_msg1515">
+        <source xml:space="preserve">Synchronizing governance objects...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1514">
-        <source xml:space="preserve">Synchronization finished</source>
+      <trans-unit id="_msg1516">
+        <source xml:space="preserve">The source code is available from %s.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1515">
-        <source xml:space="preserve">Synchronizing blockchain...</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1516">
-        <source xml:space="preserve">Synchronizing governance objects...</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg1517">
-        <source xml:space="preserve">The source code is available from %s.</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1518">
         <source xml:space="preserve">The specified config file %s does not exist
 </source>
         <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1518">
+        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1519">
-        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
+        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1520">
+        <source xml:space="preserve">This is expected because you are running a pruned node.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1521">
+        <source xml:space="preserve">This is experimental software.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1520">
-        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
+      <trans-unit id="_msg1522">
+        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1521">
-        <source xml:space="preserve">This is expected because you are running a pruned node.</source>
+      <trans-unit id="_msg1523">
+        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1522">
-        <source xml:space="preserve">This is experimental software.</source>
+      <trans-unit id="_msg1524">
+        <source xml:space="preserve">Transaction amount too small</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1523">
-        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
+      <trans-unit id="_msg1525">
+        <source xml:space="preserve">Transaction amounts must not be negative</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1524">
-        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
+      <trans-unit id="_msg1526">
+        <source xml:space="preserve">Transaction created successfully.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1525">
-        <source xml:space="preserve">Transaction amount too small</source>
+      <trans-unit id="_msg1527">
+        <source xml:space="preserve">Transaction fees are too high.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1526">
-        <source xml:space="preserve">Transaction amounts must not be negative</source>
+      <trans-unit id="_msg1528">
+        <source xml:space="preserve">Transaction has too long of a mempool chain</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1527">
-        <source xml:space="preserve">Transaction created successfully.</source>
+      <trans-unit id="_msg1529">
+        <source xml:space="preserve">Transaction must have at least one recipient</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1528">
-        <source xml:space="preserve">Transaction fees are too high.</source>
+      <trans-unit id="_msg1530">
+        <source xml:space="preserve">Transaction not valid.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1529">
-        <source xml:space="preserve">Transaction has too long of a mempool chain</source>
+      <trans-unit id="_msg1531">
+        <source xml:space="preserve">Transaction too large for fee policy</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1530">
-        <source xml:space="preserve">Transaction must have at least one recipient</source>
+      <trans-unit id="_msg1532">
+        <source xml:space="preserve">Transaction too large</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1531">
-        <source xml:space="preserve">Transaction not valid.</source>
+      <trans-unit id="_msg1533">
+        <source xml:space="preserve">Trying to connect...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1532">
-        <source xml:space="preserve">Transaction too large for fee policy</source>
+      <trans-unit id="_msg1534">
+        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1533">
-        <source xml:space="preserve">Transaction too large</source>
+      <trans-unit id="_msg1535">
+        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1534">
-        <source xml:space="preserve">Trying to connect...</source>
+      <trans-unit id="_msg1536">
+        <source xml:space="preserve">Unable to create PID file &apos;%s&apos;: %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1535">
-        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
+      <trans-unit id="_msg1537">
+        <source xml:space="preserve">Unable to generate initial keys</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1536">
-        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
+      <trans-unit id="_msg1538">
+        <source xml:space="preserve">Unable to locate enough mixed funds for this transaction.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1537">
-        <source xml:space="preserve">Unable to create PID file &apos;%s&apos;: %s</source>
+      <trans-unit id="_msg1539">
+        <source xml:space="preserve">Unable to locate enough non-denominated funds for this transaction.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1538">
-        <source xml:space="preserve">Unable to generate initial keys</source>
+      <trans-unit id="_msg1540">
+        <source xml:space="preserve">Unable to sign spork message, wrong key?</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1539">
-        <source xml:space="preserve">Unable to locate enough mixed funds for this transaction.</source>
+      <trans-unit id="_msg1541">
+        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1540">
-        <source xml:space="preserve">Unable to locate enough non-denominated funds for this transaction.</source>
+      <trans-unit id="_msg1542">
+        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1541">
-        <source xml:space="preserve">Unable to sign spork message, wrong key?</source>
+      <trans-unit id="_msg1543">
+        <source xml:space="preserve">Unknown response.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1542">
-        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+      <trans-unit id="_msg1544">
+        <source xml:space="preserve">Unknown state: id = %u</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1543">
-        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
+      <trans-unit id="_msg1545">
+        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1544">
-        <source xml:space="preserve">Unknown response.</source>
+      <trans-unit id="_msg1546">
+        <source xml:space="preserve">Upgrading UTXO database</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1545">
-        <source xml:space="preserve">Unknown state: id = %u</source>
+      <trans-unit id="_msg1547">
+        <source xml:space="preserve">Upgrading txindex database</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1546">
-        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
+      <trans-unit id="_msg1548">
+        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1547">
-        <source xml:space="preserve">Upgrading UTXO database</source>
+      <trans-unit id="_msg1549">
+        <source xml:space="preserve">Verifying blocks...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1548">
-        <source xml:space="preserve">Upgrading txindex database</source>
+      <trans-unit id="_msg1550">
+        <source xml:space="preserve">Verifying wallet(s)...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1549">
-        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+      <trans-unit id="_msg1551">
+        <source xml:space="preserve">Very low number of keys left: %d</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1550">
-        <source xml:space="preserve">Verifying blocks...</source>
+      <trans-unit id="_msg1552">
+        <source xml:space="preserve">Wallet is locked.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1551">
-        <source xml:space="preserve">Verifying wallet(s)...</source>
+      <trans-unit id="_msg1553">
+        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1552">
-        <source xml:space="preserve">Very low number of keys left: %d</source>
-        <target xml:space="preserve"></target>
+      <trans-unit id="_msg1554">
+        <source xml:space="preserve">Warning</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning</target>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1553">
-        <source xml:space="preserve">Wallet is locked.</source>
+      <trans-unit id="_msg1555">
+        <source xml:space="preserve">Warning: can&apos;t use %s and %s together, will prefer %s</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1554">
-        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
+      <trans-unit id="_msg1556">
+        <source xml:space="preserve">Warning: incorrect parameter %s, path must exist! Using default path.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1555">
-        <source xml:space="preserve">Warning</source>
-        <target xml:space="preserve" state="needs-review-translation">Warning</target>
+      <trans-unit id="_msg1557">
+        <source xml:space="preserve">Warning: unknown new rules activated: Expected: 0x%08x, Actual: 0x%08x</source>
+        <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1556">
-        <source xml:space="preserve">Warning: can&apos;t use %s and %s together, will prefer %s</source>
+      <trans-unit id="_msg1558">
+        <source xml:space="preserve">Wasn&apos;t able to create wallet backup folder %s!</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1557">
-        <source xml:space="preserve">Warning: incorrect parameter %s, path must exist! Using default path.</source>
+      <trans-unit id="_msg1559">
+        <source xml:space="preserve">Will retry...</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1558">
-        <source xml:space="preserve">Warning: unknown new rules activated (versionbit %i)</source>
+      <trans-unit id="_msg1560">
+        <source xml:space="preserve">You are starting with governance validation disabled.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1559">
-        <source xml:space="preserve">Wasn&apos;t able to create wallet backup folder %s!</source>
+      <trans-unit id="_msg1561">
+        <source xml:space="preserve">You can not disable governance validation on a smartnode.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1560">
-        <source xml:space="preserve">Will retry...</source>
+      <trans-unit id="_msg1562">
+        <source xml:space="preserve">You can not start a smartnode with wallet enabled.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1561">
-        <source xml:space="preserve">You are starting with governance validation disabled.</source>
+      <trans-unit id="_msg1563">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -addressindex</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1562">
-        <source xml:space="preserve">You can not disable governance validation on a smartnode.</source>
+      <trans-unit id="_msg1564">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -assetindex</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1563">
-        <source xml:space="preserve">You can not start a smartnode with wallet enabled.</source>
+      <trans-unit id="_msg1565">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -futureindex</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1564">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -addressindex</source>
+      <trans-unit id="_msg1566">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -spentindex</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1565">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -assetindex</source>
+      <trans-unit id="_msg1567">
+        <source xml:space="preserve">Your entries added successfully.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1566">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -futureindex</source>
+      <trans-unit id="_msg1568">
+        <source xml:space="preserve">no mixing available.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1567">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to change -spentindex</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1568">
-        <source xml:space="preserve">Your entries added successfully.</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg1569">
-        <source xml:space="preserve">no mixing available.</source>
-        <target xml:space="preserve"></target>
-        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1570">
         <source xml:space="preserve">see debug.log for details.</source>
         <target xml:space="preserve" state="needs-review-translation">see debug.log for details.</target>
-        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
     </group>
   </body></file>

--- a/src/qt/raptoreumstrings.cpp
+++ b/src/qt/raptoreumstrings.cpp
@@ -118,9 +118,6 @@ QT_TRANSLATE_NOOP("raptoreum-core", ""
 "Warning: The Network does not appear to fully agree! Some miners addear to "
 "experiencing issues."),
 QT_TRANSLATE_NOOP("raptoreum-core", ""
-"Warning: Unknown block versions being mined! It's possible unknown rules are "
-"in effect"),
-QT_TRANSLATE_NOOP("raptoreum-core", ""
 "Warning: We do not appear to fully agree with our peers! You may need to "
 "upgrade, or other nodes may need to upgrade."),
 QT_TRANSLATE_NOOP("raptoreum-core", ""
@@ -314,7 +311,7 @@ QT_TRANSLATE_NOOP("raptoreum-core", "Wallet needed to be rewritten: restart %s t
 QT_TRANSLATE_NOOP("raptoreum-core", "Warning"),
 QT_TRANSLATE_NOOP("raptoreum-core", "Warning: can't use %s and %s together, will prefer %s"),
 QT_TRANSLATE_NOOP("raptoreum-core", "Warning: incorrect parameter %s, path must exist! Using default path."),
-QT_TRANSLATE_NOOP("raptoreum-core", "Warning: unknown new rules activated (versionbit %i)"),
+QT_TRANSLATE_NOOP("raptoreum-core", "Warning: unknown new rules activated: Expected: 0x%08x, Actual: 0x%08x"),
 QT_TRANSLATE_NOOP("raptoreum-core", "Wasn't able to create wallet backup folder %s!"),
 QT_TRANSLATE_NOOP("raptoreum-core", "Will retry..."),
 QT_TRANSLATE_NOOP("raptoreum-core", "You are starting with governance validation disabled."),

--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -5,7 +5,7 @@ file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 ---------------------------------------------------------------------
 
-This file contains color changes for the dash theme "Dark".
+This file contains color changes for the raptoreum theme "Dark".
 
 NOTE: This file gets appended to the general.css while its
 getting loaded in GUIUtil::loadStyleSheet(). Thus changes made in

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1004,11 +1004,11 @@ AboutDialog
 
 QDialog#AboutDialog QLabel#label,
 QDialog#AboutDialog QLabel#copyrightLabel,
-QDialog#AboutDialog QLabel#label_2 { /* About Dash Contents */
+QDialog#AboutDialog QLabel#label_2 { /* About Raptoreum Contents */
     margin-left: 10px;
 }
 
-QDialog#AboutDialog QLabel#label_2 { /* Margin for About Dash text */
+QDialog#AboutDialog QLabel#label_2 { /* Margin for About Raptoreum text */
     margin-right: 10px;
 }
 

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -5,7 +5,7 @@ file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 ---------------------------------------------------------------------
 
-This file contains color changes for the dash theme "Light".
+This file contains color changes for the raptoreum theme "Light".
 
 NOTE: This file gets appended to the general.css while its
 getting loaded in GUIUtil::loadStyleSheet(). Thus changes made in

--- a/src/qt/res/css/traditional.css
+++ b/src/qt/res/css/traditional.css
@@ -5,7 +5,7 @@ file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 ---------------------------------------------------------------------
 
-This file contains all changes for the dash theme "Traditional".
+This file contains all changes for the raptoreum theme "Traditional".
 
 NOTE: This file gets not appended to the general.css. The Traditional
 theme is a standalone theme which just fixes some bugs in the OS default

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -420,7 +420,7 @@ static UniValue gobject_submit(const JSONRPCRequest &request) {
 
 void gobject_vote_conf_help(const JSONRPCRequest &request) {
     RPCHelpMan{"gobject vote-conf",
-               "Vote on a governance object by masternode configured in dash.conf\n",
+               "Vote on a governance object by smartnode configured in raptoreum.conf\n",
                {
                        {"governance-hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
                         "hash of the governance object"},

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -519,8 +519,8 @@ static UniValue getblocktemplate(const JSONRPCRequest &request) {
                                {RPCResult::Type::STR, "bits", "compressed target of next block"},
                                {RPCResult::Type::STR, "previousbits", "compressed target of current highest block"},
                                {RPCResult::Type::NUM, "height", "The height of the next block"},
-                               {RPCResult::Type::ARR, "masternode",
-                                "required masternode payments that must be included in the next block",
+                               {RPCResult::Type::ARR, "smartnode",
+                                "required smartnode payments that must be included in the next block",
                                 {
                                         {RPCResult::Type::OBJ, "", "",
                                          {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -367,7 +367,7 @@ UniValue getaddednodeinfo(const JSONRPCRequest &request) {
                                                  {RPCResult::Type::OBJ, "", "",
                                                   {
                                                           {RPCResult::Type::STR, "address",
-                                                           "The dash server IP and port we're connected to"},
+                                                           "The Raptoreum server IP and port we're connected to"},
                                                           {RPCResult::Type::STR, "connected",
                                                            "connection, inbound or outbound"},
                                                   }},

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -157,12 +157,12 @@ static RPCArg GetRpcArg(const std::string &strParamName) {
             {"operatorPubKey_register",
                     {"operatorPubKey_register", RPCArg::Type::STR,                RPCArg::Optional::NO,
                             "The operator BLS public key. The BLS private key does not have to be known.\n"
-                            "It has to match the BLS private key which is later used when operating the masternode."}
+                            "It has to match the BLS private key which is later used when operating the smartnode."}
             },
             {"operatorPubKey_update",
                     {"operatorPubKey_update",   RPCArg::Type::STR,                RPCArg::Optional::NO,
                             "The operator BLS public key. The BLS private key does not have to be known.\n"
-                            "It has to match the BLS private key which is later used when operating the masternode.\n"
+                            "It has to match the BLS private key which is later used when operating the smartnode.\n"
                             "If set to an empty string, the currently active operator BLS public key is reused."}
             },
             {"operatorReward",
@@ -178,11 +178,11 @@ static RPCArg GetRpcArg(const std::string &strParamName) {
             },
             {"payoutAddress_register",
                     {"payoutAddress_register",  RPCArg::Type::STR,                RPCArg::Optional::NO,
-                            "The raptoreum address to use for masternode reward payments."}
+                            "The raptoreum address to use for smartnode reward payments."}
             },
             {"payoutAddress_update",
                     {"payoutAddress_update",    RPCArg::Type::STR,                RPCArg::Optional::NO,
-                            "The raptoreum address to use for masternode reward payments.\n"
+                            "The raptoreum address to use for smartnode reward payments.\n"
                             "If set to an empty string, the currently active payout address is reused."}
             },
             {"proTxHash",
@@ -191,7 +191,7 @@ static RPCArg GetRpcArg(const std::string &strParamName) {
             },
             {"reason",
                     {"reason",                  RPCArg::Type::NUM, /* default */  "",
-                            "The reason for masternode service revocation."}
+                            "The reason for smartnode service revocation."}
             },
             {"submit",
                     {"submit",                  RPCArg::Type::BOOL, /* default */ "true",
@@ -524,7 +524,7 @@ void protx_register_help(const JSONRPCRequest& request)
         + HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("collateralHash"),
-            GetRpcArg("collateralAddress"),
+            GetRpcArg("collateralIndex"),
             GetRpcArg("ipAndPort"),
             GetRpcArg("ownerAddress"),
             GetRpcArg("operatorPubKey_register"),
@@ -554,7 +554,7 @@ void protx_register_prepare_help(const JSONRPCRequest& request)
         "The prepared transaction will also contain inputs and outputs to cover fees.\n",
         {
             GetRpcArg("collateralHash"),
-            GetRpcArg("collateralAddress"),
+            GetRpcArg("collateralIndex"),
             GetRpcArg("ipAndPort"),
             GetRpcArg("ownerAddress"),
             GetRpcArg("operatorPubKey_register"),
@@ -1084,7 +1084,7 @@ void protx_quick_setup_help(const JSONRPCRequest& request)
         + HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("collateralHash"),
-            GetRpcArg("collateralAddress"),
+            GetRpcArg("collateralIndex"),
             GetRpcArg("ipAndPort"),
             GetRpcArg("feeSourceAddress"),
         },

--- a/src/smartnode/smartnode-meta.h
+++ b/src/smartnode/smartnode-meta.h
@@ -175,4 +175,4 @@ public:
 
 extern CSmartnodeMetaMan mmetaman;
 
-#endif // BITCOIN_SMARTNODE_MASTERNODE_META_H
+#endif // BITCOIN_SMARTNODE_SMARTNODE_META_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -774,7 +774,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams &chainparams, CTxMemPool
         // check special TXs after all the other checks. If we'd do this before the other checks, we might end up
         // DoS scoring a node for non-critical errors, e.g. duplicate keys because a TX is received that was already
         // mined
-        // NOTE: we use UTXO here and do NOT allow mempool txes as masternode collaterals
+        // NOTE: we use UTXO here and do NOT allow mempool txes as smartnode collaterals
         if (!CheckSpecialTx(tx, ::ChainActive().Tip(), state, ::ChainstateActive().CoinsTip(), &assetsCache, true))
             return false;
         if (pool.existsProviderTxConflict(tx)) {

--- a/src/version.h
+++ b/src/version.h
@@ -21,14 +21,14 @@ static const int OLD_MIN_PEER_PROTO_VERSION = 70213;
 
 static const int MIN_PEER_PROTO_VERSION = 70219;
 
-//! minimum proto version of masternode to accept in DKGs
+//! minimum proto version of smartnode to accept in DKGs
 static const int OLD_MIN_SMARTNODE_PROTO_VERSION = 70218;
 static const int MIN_SMARTNODE_PROTO_VERSION = 70219;
 
 //! minimum proto version for governance sync and messages
 static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70213;
 
-//! minimum proto version to broadcast governance messages from banned masternodes
+//! minimum proto version to broadcast governance messages from banned smartnodes
 static const int GOVERNANCE_POSE_BANNED_VOTES_VERSION = 70215;
 
 //! nTime field added to CAddress, starting with this version;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -144,11 +144,11 @@ void WalletInit::AddWalletOptions() const {
                  strprintf("Enable multiple CoinJoin mixing sessions per block, experimental (0-1, default: %u)",
                            DEFAULT_COINJOIN_MULTISESSION), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET_COINJOIN);
     gArgs.AddArg("-coinjoinrounds=<n>",
-                 strprintf("Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)",
+                 strprintf("Use N separate smartnodes for each denominated input to mix funds (%u-%u, default: %u)",
                            MIN_COINJOIN_ROUNDS, MAX_COINJOIN_ROUNDS, DEFAULT_COINJOIN_ROUNDS), ArgsManager::ALLOW_ANY,
                  OptionsCategory::WALLET_COINJOIN);
     gArgs.AddArg("-coinjoinsessions=<n>",
-                 strprintf("Use N separate masternodes in parallel to mix funds (%u-%u, default: %u)",
+                 strprintf("Use N separate smartnodes in parallel to mix funds (%u-%u, default: %u)",
                            MIN_COINJOIN_SESSIONS, MAX_COINJOIN_SESSIONS, DEFAULT_COINJOIN_SESSIONS),
                  ArgsManager::ALLOW_ANY, OptionsCategory::WALLET_COINJOIN);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3157,7 +3157,7 @@ static UniValue listunspent(const JSONRPCRequest &request) {
                                  "Minimum sum value of all UTXOs in " + CURRENCY_UNIT + ""},
                                 {"coinType", RPCArg::Type::NUM, /* default */ "0", "Filter coinTypes as follows:\n"
                                                                                    "                         0=ALL_COINS, 1=ONLY_FULLY_MIXED, 2=ONLY_READY_TO_MIX, 3=ONLY_NONDENOMINATED,\n"
-                                                                                   "                         4=ONLY_MASTERNODE_COLLATERAL, 5=ONLY_COINJOIN_COLLATERAL"},
+                                                                                   "                         4=ONLY_SMARTNODE_COLLATERAL, 5=ONLY_COINJOIN_COLLATERAL"},
                         },
                         "query_options"},
                },


### PR DESCRIPTION
update translation files
updated transifex links on doc/translation_process.md
fixed help documentation for protx  quick_setup, register and register_prepare
fixed left over masternode references

note for reviewers: change on files raptoreum_en.ts, raptoreum_en.xlf and raptoreumstrings.cpp are auto generated by make translate