### PR TITLE
qt: fix sub-asset creation in non-English locales (#440)

### DIFF
--- a/src/qt/createassetsdialog.cpp
+++ b/src/qt/createassetsdialog.cpp
@@ -858,12 +858,19 @@ void CreateAssetsDialog::onAssetNameChanged(QString name)
     ui->assetNameValidation->setText(tr("Asset name is valid and available"));
 }
 
-void CreateAssetsDialog::onAssetTypeSelected(QString name) {
-    if (name == "Root") {
+void CreateAssetsDialog::onAssetTypeSelected(QString) {
+    // The combobox display text is translated in non-English locales, so comparing
+    // it against the English literals "Root"/"Sub" never matches. That left the
+    // root-asset selector permanently hidden and made sub-asset creation impossible
+    // in any non-English language (issue #440). Use the locale-independent item
+    // index instead: index 0 is "Root", any other index is "Sub" (consistent with
+    // the rest of this dialog, see issue #418).
+    bool isRoot = ui->AssetTypeBox->currentIndex() == 0;
+    if (isRoot) {
         ui->RootAssetLabel->setVisible(false);
         ui->RootAssetBox->setVisible(false);
         ui->assetnameText->setToolTip(tr("A-Z 0-9, no spaces"));
-    } else if (name == "Sub") {
+    } else {
         ui->RootAssetLabel->setVisible(true);
         ui->RootAssetBox->setVisible(true);
         ui->assetnameText->setToolTip(tr("a-z A-Z 0-9 and space"));


### PR DESCRIPTION
## Problem

When the wallet display language is set to anything other than English,
the *Create asset* dialog does not show the root-asset selector after
choosing the **Sub** asset type, so a parent asset can never be selected
and sub-asset creation becomes impossible (issue #440).

## Root cause

`CreateAssetsDialog::onAssetTypeSelected()` was driven by the **translated**
combobox text:

```cpp
if (name == "Root") { ... }
else if (name == "Sub") { ... }
```

In non-English locales Qt translates the combobox items (e.g. "Racine" /
"Sous" in French), so neither branch matches, the `else if` is skipped and
`RootAssetBox`/`RootAssetLabel` are never made visible.

## Fix

Use the locale-independent item index instead (index 0 == Root, any other
index == Sub), which is exactly how the rest of the dialog already decides
the asset type after #418. The translated string is no longer compared, so
the behaviour is identical across all languages.

Closes #440.