### PR TITLE
build: add ENABLE_WALLET guards to rpc/rpcassets.cpp

### DIFF
--- a/src/rpc/rpcassets.cpp
+++ b/src/rpc/rpcassets.cpp
@@ -812,6 +812,7 @@ UniValue getassetdetailsbyid(const JSONRPCRequest &request) {
     return result;
 }
 
+#ifdef ENABLE_WALLET
 UniValue listassetsbalance(const JSONRPCRequest &request) {
     if (request.fHelp || !Updates().IsAssetsActive(::ChainActive().Tip()) || request.params.size() > 0)
         throw std::runtime_error(
@@ -1062,6 +1063,7 @@ UniValue listunspentassets(const JSONRPCRequest& request)
 
     return results;
 }
+#endif // ENABLE_WALLET
 
 UniValue listassets(const JSONRPCRequest &request) {
     RPCHelpMan{"listassets",
@@ -1158,6 +1160,7 @@ UniValue listassets(const JSONRPCRequest &request) {
     UniValue result(UniValue::VOBJ);
 
     if (mine) {
+#ifdef ENABLE_WALLET
         // Get only assets owned by this wallet
         std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
         if (!wallet) {
@@ -1201,6 +1204,10 @@ UniValue listassets(const JSONRPCRequest &request) {
                 loaded++;
             }
         }
+#else
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND,
+                           "The 'mine' option requires wallet support, which was disabled at compile time.");
+#endif // ENABLE_WALLET
     } else {
         // Get all assets (original behavior)
         std::vector<CDatabaseAssetData> assets;


### PR DESCRIPTION
## Summary

Restore the ability to build with `./configure --disable-wallet` on current `develop`.

PR #436 (`Bug/createrawtransaction for asset`) added three new RPC handlers in `src/rpc/rpcassets.cpp` that unconditionally reference wallet-only symbols (`CWallet`, `GetWalletForJSONRPCRequest`, `COutput`, `CCoinControl`, `CInputCoin`, `CoinType`):

- `listassetsbalance` (lines 815-869)
- `listunspentassets` (lines 871-1064)
- `listassets`, `mine=true` branch (lines 1160-1203)

The RPC command table at the bottom of the file already wraps the registrations for `listassetsbalance` and `listunspentassets` in `#ifdef ENABLE_WALLET`, but the function bodies themselves were left unguarded. Since the file's includes for wallet headers are gated on `ENABLE_WALLET` (lines 16-20), `--disable-wallet` builds fail to compile this TU with dozens of "`CWallet` was not declared in this scope" errors.

## Fix

- Wrap the two wallet-only function bodies (`listassetsbalance`, `listunspentassets`) in `#ifdef ENABLE_WALLET` / `#endif`. The matching table entries are already guarded, so when the bodies are absent the function pointers are simply never referenced.
- In `listassets`, the function is intentionally mixed: `mine=false` is wallet-independent (queries `passetsdb` only), `mine=true` needs the wallet. Guard only the `mine=true` branch, and in the `#else` path throw `RPC_METHOD_NOT_FOUND` so a client that requests `mine=true` against a no-wallet node sees a clear error instead of silently getting wrong data.

## Test plan

- [x] `./configure --disable-bench --without-gui --disable-wallet`, then `make rpc/libraptoreum_server_a-rpcassets.o` — compiles cleanly (was broken on `develop`).
- [x] `nm` on the resulting `.o` confirms zero unresolved `CWallet` / `GetWalletForJSONRPCRequest` symbols.
- [x] `./configure ... --enable-wallet --with-incompatible-bdb`, then recompile the same TU — still builds.

Note: a separate, pre-existing link-time failure in `src/mapport.cpp` (undefined references to `readnatpmpresponseorretry` / `sendnewportmappingrequest` from `libnatpmp`) keeps the no-wallet `raptoreumd` link from completing on this build host. That's an unrelated NAT-PMP library-ordering issue and not in scope here.

## Why this matters

- CI builds with `--disable-wallet` (e.g. for testing headless/light-node configurations) are currently broken on `develop`.
- Future Guix-style deterministic builds typically need both `--enable-wallet` and `--disable-wallet` paths to work.

Related: #443 (EVM integration, runs into this same restriction during test-suite verification), #444 (the `amount_tests` overflow fix that lets the test suite report honest pass/fail counts), #445 (broader `CFeeRate` hardening tracking).
