### PR TITLE
Send to address updates

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -361,14 +361,11 @@ UniValue sendtoaddress(const JSONRPCRequest &request) {
                        RPCResult::Type::STR_HEX, "txid", "The transaction id."
                },
                RPCExamples{
-                       HelpExampleCli("sendtoaddress", "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1")
-                       + HelpExampleCli("sendtoaddress",
-                                        "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1 '{\"future_maturity\":100, \"future_locktime\":10000}'")
-                       + HelpExampleCli("sendtoaddress",
-                                        "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1 [] \"donation\" \"seans outpost\"")
-                       + HelpExampleCli("sendtoaddress", "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1 \"\" \"\" true")
-                       + HelpExampleRpc("sendtoaddress",
-                                        "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\", [], 0.1, \"donation\", \"seans outpost\"")
+                       HelpExampleCli("sendtoaddress",   "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1")
+                       + HelpExampleCli("sendtoaddress", "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1 '{\"future_maturity\":100, \"future_locktime\":10000}'")
+                       + HelpExampleCli("sendtoaddress", "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1 [] \"donation\" \"seans outpost\"")
+                       + HelpExampleCli("sendtoaddress", "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 0.1 [] \"\" \"\" true")
+                       + HelpExampleRpc("sendtoaddress", "\"RwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\", 0.1, [], \"donation\", \"seans outpost\"")
                },
     }.Check(request);
 
@@ -405,7 +402,7 @@ UniValue sendtoaddress(const JSONRPCRequest &request) {
             hasFuture = true;
             fpp.maturity = request.params[nextParamsIndex]["future_maturity"].get_int();
             fpp.locktime = request.params[nextParamsIndex]["future_locktime"].get_int();
-            fpp.futureRecScript = GetScriptForDestination(dest);           
+            fpp.futureRecScript = GetScriptForDestination(dest);
         }
     }
     nextParamsIndex++;
@@ -415,7 +412,7 @@ UniValue sendtoaddress(const JSONRPCRequest &request) {
     nextParamsIndex++;
     if (!request.params[nextParamsIndex].isNull() && !request.params[nextParamsIndex].get_str().empty()){
         mapValue["to"] = request.params[nextParamsIndex].get_str();
-    }  
+    }
     nextParamsIndex++;
     bool fSubtractFeeFromAmount = false;
     if (!request.params[nextParamsIndex].isNull()) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2121,6 +2121,7 @@ bool CWalletTx::isFutureSpendable(unsigned int outputIndex) const {
 
         CFutureTx futureTx;
         if (GetTxPayload(tx->vExtraPayload, futureTx)) {
+            LOCK(cs_main);
             int maturity = GetDepthInMainChain();
             int64_t adjustCurrentTime = GetAdjustedTime();
             uint32_t confirmedTime = GetConfirmationTime();
@@ -2548,7 +2549,7 @@ bool CWalletTx::SubmitMemoryPoolAndRelay(std::string &err_string, bool relay) {
     if (GetDepthInMainChain() != 0) return false;
     // Don't try to submit transactions locked via InstantSend.
     if (IsLockedByInstantSend()) return false;
-    
+
     // Submit transaction to mempool for relay
     pwallet->WalletLogPrintf("Submitting wtx %s to mempool for relay\n", GetHash().ToString());
     // We must set fInMempool here - while it will be re-set to true by the
@@ -3380,7 +3381,7 @@ std::map <std::string, std::pair<CAmount, CAmount>> CWallet::getAssetsBalanceAll
             CAssetTransfer transferTemp;
             if (!GetTransferAsset(coin.txout.scriptPubKey, transferTemp))
                 continue;
-            
+
             if (!output.fSpendable || (output.isFuture && !output.isFutureSpendable) || (output.nDepth <
                 (output.tx->IsFromMe(ISMINE_ALL) ? 0 : 1)))
                 pending += transferTemp.nAmount;
@@ -4480,7 +4481,7 @@ bool CWallet::CreateTransaction(const std::vector <CRecipient> &vecSend, CTransa
                             return false;
                         }
                         vecCoins.insert(vecCoins.end(), setAssetsTmp.begin(), setAssetsTmp.end());
-                        
+
                         std::map<std::string, std::vector<std::pair<uint64_t, uint64_t>>> mapUniqueIds;
                         mapUniqueIds.clear();
 
@@ -4491,7 +4492,7 @@ bool CWallet::CreateTransaction(const std::vector <CRecipient> &vecSend, CTransa
                                 if(assetTransfer.isUnique){
                                     uint64_t rangeEnd = assetTransfer.uniqueId + assetTransfer.nAmount / COIN;
                                     if (!mapUniqueIds.count(assetTransfer.assetId)){
-                                        std::vector<std::pair<uint64_t, uint64_t>> tmp; 
+                                        std::vector<std::pair<uint64_t, uint64_t>> tmp;
                                         tmp.push_back(std::make_pair(assetTransfer.uniqueId, rangeEnd));
                                         mapUniqueIds.insert(std::make_pair(assetTransfer.assetId, tmp));
                                     } else {
@@ -4547,7 +4548,7 @@ bool CWallet::CreateTransaction(const std::vector <CRecipient> &vecSend, CTransa
                                     }
                                     if (change) {
                                         entry.first = entry.first + (amount / COIN);
-                                        mapUniqueIds.at(asset.first).push_back(entry);  
+                                        mapUniqueIds.at(asset.first).push_back(entry);
                                     }
                                 }
                             }
@@ -5803,6 +5804,7 @@ bool CWallet::Verify(interfaces::Chain &chain, const WalletLocation &location, s
     if (!tempWallet->AutoBackupWallet(wallet_path, warning_string, error_string) && !error_string.empty()) {
         return false;
     }
+    return true;
 }
 
 std::shared_ptr <CWallet> CWallet::CreateWalletFromFile(interfaces::Chain &chain, const WalletLocation &location,


### PR DESCRIPTION
Fixes #383 

I tested all of the commands and they work properly, but the documentation was incorrect.  I have corrected the documentation.

As for the error when using `[]` - I had no troubles using bash, but with zsh, you need to escape these characters and then the command works.

NB: During testing, I found a case where we had a missing lock.  It has been fixed.