### PR TITLE
Improve create asset validation messaging

### DIFF
--- a/src/qt/createassetsdialog.h
+++ b/src/qt/createassetsdialog.h
@@ -87,7 +87,7 @@ private:
 
 private
     Q_SLOTS:
-    void checkAvailabilityClicked();
+    void onAssetNameChanged(QString name);
 
     void on_createAssetButton_clicked();
 

--- a/src/qt/forms/createassetsdialog.ui
+++ b/src/qt/forms/createassetsdialog.ui
@@ -654,13 +654,6 @@
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="QPushButton" name="availabilityButton">
-              <property name="text">
-               <string>Check Availabilty</string>
-              </property>
-             </widget>
-            </item>
            </layout>
           </item>
           <item row="4" column="2">
@@ -942,6 +935,13 @@
              </layout>
             </item>
            </layout>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="assetNameValidation">
+            <property name="text">
+             <string></string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
This resolves #335 

Removed Check Availability button when creating assets and provided automatic feedback when entering the asset (root or sub) information.

Example of behavior:
![Asset name validation](https://github.com/user-attachments/assets/4283889a-20b0-404f-b8f2-64c3ffd8bc36)
