### PR TITLE
rpc: mine to the wallet selected on the setgenerate endpoint (#450)

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -66,6 +66,12 @@ double nHashesPerSec = 0;
 uint64_t nHashesDone = 0;
 std::string alsoHashString;
 
+// Name of the wallet selected for mining rewards (issue #450). Set by
+// GenerateRaptoreums() before the miner threads start; empty means "use the
+// first loaded wallet" (previous behaviour). It is only written while the
+// miner is stopped, so the worker threads read a stable value.
+static std::string g_miningWalletName;
+
 int64_t UpdateTime(CBlockHeader *pblock, const Consensus::Params &consensusParams, const CBlockIndex *pindexPrev) {
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast() + 1, GetAdjustedTime());
@@ -560,7 +566,15 @@ void static RaptoreumMiner(const CChainParams& chainparams, NodeContext& node) {
         CWallet * pWallet = NULL;
 
     #ifdef ENABLE_WALLET
-        pWallet = GetFirstWallet();
+        // Route rewards to the wallet selected on the setgenerate endpoint when
+        // one was given (issue #450); otherwise fall back to the first loaded
+        // wallet so existing single-wallet/CLI usage is unchanged.
+        if (!g_miningWalletName.empty()) {
+            if (std::shared_ptr<CWallet> selected = GetWallet(g_miningWalletName))
+                pWallet = selected.get();
+        }
+        if (pWallet == NULL)
+            pWallet = GetFirstWallet();
 
   		  // TODO: either add this function back in, or update this for more appropriate wallet functionality
         // if (!EnsureWalletIsAvailable(pWallet, false)) {
@@ -704,7 +718,8 @@ void static RaptoreumMiner(const CChainParams& chainparams, NodeContext& node) {
 }
 
 // TODO: add reference node, get the conn man from there
-int GenerateRaptoreums(bool fGenerate, int nThreads, const CChainParams &chainparams, NodeContext &node) {
+int GenerateRaptoreums(bool fGenerate, int nThreads, const CChainParams &chainparams, NodeContext &node,
+                       const std::string &walletName) {
     static boost::thread_group *minerThreads = NULL;
 
     int numCores = GetNumCores();
@@ -720,6 +735,9 @@ int GenerateRaptoreums(bool fGenerate, int nThreads, const CChainParams &chainpa
     if (nThreads == 0 || !fGenerate) {
         return numCores;
     }
+
+    // Record the target wallet before the worker threads start reading it (#450).
+    g_miningWalletName = walletName;
 
     minerThreads = new boost::thread_group();
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -224,6 +224,14 @@ void IncrementExtraNonce(CBlock *pblock, const CBlockIndex *pindexPrev, unsigned
 
 int64_t UpdateTime(CBlockHeader *pblock, const Consensus::Params &consensusParams, const CBlockIndex *pindexPrev);
 
-int GenerateRaptoreums(bool fGenerate, int nThreads, const CChainParams &chainparams, NodeContext &node);
+/**
+ * Start/stop the built-in CPU miner.
+ *
+ * walletName optionally selects which loaded wallet receives the coinbase
+ * rewards (issue #450). When empty the miner falls back to the first loaded
+ * wallet, preserving the previous behaviour.
+ */
+int GenerateRaptoreums(bool fGenerate, int nThreads, const CChainParams &chainparams, NodeContext &node,
+                       const std::string &walletName = "");
 
 #endif // BITCOIN_MINER_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -5,6 +5,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include <config/raptoreum-config.h>
+#endif
+
 #include <amount.h>
 #include <chain.h>
 #include <chainparams.h>
@@ -34,6 +38,10 @@
 #include <validation.h>
 #include <validationinterface.h>
 #include <warnings.h>
+
+#ifdef ENABLE_WALLET
+#include <wallet/rpcwallet.h>
+#endif
 
 #include <governance/governance-classes.h>
 #include <smartnode/smartnode-payments.h>
@@ -1226,7 +1234,16 @@ UniValue setgenerate(const JSONRPCRequest &request) {
     if (!node.connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    int numCores = GenerateRaptoreums(fGenerate, nGenProcLimit, Params(), node);
+    // If the call came in through a /wallet/<name> endpoint (e.g. a wallet picked
+    // in the GUI console), mine to that wallet instead of the first loaded one
+    // (issue #450). Left empty for non-wallet endpoints, which keeps the previous
+    // default-wallet behaviour and never throws in multi-wallet setups.
+    std::string walletName;
+#ifdef ENABLE_WALLET
+    GetWalletNameFromJSONRPCRequest(request, walletName);
+#endif
+
+    int numCores = GenerateRaptoreums(fGenerate, nGenProcLimit, Params(), node, walletName);
 
     nGenProcLimit = nGenProcLimit >= 0 ? nGenProcLimit : numCores;
     std::string msg = std::to_string(nGenProcLimit) + " of " + std::to_string(numCores);

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -40,6 +40,15 @@ Span<const CRPCCommand> GetWalletRPCCommands();
  */
 std::shared_ptr <CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest &request);
 
+/**
+ * Extract the wallet name from a JSONRPCRequest's /wallet/<name> endpoint, if any.
+ *
+ * @param[in]  request     JSONRPCRequest to inspect
+ * @param[out] wallet_name set to the endpoint's wallet name when present
+ * @return true if the request was made through a wallet endpoint
+ */
+bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest &request, std::string &wallet_name);
+
 void EnsureWalletIsUnlocked(CWallet *);
 
 WalletContext &EnsureWalletContext(const util::Ref &context);


### PR DESCRIPTION
## Problem

`setgenerate` always routed the coinbase rewards to the first loaded wallet
(`GetFirstWallet`), ignoring which wallet the call was made against. In a
multi-wallet setup the rewards therefore went to the default wallet instead of
the one selected in the GUI console (issue #450).

## Change

Thread the wallet name from the `/wallet/<name>` RPC endpoint down to the miner:

- `setgenerate` reads it with `GetWalletNameFromJSONRPCRequest` (no throw when no
  wallet is specified, so CLI/single-wallet use is unchanged),
- passes it to `GenerateRaptoreums(..., walletName)`,
- `RaptoreumMiner` resolves it with `GetWallet` and falls back to `GetFirstWallet`
  when the name is empty or the wallet is not loaded.

`GetWalletNameFromJSONRPCRequest` is now declared in `wallet/rpcwallet.h` so the
mining RPC can use it (guarded by `ENABLE_WALLET`).

## Testing

Compile-validated on `develop` with `--enable-wallet` (miner.cpp, rpc/mining.cpp,
wallet/rpcwallet.cpp all build cleanly). The actual reward routing was **not**
exercised at runtime: `setgenerate` is rejected on regtest (`MineBlocksOnDemand`)
and observing a real coinbase requires mining on a live network. A maintainer
with a mining setup can confirm by selecting a non-default wallet and checking
the coinbase destination. The change is backward compatible — with no wallet
endpoint the behaviour is identical to before.

Closes #450.