### PR TITLE
wallet: let sendtoaddress skip the optional future argument cleanly (#383)

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -329,7 +329,10 @@ UniValue sendtoaddress(const JSONRPCRequest &request) {
                        {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO,
                         "The amount in " + CURRENCY_UNIT + " to send. eg 0.1"},
                        {"future", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "Future transaction is mature when it has enough confirmations or locktime in seconds has past from its first confirm.",
+                        "Future transaction is mature when it has enough confirmations or locktime in seconds has past from its first confirm.\n"
+                        "                             This argument is optional: to skip it positionally and still pass later\n"
+                        "                             arguments, give an empty array [] or null (an empty string \"\" is NOT valid here).\n"
+                        "                             Alternatively use named arguments, e.g. -named ... subtractfeefromamount=true.",
                         {
                                 {"future_maturity", RPCArg::Type::NUM, /* default */ "",
                                  "Number of confirmations required for this future to mature."},
@@ -391,7 +394,10 @@ UniValue sendtoaddress(const JSONRPCRequest &request) {
     bool hasFuture = false;
     int nextParamsIndex = 2;
     if (!request.params[nextParamsIndex].isNull()) {
-        if (request.params[nextParamsIndex].isObject()) {
+        // The optional "future" argument can be skipped positionally by passing an
+        // empty array, null, or an empty object. Only a non-empty object actually
+        // requests a future transaction; anything else means "no future" (issue #383).
+        if (request.params[nextParamsIndex].isObject() && !request.params[nextParamsIndex].empty()) {
             if (request.params[nextParamsIndex]["future_maturity"].isNull()) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("no future_maturity is specified "));
             }


### PR DESCRIPTION
## Background

Issue #383 reports that `sendtoaddress` "does not work except the default/simplest
send" and that anything after the `future` argument fails, often with a cryptic
`error: Error parsing JSON:`.

Testing the current code on regtest shows the feature mostly works already — the
later arguments (`comment`, `comment_to`, `subtractfeefromamount`, ...) are
accepted when `future` is given as `[]`, `null`, or a valid object, and named
arguments (`-named`) also work. Two rough edges remain:

- Passing an **empty object** `{}` for `future` entered the future branch and
  failed with `no future_maturity is specified`.
- Passing an **empty string** `""` for `future` fails at the CLI layer with
  `Error parsing JSON`, because `future` is a JSON-typed positional argument and
  `""` is not valid JSON.

## Change

- Treat an empty object the same as an absent `future`: only a **non-empty**
  object requests a future transaction. `{}`, `[]` and `null` now all mean
  "no future". A non-empty but incomplete object (e.g. only `future_maturity`)
  still errors exactly as before, so validation is unchanged.
- Expand the `future` help text to explain that the argument is optional and how
  to skip it positionally (`[]`/`null`, not `""`) or via `-named`.

## Verified (regtest)

```
sendtoaddress <addr> 1 {} "comment" "commentto" true        -> txid (was: error -8)
sendtoaddress <addr> 1 [] "" "" true                        -> txid (unchanged)
sendtoaddress <addr> 1 {"future_maturity":50,"future_locktime":-1} "" "" true -> txid (unchanged)
sendtoaddress <addr> 1 {"future_maturity":50} "" "" true    -> error -8 "no future_locktime" (validation preserved)
```

Closes #383.