### PR TITLE
Feature: Github version check added to the QT wallet.

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -96,6 +96,7 @@ QT_MOC_CPP = \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_utilitydialog.cpp \
+  qt/moc_updatechecker.cpp \
   qt/moc_walletcontroller.cpp \
   qt/moc_walletframe.cpp \
   qt/moc_walletmodel.cpp \
@@ -178,6 +179,7 @@ BITCOIN_QT_H = \
   qt/transactiontablemodel.h \
   qt/transactionview.h \
   qt/utilitydialog.h \
+  qt/updatechecker.h \
   qt/walletcontroller.h \
   qt/walletframe.h \
   qt/walletmodel.h \
@@ -290,6 +292,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/createassetsdialog.cpp \
   qt/uploaddownload.cpp \
   qt/updateassetsdialog.cpp \
+  qt/updatechecker.cpp \
   qt/assetsdialog.cpp \
   qt/sendassetsentry.cpp \
   qt/signverifymessagedialog.cpp \

--- a/src/qt/raptoreum.cpp
+++ b/src/qt/raptoreum.cpp
@@ -23,6 +23,7 @@
 #include <qt/splashscreen.h>
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
+#include <qt/updatechecker.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/paymentserver.h>
@@ -715,6 +716,11 @@ int GuiMain(int argc, char *argv[]) {
     int rv = EXIT_SUCCESS;
     try {
         app.createWindow(networkStyle.data());
+
+        // Check Version
+        UpdateChecker* updateChecker = new UpdateChecker(&app);
+        updateChecker->checkForUpdates();
+
         // Perform base initialization before spinning up initialization/shutdown thread
         // This is acceptable because this function only contains steps that are quick to execute,
         // so the GUI thread won't be held up.

--- a/src/qt/updatechecker.cpp
+++ b/src/qt/updatechecker.cpp
@@ -1,0 +1,109 @@
+#include <qt/updatechecker.h>
+#include <clientversion.h>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageBox>
+#include <QUrl>
+#include <QNetworkRequest>
+#include <QDesktopServices>
+
+UpdateChecker::UpdateChecker(QObject *parent) : QObject(parent) {
+    manager = new QNetworkAccessManager(this);
+}
+
+void UpdateChecker::checkForUpdates() {
+    // GitHub API endpoint for the latest stable release
+    QUrl url("https://api.github.com/repos/Raptor3um/raptoreum/releases/latest");
+    QNetworkRequest request(url);
+    
+    // GitHub requires a User-Agent header for API requests
+    request.setHeader(QNetworkRequest::UserAgentHeader, "Raptoreum-Update-Checker");
+
+    connect(manager, &QNetworkAccessManager::finished, this, &UpdateChecker::handleResponse);
+    manager->get(request);
+}
+
+void UpdateChecker::handleResponse(QNetworkReply* reply) {
+    // Error handling: if the API is unreachable or the user is offline, fail silently
+    if (reply->error() != QNetworkReply::NoError) {
+        reply->deleteLater();
+        return;
+    }
+
+    // Check HTTP status code (should be 200 OK)
+    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (statusCode != 200) {
+        reply->deleteLater();
+        return;
+    }
+
+    // Parse JSON response
+    QByteArray response = reply->readAll();
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(response);
+    if (jsonDoc.isNull() || !jsonDoc.isObject()) {
+        reply->deleteLater();
+        return;
+    }
+
+    QJsonObject jsonObj = jsonDoc.object();
+    QString remoteTag = jsonObj["tag_name"].toString(); // Expected format: "v1.2.3" or "1.2.3"
+
+    // Clean version string (remove leading 'v' if present)
+    QString cleanRemote = remoteTag;
+    if (cleanRemote.startsWith('v')) cleanRemote.remove(0, 1);
+
+    // Build local version string from clientversion.h macros
+    QString localVersion = QString("%1.%2.%3")
+                            .arg(CLIENT_VERSION_MAJOR)
+                            .arg(CLIENT_VERSION_MINOR)
+                            .arg(CLIENT_VERSION_REVISION, 2, 10, QChar('0'));
+
+    // If remote version is higher, notify the user
+    if (isNewer(cleanRemote, localVersion)) {
+        showUpdateDialog(remoteTag);
+    }
+
+    reply->deleteLater();
+}
+
+bool UpdateChecker::isNewer(const QString& remote, const QString& local) {
+    // Regular expression to find version numbers (e.g., 2.0.03)
+    QRegularExpression re("(\\d+)\\.(\\d+)\\.(\\d+)");
+    
+    QRegularExpressionMatch remoteMatch = re.match(remote);
+    QRegularExpressionMatch localMatch = re.match(local);
+
+    if (!remoteMatch.hasMatch() || !localMatch.hasMatch()) {
+        // If we can't parse numbers, fallback to basic string comparison
+        return remote > local;
+    }
+
+    // Compare Major, Minor, and Revision
+    for (int i = 1; i <= 3; ++i) {
+        int remoteNum = remoteMatch.captured(i).toInt();
+        int localNum = localMatch.captured(i).toInt();
+
+        if (remoteNum > localNum) return true;
+        if (remoteNum < localNum) return false;
+    }
+
+    // If we are here, versions are identical or remote has an extra build number
+    return false; 
+}
+
+void UpdateChecker::showUpdateDialog(const QString& version) {
+    QString url = "https://github.com/Raptor3um/raptoreum/releases/latest";
+    
+    QMessageBox msgBox;
+    msgBox.setWindowTitle("Update Available");
+    msgBox.setTextFormat(Qt::RichText);
+    msgBox.setText(tr("A new stable version of Raptoreum Core is available: <b>%1</b>").arg(version));
+    msgBox.setInformativeText(tr("It is recommended to always use the latest version for security and stability.<br><br>"
+                                 "<a href='%1'>View Release on GitHub</a>").arg(url));
+    msgBox.setIcon(QMessageBox::Information);
+    msgBox.setStandardButtons(QMessageBox::Ok);
+    
+    // Enable link clicking
+    msgBox.exec();
+}

--- a/src/qt/updatechecker.h
+++ b/src/qt/updatechecker.h
@@ -1,0 +1,41 @@
+#ifndef RAPTOREUM_QT_UPDATECHECKER_H
+#define RAPTOREUM_QT_UPDATECHECKER_H
+
+#include <QObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QString>
+
+/**
+ * Class responsible for checking the latest stable release on GitHub.
+ * It compares the remote tag version with the local CLIENT_VERSION.
+ */
+class UpdateChecker : public QObject {
+    Q_OBJECT
+
+public:
+    explicit UpdateChecker(QObject *parent = nullptr);
+    void checkForUpdates();
+
+private Q_SLOTS:
+    /**
+     * Handles the network response from GitHub API.
+     */
+    void handleResponse(QNetworkReply* reply);
+
+private:
+    QNetworkAccessManager* manager;
+    
+    /**
+     * Compares two version strings (e.g., "1.2.3" and "1.2.4").
+     * Returns true if remote version is higher than local.
+     */
+    bool isNewer(const QString& remote, const QString& local);
+    
+    /**
+     * Displays a non-modal information dialog if an update is found.
+     */
+    void showUpdateDialog(const QString& version);
+};
+
+#endif // RAPTOREUM_QT_UPDATECHECKER_H


### PR DESCRIPTION
<img width="1193" height="1048" alt="Bildschirmfoto vom 2026-03-01 16-21-16" src="https://github.com/user-attachments/assets/b8a6029a-3447-42bd-a148-624d3163e4fa" />

A check has been added when starting the QT wallet.
1. Check: Is Github accessible?
2. Check: Version comparison between local wallet and Github.

The check is performed every time the QT wallet is started.
A message indicating that a new version is available appears as soon as a difference is detected.

Tested in Ubuntu.