### PR TITLE
assets: fix null-deref crash-loop on block replay for asset update/mint

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -517,17 +517,22 @@ void AddAssets(const CTransaction &tx, int nHeight, CAssetsCache *assetCache,
                 if (!assetCache->GetAssetMetaData(assetTx.assetId, asset))
                     return;
                 assetCache->UpdateAsset(assetTx);
-                undoAssetData->first = assetTx.assetId; // Asset Name
-                undoAssetData->second = CBlockAssetUndo{false, asset.circulatingSupply,
-                                                        asset.mintCount,
-                                                        asset.updatable,
-                                                        asset.referenceHash,
-                                                        asset.type,
-                                                        asset.targetAddress,
-                                                        asset.issueFrequency,
-                                                        asset.amount,
-                                                        asset.ownerAddress,
-                                                        asset.collateralAddress};
+                // undoAssetData is null when called without an undo sink, e.g. from
+                // RollforwardBlock() during ReplayBlocks() on startup. Only record undo
+                // data when a sink was provided, otherwise this would dereference null.
+                if (undoAssetData != nullptr) {
+                    undoAssetData->first = assetTx.assetId; // Asset Name
+                    undoAssetData->second = CBlockAssetUndo{false, asset.circulatingSupply,
+                                                            asset.mintCount,
+                                                            asset.updatable,
+                                                            asset.referenceHash,
+                                                            asset.type,
+                                                            asset.targetAddress,
+                                                            asset.issueFrequency,
+                                                            asset.amount,
+                                                            asset.ownerAddress,
+                                                            asset.collateralAddress};
+                }
             }
         } else if (tx.nType == TRANSACTION_MINT_ASSET) {
             CMintAssetTx assetTx;
@@ -544,17 +549,20 @@ void AddAssets(const CTransaction &tx, int nHeight, CAssetsCache *assetCache,
                 if (!assetCache->GetAssetMetaData(assetTx.assetId, asset))
                     return;
                 assetCache->UpdateAsset(assetTx.assetId, amount); // Update circulating supply
-                undoAssetData->first = assetTx.assetId;           // Asset Name
-                undoAssetData->second = CBlockAssetUndo{true, asset.circulatingSupply,
-                                                        asset.mintCount,
-                                                        asset.updatable,
-                                                        asset.referenceHash,
-                                                        asset.type,
-                                                        asset.targetAddress,
-                                                        asset.issueFrequency,
-                                                        asset.amount,
-                                                        asset.ownerAddress,
-                                                        asset.collateralAddress};
+                // See the note above: undoAssetData is null on the replay path.
+                if (undoAssetData != nullptr) {
+                    undoAssetData->first = assetTx.assetId;           // Asset Name
+                    undoAssetData->second = CBlockAssetUndo{true, asset.circulatingSupply,
+                                                            asset.mintCount,
+                                                            asset.updatable,
+                                                            asset.referenceHash,
+                                                            asset.type,
+                                                            asset.targetAddress,
+                                                            asset.issueFrequency,
+                                                            asset.amount,
+                                                            asset.ownerAddress,
+                                                            asset.collateralAddress};
+                }
             }
         } 
         //process asset transaction in order to track address balances


### PR DESCRIPTION
## Summary

`AddAssets()` writes undo data for `TRANSACTION_UPDATE_ASSET` and `TRANSACTION_MINT_ASSET` after only checking `IsAssetsActive() && assetCache` — it does not check `undoAssetData`. `RollforwardBlock()` (used by `ReplayBlocks()` on startup) calls `AddAssets()` without an undo sink, so `undoAssetData` is null.

Replaying a block that contains an asset update/mint then dereferences null (`undoAssetData->first = ...`) and crashes the node. Because it happens during `ReplayBlocks()` at startup (after an unclean shutdown), the crash re-triggers on every restart — a **crash-loop**.

`src/assets/assets.cpp:520` / `:547`, reached from `src/validation.cpp:4974`.

## Fix

Only record undo data when a sink was provided (`if (undoAssetData != nullptr)`). The `TRANSACTION_NEW_ASSET` branch already doesn't touch `undoAssetData`, and the normal connect path (`ConnectBlock`) always passes a valid sink, so behaviour there is unchanged.

## Testing

Branch builds cleanly; the `assets` unit test suite passes (no regression).
