### PR TITLE
rpc: persist the latest setgenerate state with ForceSetArg (#448)

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1219,8 +1219,13 @@ UniValue setgenerate(const JSONRPCRequest &request) {
     }
 
 
-    gArgs.SoftSetArg("-gen", (fGenerate ? "1" : "0"));
-    gArgs.SoftSetArg("-genproclimit", itostr(nGenProcLimit));
+    // setgenerate is an explicit runtime command, so it must overwrite any
+    // previously stored values. SoftSetArg() only sets an arg when it is unset,
+    // which meant the very first invocation "stuck": later calls could not update
+    // -gen or -genproclimit, so the node kept reporting/using the original thread
+    // count (issue #448). Force the values to reflect this call.
+    gArgs.ForceSetArg("-gen", (fGenerate ? "1" : "0"));
+    gArgs.ForceSetArg("-genproclimit", itostr(nGenProcLimit));
 
     NodeContext &node = EnsureNodeContext(request.context);
     if (!node.connman)


### PR DESCRIPTION
Follow-up to #448 / #449.

`setgenerate` stored `-gen` and `-genproclimit` with `SoftSetArg()`, which
only writes an arg when it is currently **unset**. Once the first
`setgenerate` call ran, those values were locked in: a later
`setgenerate true 20` or `setgenerate false` could no longer update the
stored thread count, so the node kept reporting/using the count from the
very first invocation.

Since `setgenerate` is an explicit runtime command it must overwrite the
previous state, so this switches the two calls to `ForceSetArg()`.

This is orthogonal to #449 (which corrects the response text) and touches
different lines — together they fully resolve the stale thread count
reported in #448.