### PR TITLE
Qt: Updated Unique Root Asset display, fixed disabled controls after unique asset creation.

### DIFF
--- a/src/qt/assetsdialog.cpp
+++ b/src/qt/assetsdialog.cpp
@@ -247,7 +247,7 @@ void AssetsDialog::Asset_clicked() {
 
     ui->nameTextLabel->setText(QString::fromStdString(asset.name));
     if (asset.isRoot) {
-      ui->typeLabel->setText(tr("Root"));
+      ui->typeLabel->setText(asset.isUnique ? tr("Unique/NFT") : tr("Root"));
     } else {
       ui->typeLabel->setText(asset.isUnique ? tr("Unique/NFT") : tr("Sub"));
     }

--- a/src/qt/createassetsdialog.cpp
+++ b/src/qt/createassetsdialog.cpp
@@ -536,6 +536,8 @@ void CreateAssetsDialog::clear() {
     ui->uniqueBox->setChecked(false);
     ui->updatableBox->setChecked(false);
 
+    onUniqueChanged();
+
     CoinControlUpdateLabels();
 
     updateTabsAndLabels();


### PR DESCRIPTION
Unique Root assets are now displayed as Root/NFT.
Also Fixes #401 
