### PR TITLE
smartnode: fix two crashes in `smartnode payments` and speed up fee computation

### DIFF
--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -485,7 +485,11 @@ UniValue smartnode_payments(const JSONRPCRequest &request) {
             payeesArr.push_back(obj);
         }
 
-        const auto dmnPayee = deterministicMNManager->GetListForBlock(pindex).GetMNPayee();
+        // The smartnode paid by a block is the payee of the list as it stood at the
+        // previous block, which is what GetBlockTxOuts() used to fill in the payees
+        // above. Using the list at this block instead would name the smartnode due
+        // to be paid by the *next* one.
+        const auto dmnPayee = deterministicMNManager->GetListForBlock(pindex->pprev).GetMNPayee();
         protxObj.pushKV("proTxHash", dmnPayee == nullptr ? "" : dmnPayee->proTxHash.ToString());
         protxObj.pushKV("amount", payedPerSmartnode);
         protxObj.pushKV("payees", payeesArr);

--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -404,6 +404,14 @@ UniValue smartnode_payments(const JSONRPCRequest &request) {
 
     while (vecPayments.size() < uint64_t(std::abs(nCount)) && pindex != nullptr) {
 
+        if (pindex->pprev == nullptr) {
+            // The genesis block has no previous block to derive the block reward
+            // from and pays no smartnode. Bail out with a clear error instead of
+            // dereferencing a null pprev below, which crashes the node.
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Smartnode payment information is not available for the genesis block");
+        }
+
         CBlock block;
         if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");

--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -427,20 +427,34 @@ UniValue smartnode_payments(const JSONRPCRequest &request) {
         // GetTransaction() lookup returned null for confirmed prevouts on such nodes and
         // the daemon crashed dereferencing it.
         CAmount nBlockFees{0};
-        if (IsBlockPruned(pindex)) {
-            throw JSONRPCError(RPC_MISC_ERROR, "Undo data not available (pruned data)");
-        }
         CBlockUndo blockUndo;
         if (!UndoReadFromDisk(blockUndo, pindex)) {
+            // The read itself is the source of truth for undo availability;
+            // IsBlockPruned() only refines the error message after a failure.
+            if (IsBlockPruned(pindex)) {
+                throw JSONRPCError(RPC_MISC_ERROR, "Undo data not available (pruned data)");
+            }
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read undo data from disk");
         }
         // vtx[0] is the coinbase (no inputs); blockUndo.vtxundo is indexed for all but the coinbase.
+        if (blockUndo.vtxundo.size() != block.vtx.size() - 1) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR,
+                               strprintf("Undo data for block %s is inconsistent: %d transaction undo records for %d transactions",
+                                         pindex->GetBlockHash().ToString(), blockUndo.vtxundo.size(), block.vtx.size()));
+        }
         for (size_t i = 1; i < block.vtx.size(); ++i) {
+            const CTransaction &tx = *block.vtx[i];
+            const CTxUndo &txUndo = blockUndo.vtxundo[i - 1];
+            if (txUndo.vprevout.size() != tx.vin.size()) {
+                throw JSONRPCError(RPC_INTERNAL_ERROR,
+                                   strprintf("Undo data for transaction %s is inconsistent: %d spent outputs for %d inputs",
+                                             tx.GetHash().ToString(), txUndo.vprevout.size(), tx.vin.size()));
+            }
             CAmount nValueIn{0};
-            for (const Coin &coin: blockUndo.vtxundo.at(i - 1).vprevout) {
+            for (const Coin &coin: txUndo.vprevout) {
                 nValueIn += coin.out.nValue;
             }
-            nBlockFees += nValueIn - block.vtx[i]->GetValueOut();
+            nBlockFees += nValueIn - tx.GetValueOut();
         }
 
         std::vector <CTxOut> voutSmartnodePayments, voutDummy;

--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -15,6 +15,7 @@
 #include <rpc/util.h>
 #include <smartnode/activesmartnode.h>
 #include <smartnode/smartnode-payments.h>
+#include <undo.h>
 #include <univalue.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
@@ -419,20 +420,27 @@ UniValue smartnode_payments(const JSONRPCRequest &request) {
 
         // Note: we have to actually calculate block reward from scratch instead of simply querying coinbase vout
         // because miners might collect less coins than they potentially could and this would break our calculations.
+        //
+        // The value of each spent input is taken from the block's undo data (a single
+        // sequential read) rather than fetching every previous transaction individually.
+        // Besides being much faster, this also works on nodes without -txindex: the old
+        // GetTransaction() lookup returned null for confirmed prevouts on such nodes and
+        // the daemon crashed dereferencing it.
         CAmount nBlockFees{0};
-        NodeContext &node = EnsureNodeContext(request.context);
-        for (const auto &tx: block.vtx) {
-            if (tx->IsCoinBase()) {
-                continue;
-            }
+        if (IsBlockPruned(pindex)) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Undo data not available (pruned data)");
+        }
+        CBlockUndo blockUndo;
+        if (!UndoReadFromDisk(blockUndo, pindex)) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read undo data from disk");
+        }
+        // vtx[0] is the coinbase (no inputs); blockUndo.vtxundo is indexed for all but the coinbase.
+        for (size_t i = 1; i < block.vtx.size(); ++i) {
             CAmount nValueIn{0};
-            for (const auto &txin: tx->vin) {
-                uint256 blockHashTmp;
-                CTransactionRef txPrev = GetTransaction(/* block_index */ nullptr, node.mempool, txin.prevout.hash,
-                                                                          Params().GetConsensus(), blockHashTmp);
-                nValueIn += txPrev->vout[txin.prevout.n].nValue;
+            for (const Coin &coin: blockUndo.vtxundo.at(i - 1).vprevout) {
+                nValueIn += coin.out.nValue;
             }
-            nBlockFees += nValueIn - tx->GetValueOut();
+            nBlockFees += nValueIn - block.vtx[i]->GetValueOut();
         }
 
         std::vector <CTxOut> voutSmartnodePayments, voutDummy;

--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -398,7 +398,9 @@ UniValue smartnode_payments(const JSONRPCRequest &request) {
         }
     }
 
-    int64_t nCount = request.params.size() > 2 ? ParseInt64V(request.params[1], "count") : 1;
+    // params[0] is the block hash and params[1] the count, so a call that supplies
+    // a count has two parameters, not more than two.
+    int64_t nCount = request.params.size() > 1 ? ParseInt64V(request.params[1], "count") : 1;
 
     // A temporary vector which is used to sort results properly (there is no "reverse" in/for UniValue)
     std::vector <UniValue> vecPayments;

--- a/test/functional/rpc_smartnode_payments.py
+++ b/test/functional/rpc_smartnode_payments.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Raptoreum developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the `smartnode payments` RPC around the genesis block.
+
+Regression test for a node crash.
+
+Old behaviour (before the fix):
+    `smartnode payments <genesis-hash>` computed the block reward with
+    `GetBlockSubsidy(pindex->pprev->nBits, ...)`. For the genesis block
+    `pindex->pprev` is a null pointer, so this dereferenced null and
+    crashed the whole node (segfault / lost RPC connection).
+
+New behaviour (after the fix):
+    the RPC detects that the requested block has no previous block and
+    returns a clear JSON-RPC error (RPC_INVALID_PARAMETER, -8) while the
+    node keeps running. Normal blocks are unaffected.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class RpcSmartnodePaymentsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0]
+        genesis_hash = node.getblockhash(0)
+
+        self.log.info("Mine a few blocks so the chain has a real, non-genesis tip")
+        node.generate(5)
+        tip_hash = node.getbestblockhash()
+        assert_equal(node.getblockcount(), 5)
+
+        self.log.info("`smartnode payments` on a normal block still works")
+        payments = node.smartnode("payments", tip_hash)
+        assert_equal(len(payments), 1)
+        assert_equal(payments[0]["height"], 5)
+        assert_equal(payments[0]["blockhash"], tip_hash)
+
+        self.log.info("`smartnode payments` on the genesis block returns an error instead of crashing the node")
+        # Before the fix this call dereferenced a null `pprev` and took the node down.
+        assert_raises_rpc_error(-8, "genesis block", node.smartnode, "payments", genesis_hash)
+
+        self.log.info("The node is still alive and responsive after the genesis query")
+        # This is the crux of the regression test: on the unpatched node the call
+        # above crashes the daemon and this final RPC never returns.
+        assert_equal(node.getblockcount(), 5)
+        assert_equal(node.getbestblockhash(), tip_hash)
+
+
+if __name__ == '__main__':
+    RpcSmartnodePaymentsTest().main()

--- a/test/functional/rpc_smartnode_payments.py
+++ b/test/functional/rpc_smartnode_payments.py
@@ -42,6 +42,21 @@ class RpcSmartnodePaymentsTest(BitcoinTestFramework):
         assert_equal(payments[0]["height"], 5)
         assert_equal(payments[0]["blockhash"], tip_hash)
 
+        self.log.info("The `count` argument selects how many blocks are returned")
+        # Before the fix the count was read only when more than two parameters were
+        # supplied, which never happens for a two-parameter call, so it silently
+        # stayed at 1 and every one of these returned a single block.
+        assert_equal(len(node.smartnode("payments", tip_hash, -1)), 1)
+        assert_equal(len(node.smartnode("payments", tip_hash, 1)), 1)
+        # counting backwards from the tip returns the tip last
+        back3 = node.smartnode("payments", tip_hash, -3)
+        assert_equal([entry["height"] for entry in back3], [3, 4, 5])
+        # counting forwards from an earlier block returns that block first
+        fwd3 = node.smartnode("payments", node.getblockhash(2), 3)
+        assert_equal([entry["height"] for entry in fwd3], [2, 3, 4])
+        # the tip cannot be extended forwards, so a large count still stops there
+        assert_equal([entry["height"] for entry in node.smartnode("payments", tip_hash, 10)], [5])
+
         self.log.info("`smartnode payments` on the genesis block returns an error instead of crashing the node")
         # Before the fix this call dereferenced a null `pprev` and took the node down.
         assert_raises_rpc_error(-8, "genesis block", node.smartnode, "payments", genesis_hash)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -181,6 +181,7 @@ BASE_SCRIPTS = [
     'feature_shutdown.py',
     'rpc_coinjoin.py',
     'rpc_masternode.py',
+    'rpc_smartnode_payments.py',
     'rpc_mnauth.py',
     'rpc_verifyislock.py',
     'rpc_verifychainlock.py',


### PR DESCRIPTION
Two fixes to `smartnode payments`, both in `src/rpc/smartnode.cpp`.

## 1. Crash on the genesis block

The block reward was derived from `GetBlockSubsidy(pindex->pprev->nBits, ...)`. For the genesis block `pindex->pprev` is null, so `smartnode payments <genesis-hash>` dereferenced null and crashed the whole node. Guarded with a clear JSON-RPC error.

## 2. Fee computation: crash on `-txindex=0`/pruning + slow

The block fees were recomputed by calling `GetTransaction()` for **every input of every transaction** in the block:

- **Latent crash:** on a node running with `-txindex=0` or pruning, `GetTransaction()` returns null for a confirmed prevout and the result was dereferenced without a null check (`txPrev->vout[...]`), taking the daemon down. (txindex is on by default, `DEFAULT_TXINDEX = true`, so this only affected non-default configs.)
- **Slow:** O(inputs) individual tx reads per block, times `count`.

Now the spent input values are read from the block's undo data (one sequential read per block), mirroring `getblock` verbosity 3 and `getblockstats`. This removes the crash and is much faster for per-block scanning.

## Testing

Built `raptoreumd` from this branch and verified on regtest:

- **Genesis:** unpatched → node crashes (`EOF reached`); patched → clean `-8` error, node stays up.
- **Fee loop, `-txindex=0`:** unpatched → `smartnode payments <block-with-a-transaction>` crashes the node; patched → returns and the node stays up.
- A functional regression test (`test/functional/rpc_smartnode_payments.py`) covers the genesis case.
- Full C++ unit test suite passes (no regression).
