### PR TITLE
qt: remove leftover empty widget from Asset Info panel (#395)

### DIFF
--- a/src/qt/forms/assetsdialog.ui
+++ b/src/qt/forms/assetsdialog.ui
@@ -120,7 +120,7 @@
           </layout>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,0">
+          <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0">
            <item>
             <widget class="QFrame" name="detailframe">
              <property name="enabled">
@@ -376,28 +376,6 @@
                </layout>
               </item>
              </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QListWidget" name="listWidget">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>380</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
             </widget>
            </item>
           </layout>

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -2023,13 +2023,6 @@ QDialog#UpdateAssetsDialog QPushButton#updateAssetButton {
 }
 
 /******************************************************
-AssetsDialog
-******************************************************/
-QDialog#AssetsDialog QListWidget#listWidget {
-    background-color: #00000000;
-}
-
-/******************************************************
 SignVerifyMessageDialog
 ******************************************************/
 


### PR DESCRIPTION
## Problem

The Assets dialog shows an empty box in the bottom-right of the Asset Info
area (most visibly on the Windows Qt build) — issue #395.

## Root cause

`src/qt/forms/assetsdialog.ui` defines a `QListWidget` named `listWidget` that
is never populated or referenced from any source file. Its only traces are the
.ui definition and a dead `QDialog#AssetsDialog QListWidget#listWidget` rule in
`general.css`. Because it has a fixed `minimumSize` width of 380px and an
expanding size policy, it reserves space and renders as an empty widget.

## Fix

Remove the orphan widget from the .ui and its dead stylesheet rule. Verified
that no code references `listWidget` (`grep` across `src/qt`), and the .ui
remains well-formed XML after the removal.

Closes #395.