### PR TITLE
qt: label asset transactions by type in the history list (#382)

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -334,6 +334,23 @@ TransactionRecord::decomposeTransaction(interfaces::Wallet &wallet, const interf
 
         // LogPrintf("TransactionRecord::%s TxId: %s, vOutIdx: %d, Unhandled\n", __func__, hash.ToString(), vOutIdx);
     }
+
+    // Tag asset special transactions with their operation so they show up as
+    // "Create/Mint/Update Asset" instead of a generic send/receive or
+    // "Payment to yourself" entry when they touch the user's own wallet (issue #382).
+    TransactionRecord::Type assetType = TransactionRecord::Other;
+    switch (wtx.tx->nType) {
+        case TRANSACTION_NEW_ASSET:    assetType = TransactionRecord::AssetCreate; break;
+        case TRANSACTION_MINT_ASSET:   assetType = TransactionRecord::AssetMint;   break;
+        case TRANSACTION_UPDATE_ASSET: assetType = TransactionRecord::AssetUpdate; break;
+        default: break;
+    }
+    if (assetType != TransactionRecord::Other) {
+        for (TransactionRecord &rec : parts) {
+            rec.type = assetType;
+        }
+    }
+
     return parts;
 }
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -102,7 +102,10 @@ public:
         CoinJoinCreateDenominations,
         CoinJoinSend,
         FutureSend,
-        FutureReceive
+        FutureReceive,
+        AssetCreate,
+        AssetMint,
+        AssetUpdate
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -383,6 +383,12 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const 
             return tr("Future Send");
         case TransactionRecord::FutureReceive:
             return tr("Future Receive");
+        case TransactionRecord::AssetCreate:
+            return tr("Create Asset");
+        case TransactionRecord::AssetMint:
+            return tr("Mint Asset");
+        case TransactionRecord::AssetUpdate:
+            return tr("Update Asset");
         case TransactionRecord::CoinJoinMixing:
             return tr("%1 Mixing").arg(QString::fromStdString(gCoinJoinName));
         case TransactionRecord::CoinJoinCollateralPayment:
@@ -488,6 +494,9 @@ QVariant TransactionTableModel::amountColor(const TransactionRecord *rec) const 
         case TransactionRecord::CoinJoinCollateralPayment:
         case TransactionRecord::CoinJoinMakeCollaterals:
         case TransactionRecord::CoinJoinCreateDenominations:
+        case TransactionRecord::AssetCreate:
+        case TransactionRecord::AssetMint:
+        case TransactionRecord::AssetUpdate:
             return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::ORANGE);
     }
     return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::DEFAULT);


### PR DESCRIPTION
## Problem

createasset, mintasset and updateasset transactions appear in the wallet's
transaction list with a generic type — typically "Payment to yourself" when
they touch the user's own wallet — so they are indistinguishable from ordinary
sends (issue #382).

## Change

- Add `AssetCreate` / `AssetMint` / `AssetUpdate` record types.
- After `decomposeTransaction`, tag asset special transactions
  (`TRANSACTION_NEW_ASSET` / `TRANSACTION_MINT_ASSET` / `TRANSACTION_UPDATE_ASSET`)
  with the matching type. Amount decomposition is left untouched; only the
  displayed type label and colour change.
- Render them as "Create Asset" / "Mint Asset" / "Update Asset" in
  `formatTxType`, and colour them like other internal operations.

Asset *transfers* (ordinary transactions carrying asset outputs) are left as a
possible follow-up since they have no dedicated tx type to key off.

## Testing

Built with `--with-gui=qt5 --enable-wallet`: `transactionrecord.cpp`,
`transactiontablemodel.cpp` and the asset dialogs compile cleanly (uic/moc + CXX)
with the new enum values handled in the type switches.

Closes #382.