### PR TITLE
build: fix build on GCC 15 (Ubuntu 26.04)

### DIFF
--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -6,6 +6,11 @@ $(package)_sha256_hash=eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a
 $(package)_patches=applem1.patch
 
 define $(package)_set_vars
+# GCC 15 defaults to -std=gnu23, where an empty parameter list means "(void)".
+# GMP 6.2.1's configure probes call a `void g(){}` helper with arguments, which
+# is a hard error under C23, so configure aborts with "could not find a working
+# compiler". Pin the C dialect until GMP is bumped to a release that fixes this.
+$(package)_cflags+=-std=gnu17
 $(package)_cxxflags+=-std=c++17
 $(package)_config_opts+=--enable-cxx --enable-fat --with-pic --disable-shared
 $(package)_cflags_armv7l_linux+=-march=armv7-a

--- a/src/dashbls/depends/mimalloc/include/mimalloc-atomic.h
+++ b/src/dashbls/depends/mimalloc/include/mimalloc-atomic.h
@@ -39,7 +39,11 @@ terms of the MIT license. A copy of the license can be found in the file
 #include <stdatomic.h>
 #define  mi_atomic(name)        atomic_##name
 #define  mi_memory_order(name)  memory_order_##name
-#define  MI_ATOMIC_VAR_INIT(x)  ATOMIC_VAR_INIT(x)
+#if !defined(ATOMIC_VAR_INIT) || (__STDC_VERSION__ >= 201710L) // c17, ATOMIC_VAR_INIT deprecated; removed in c23
+ #define  MI_ATOMIC_VAR_INIT(x)  x
+#else
+ #define  MI_ATOMIC_VAR_INIT(x)  ATOMIC_VAR_INIT(x)
+#endif
 #endif
 
 // Various defines for all used memory orders in mimalloc


### PR DESCRIPTION
# build: fix build on GCC 15 (Ubuntu 26.04)

Raptoreum does not build on Ubuntu 26.04 LTS. There are two independent
blockers, both caused by the same upstream change: **GCC 15 switched the default
C dialect from `-std=gnu17` to `-std=gnu23`**.

Both fixes are scoped to the failing component; neither touches consensus code
or changes behaviour on Ubuntu 22.04 / 24.04, where `gnu17` was already the
compiler default.

---

## 1. `depends`: GMP configure aborts

```
Configuring gmp...
configure: error: could not find a working compiler, see config.log for details
make: *** [funcs.mk:292: .gmp_stamp_configured] Error 1
```

Under C23 an empty parameter list is no longer "unspecified parameters" --
`void g(){}` now means `void g(void)`. GMP 6.2.1's "long long reliability test"
probe declares a helper that way and then calls it with six arguments:

```c
void g(){}                                  /* line 7  */
g(i,d[i].src,d[i].n,got,d[i].want,9);       /* line 12 */
```

```
conftest.c:12:48: error: too many arguments to function 'g'; expected 0, have 6
conftest.c:7:6: note: declared here
```

GMP treats that probe failing as "the compiler is broken" and aborts configure,
which takes the whole depends build down.

**Fix:** pin the C dialect for the GMP package only (`depends/packages/gmp.mk`):

```makefile
$(package)_cflags+=-std=gnu17
```

## 2. `dashbls`/mimalloc: `ATOMIC_VAR_INIT` removed in C23

```
mimalloc-atomic.h:42:33: error: implicit declaration of function 'ATOMIC_VAR_INIT'
mimalloc-atomic.h:42:33: error: initializer element is not constant
make[2]: *** [dashbls/libdashbls.la] Error 2
```

`ATOMIC_VAR_INIT` was deprecated in C17 and **removed in C23**, so it is no
longer provided by `<stdatomic.h>`.

The C++ branch of this same header already guards against exactly this (added
upstream for C++20, see mimalloc issue #571):

```c
#if !defined(ATOMIC_VAR_INIT) || (__cplusplus >= 202002L)
 #define MI_ATOMIC_VAR_INIT(x)  x
#else
 #define MI_ATOMIC_VAR_INIT(x)  ATOMIC_VAR_INIT(x)
#endif
```

**Fix:** apply the same guard to the C11 branch. `MI_ATOMIC_VAR_INIT(x)`
expands to plain `x`, which is what `ATOMIC_VAR_INIT` did for initialisation
anyway, so behaviour is unchanged on older compilers.

---

## Verification

Built from a clean clone of `develop` (989ec2e1d) inside an `ubuntu:26.04`
container -- gcc 15.2.0, `__STDC_VERSION__ 202311L` -- replicating the CI steps:

```
make -C depends HOST=x86_64-pc-linux-gnu
./autogen.sh
./configure --prefix=$(pwd)/depends/x86_64-pc-linux-gnu
make
```

- Before: depends dies at GMP; with GMP fixed, the source build dies at dashbls.
- After: all 28 depends packages build, a clean full source build completes with
  0 errors (`raptoreumd`, `raptoreum-cli`, `raptoreum-qt`, `test_raptoreum`),
  and the unit test suite is green:

```
Test module "Raptoreum Test Suite" has passed with:
  362 test cases out of 362 passed
  4814561 assertions out of 4814561 passed
```

(Run with a UTF-8 locale set. On a bare container with `LC_CTYPE=POSIX`,
`fs_tests/fsbridge_fstream` aborts in Boost.Filesystem's path codecvt -- an
environment artifact, not a code issue; CI runners already set a locale.)

Packages verified as needing **no** change under GCC 15: BDB 4.8.30,
OpenSSL 1.1.1w, Boost 1.84.0, Qt 5.15.5, libevent, zeromq, backtrace, immer.

## Notes for maintainers

- `ubuntu-26.04` exists as a GitHub Actions runner label but is currently
  flagged **preview** (no SLA); `ubuntu-latest` still maps to 24.04. I have
  deliberately **not** added a CI matrix row here -- worth doing once the image
  goes GA, and it is a 5-line addition to the existing `build-linux` matrix.
- Unrelated flake seen while testing: `xproto` can fail to stage under high
  `-j` because `install-xprotoHEADERS` and `install-nodist_xprotoHEADERS` race
  creating the same directory (`mkdir: ... File exists`). It succeeds on retry.
  Pre-existing, not GCC-15 specific, so it is not addressed in this PR.
- Longer term, bumping GMP to 6.3.0 fixes issue 1 upstream, but that is a bigger
  change (new version + hash, and `applem1.patch` would need review).
