### PR TITLE
node: defensive hardening for latent crash paths + remove debug print

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -586,7 +586,15 @@ bool GetAssetData(const CScript &script, CAssetOutputEntry &data) {
 }
 
 bool validateAmount(const CAmount nAmount, const uint16_t decimalPoint) {
-    if (nAmount % int64_t(pow(10, (8 - decimalPoint))) != 0) {
+    // Assets carry at most 8 decimals. A larger decimalPoint would make the divisor
+    // below (10^(8-decimalPoint)) underflow to 0 and divide by zero (SIGFPE). Using an
+    // integer lookup table also keeps this off floating-point math in a consensus path.
+    if (decimalPoint > 8) {
+        return false;
+    }
+    static const int64_t divisors[9] = {
+            100000000, 10000000, 1000000, 100000, 10000, 1000, 100, 10, 1};
+    if (nAmount % divisors[decimalPoint] != 0) {
         return false;
     }
     return true;

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -717,7 +717,7 @@ namespace llmq {
             // Check if request has ENCRYPTED_CONTRIBUTIONS data
             if (request.GetDataMask() & CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS) {
 
-                if (WITH_LOCK(pQuorum->cs, return pQuorum->quorumVvec->size() != pQuorum->params.threshold)) {
+                if (WITH_LOCK(pQuorum->cs, return pQuorum->quorumVvec == nullptr || pQuorum->quorumVvec->size() != pQuorum->params.threshold)) {
                     errorHandler("No valid quorum verification vector available", 0); // Don't bump score because we asked for it
                     return;
                 }

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -181,6 +181,13 @@ namespace llmq {
         // Peek into the message and see which LLMQType it is. First byte of all messages is always the LLMQType
         Consensus::LLMQType llmqType = (Consensus::LLMQType) * vRecv.begin();
         if (llmqType == Consensus::LLMQType::LLMQ_INVALID && (strCommand == NetMsgType::QCONTRIB || strCommand == NetMsgType::QPCOMMITMENT)) {
+            // These messages carry the real LLMQType in the second byte. Reject a
+            // 1-byte message instead of reading past the end of the buffer.
+            if (vRecv.size() < 2) {
+                LOCK(cs_main);
+                Misbehaving(pfrom->GetId(), 100);
+                return;
+            }
             llmqType = (Consensus::LLMQType) * (vRecv.begin() + 1);
         }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1489,6 +1489,9 @@ static UniValue gettxout(const JSONRPCRequest &request) {
     }
 
     const CBlockIndex *pindex = LookupBlockIndex(coins_view->GetBestBlock());
+    if (pindex == nullptr) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Best block not found in block index");
+    }
     ret.pushKV("bestblock", pindex->GetBlockHash().GetHex());
     if (coin.nHeight == MEMPOOL_HEIGHT) {
         ret.pushKV("confirmations", 0);

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1395,8 +1395,6 @@ UniValue protx_list(const JSONRPCRequest &request) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid height specified");
         }
 
-        std::cout << "protx_list: height" << height << ", ::ChainActive().Height(): " << ::ChainActive().Height()
-                  << ", fSpentIndex: " << fSpentIndex << std::endl;
 
         if (height != ::ChainActive().Height() && !fSpentIndex) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "specifying height requires spentindex enabled");

--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -574,6 +574,9 @@ static UniValue smartnodelist(const JSONRPCRequest &request) {
 
         LOCK(cs_main);
         const CBlockIndex *pindex = ::ChainActive()[dmn->pdmnState->nLastPaidHeight];
+        if (pindex == nullptr) {
+            return (int) 0;
+        }
         return (int) pindex->nTime;
     };
 

--- a/src/test/assets_tests.cpp
+++ b/src/test/assets_tests.cpp
@@ -657,4 +657,21 @@ BOOST_FIXTURE_TEST_CASE(assets_invalid_cases, TestChainDIP3BeforeActivationSetup
     }
 }
 
+BOOST_AUTO_TEST_CASE(validate_amount_decimal_point) {
+    // Normal range (decimalPoint 0..8): the divisor is 10^(8 - decimalPoint) and an
+    // amount is valid iff it is a whole multiple of that divisor.
+    BOOST_CHECK(validateAmount(100000000, 0));  // exactly 1 unit with 0 decimals
+    BOOST_CHECK(!validateAmount(1, 0));         // not a multiple of 1e8
+    BOOST_CHECK(validateAmount(10000, 4));      // multiple of 1e4
+    BOOST_CHECK(!validateAmount(10001, 4));     // not a multiple of 1e4
+    BOOST_CHECK(validateAmount(1, 8));          // divisor is 1, anything passes
+    BOOST_CHECK(validateAmount(0, 4));          // zero is always valid
+
+    // Out-of-range decimalPoint (> 8) must be rejected, not crash. Before the fix the
+    // divisor 10^(8 - decimalPoint) underflowed to 0 and the modulo raised SIGFPE.
+    BOOST_CHECK(!validateAmount(100000000, 9));
+    BOOST_CHECK(!validateAmount(0, 100));
+    BOOST_CHECK(!validateAmount(12345, 65535)); // max uint16_t, previously div-by-zero
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Defensive fixes for node-aborting conditions in RPC and P2P/consensus paths, plus removal of a stray debug print. These are mostly latent (hard to trigger today) but rely on fragile invariants; a couple are cheap wins.

## Changes

- **rpc/blockchain.cpp (`gettxout`)** — null-check `LookupBlockIndex(best block)` before dereferencing (every other `LookupBlockIndex` in the file is checked).
- **rpc/smartnode.cpp (`smartnodelist`)** — null-check `ChainActive()[nLastPaidHeight]` before reading `nTime`.
- **llmq/quorums_dkgsessionmgr.cpp** — reject a 1-byte `QCONTRIB`/`QPCOMMITMENT` instead of reading the second byte past the end of the buffer.
- **llmq/quorums.cpp (`QDATA` handler)** — null-check `quorumVvec` (a shared_ptr) before `size()`.
- **assets/`validateAmount`** — reject `decimalPoint > 8` (the `10^(8-decimalPoint)` divisor underflows to 0 → SIGFPE) and use an integer lookup table instead of `pow()`, keeping this off floating-point math in a consensus path. Unit test added.
- **rpc/rpcevo.cpp (`protx list`)** — remove a leftover `std::cout` debug line that ran on every call inside the `cs_main` critical section.

## Testing

Branch builds cleanly; `assets`/`evo` unit suites pass, and the new `validate_amount_decimal_point` unit test passes (covers the 0..8 range and asserts `decimalPoint > 8` is rejected instead of dividing by zero).
