### PR TITLE
rpc: remove redundant per-item work from smartnode, protx and gobject listings

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -525,24 +525,6 @@ CGovernanceManager::GetCurrentVotes(const uint256 &nParentHash, const COutPoint 
     return vecResult;
 }
 
-std::vector <CGovernanceObject> CGovernanceManager::GetAllNewerThan(int64_t nMoreThanTime) const {
-    LOCK(cs);
-
-    std::vector <CGovernanceObject> vGovObjs;
-
-    for (const auto &objPair: mapObjects) {
-        // IF THIS OBJECT IS OLDER THAN TIME, CONTINUE
-        if (objPair.second.GetCreationTime() < nMoreThanTime) {
-            continue;
-        }
-
-        // ADD GOVERNANCE OBJECT TO LIST
-        vGovObjs.push_back(objPair.second);
-    }
-
-    return vGovObjs;
-}
-
 //
 // Sort by votes, if there's a tie sort by their feeHash TX
 //

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -245,7 +245,19 @@ public:
     std::vector <CGovernanceVote>
     GetCurrentVotes(const uint256 &nParentHash, const COutPoint &mnCollateralOutpointFilter) const;
 
-    std::vector <CGovernanceObject> GetAllNewerThan(int64_t nMoreThanTime) const;
+    // Hands every object created at or after nMoreThanTime to the callback by
+    // reference. Replaces the former GetAllNewerThan(), which copied every object
+    // (and all of its votes) into a vector just for the caller to read them.
+    template<typename Callable>
+    void ForEachObjectNewerThan(int64_t nMoreThanTime, Callable &&func) const {
+        LOCK(cs);
+        for (const auto &objPair: mapObjects) {
+            if (objPair.second.GetCreationTime() < nMoreThanTime) {
+                continue;
+            }
+            func(objPair.second);
+        }
+    }
 
     void AddGovernanceObject(CGovernanceObject &govobj, CConnman &connman, CNode *pfrom = nullptr);
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -723,24 +723,26 @@ UniValue ListObjects(const std::string &strCachedSignal, const std::string &strT
 
     LOCK2(cs_main, governance.cs);
 
-    std::vector <CGovernanceObject> objs = governance.GetAllNewerThan(nStartTime);
     governance.UpdateLastDiffTime(GetTime());
 
     // CREATE RESULTS FOR USER
 
-    for (const auto &govObj: objs) {
-        if (strCachedSignal == "valid" && !govObj.IsSetCachedValid()) continue;
-        if (strCachedSignal == "funding" && !govObj.IsSetCachedFunding()) continue;
-        if (strCachedSignal == "delete" && !govObj.IsSetCachedDelete()) continue;
-        if (strCachedSignal == "endorsed" && !govObj.IsSetCachedEndorsed()) continue;
+    governance.ForEachObjectNewerThan(nStartTime, [&](const CGovernanceObject &govObj) {
+        if (strCachedSignal == "valid" && !govObj.IsSetCachedValid()) return;
+        if (strCachedSignal == "funding" && !govObj.IsSetCachedFunding()) return;
+        if (strCachedSignal == "delete" && !govObj.IsSetCachedDelete()) return;
+        if (strCachedSignal == "endorsed" && !govObj.IsSetCachedEndorsed()) return;
 
-        if (strType == "proposals" && govObj.GetObjectType() != GOVERNANCE_OBJECT_PROPOSAL) continue;
-        if (strType == "triggers" && govObj.GetObjectType() != GOVERNANCE_OBJECT_TRIGGER) continue;
+        if (strType == "proposals" && govObj.GetObjectType() != GOVERNANCE_OBJECT_PROPOSAL) return;
+        if (strType == "triggers" && govObj.GetObjectType() != GOVERNANCE_OBJECT_TRIGGER) return;
+
+        // GetHash() is recomputed from the object data on every call, so do it once.
+        const std::string strHash = govObj.GetHash().ToString();
 
         UniValue bObj(UniValue::VOBJ);
         bObj.pushKV("DataHex", govObj.GetDataAsHexString());
         bObj.pushKV("DataString", govObj.GetDataAsPlainString());
-        bObj.pushKV("Hash", govObj.GetHash().ToString());
+        bObj.pushKV("Hash", strHash);
         bObj.pushKV("CollateralHash", govObj.GetCollateralHash().ToString());
         bObj.pushKV("ObjectType", govObj.GetObjectType());
         bObj.pushKV("CreationTime", govObj.GetCreationTime());
@@ -750,9 +752,13 @@ UniValue ListObjects(const std::string &strCachedSignal, const std::string &strT
         }
 
         // REPORT STATUS FOR FUNDING VOTES SPECIFICALLY
-        bObj.pushKV("AbsoluteYesCount", govObj.GetAbsoluteYesCount(VOTE_SIGNAL_FUNDING));
-        bObj.pushKV("YesCount", govObj.GetYesCount(VOTE_SIGNAL_FUNDING));
-        bObj.pushKV("NoCount", govObj.GetNoCount(VOTE_SIGNAL_FUNDING));
+        // Each of these walks the whole vote map, and GetAbsoluteYesCount() is
+        // defined as yes - no, so count each outcome once and reuse the results.
+        const int nYesCount = govObj.GetYesCount(VOTE_SIGNAL_FUNDING);
+        const int nNoCount = govObj.GetNoCount(VOTE_SIGNAL_FUNDING);
+        bObj.pushKV("AbsoluteYesCount", nYesCount - nNoCount);
+        bObj.pushKV("YesCount", nYesCount);
+        bObj.pushKV("NoCount", nNoCount);
         bObj.pushKV("AbstainCount", govObj.GetAbstainCount(VOTE_SIGNAL_FUNDING));
 
         // REPORT VALIDITY AND CACHING FLAGS FOR VARIOUS SETTINGS
@@ -764,8 +770,8 @@ UniValue ListObjects(const std::string &strCachedSignal, const std::string &strT
         bObj.pushKV("fCachedDelete", govObj.IsSetCachedDelete());
         bObj.pushKV("fCachedEndorsed", govObj.IsSetCachedEndorsed());
 
-        objResult.pushKV(govObj.GetHash().ToString(), bObj);
-    }
+        objResult.pushKV(strHash, bObj);
+    });
 
     return objResult;
 }

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1291,21 +1291,29 @@ UniValue BuildDMNListEntry(CWallet *pwallet, const CDeterministicMNCPtr &dmn, bo
     o.pushKV("confirmations", confirmations);
 
 #ifdef ENABLE_WALLET
-    bool hasOwnerKey = CheckWalletOwnsKey(pwallet, dmn->pdmnState->keyIDOwner);
-    bool hasVotingKey = CheckWalletOwnsKey(pwallet, dmn->pdmnState->keyIDVoting);
-
-    bool ownsCollateral = false;
-    uint256 tmpHashBlock;
-    CTransactionRef collateralTx = GetTransaction(/* block_index */ nullptr, /* mempool */ nullptr, dmn->collateralOutpoint.hash, Params().GetConsensus(), tmpHashBlock);
-    if (collateralTx) {
-        ownsCollateral = CheckWalletOwnsScript(pwallet, collateralTx->vout[dmn->collateralOutpoint.n].scriptPubKey);
-    }
-
+    // All of this is only reported when a wallet is available, so skip it
+    // entirely otherwise instead of computing it and throwing it away.
     if (pwallet) {
+        bool ownsCollateral = false;
+        // The collateral of a smartnode in the list is normally unspent, so it can
+        // be read straight from the UTXO set. Falling back to GetTransaction() (a
+        // txindex lookup plus a block file read) is only needed when listing at a
+        // historical height at which the collateral has since been spent.
+        Coin coin;
+        if (GetUTXOCoin(dmn->collateralOutpoint, coin)) {
+            ownsCollateral = CheckWalletOwnsScript(pwallet, coin.out.scriptPubKey);
+        } else {
+            uint256 tmpHashBlock;
+            CTransactionRef collateralTx = GetTransaction(/* block_index */ nullptr, /* mempool */ nullptr, dmn->collateralOutpoint.hash, Params().GetConsensus(), tmpHashBlock);
+            if (collateralTx && dmn->collateralOutpoint.n < collateralTx->vout.size()) {
+                ownsCollateral = CheckWalletOwnsScript(pwallet, collateralTx->vout[dmn->collateralOutpoint.n].scriptPubKey);
+            }
+        }
+
         UniValue walletObj(UniValue::VOBJ);
-        walletObj.pushKV("hasOwnerKey", hasOwnerKey);
+        walletObj.pushKV("hasOwnerKey", CheckWalletOwnsKey(pwallet, dmn->pdmnState->keyIDOwner));
         walletObj.pushKV("hasOperatorKey", false);
-        walletObj.pushKV("hasVotingKey", hasVotingKey);
+        walletObj.pushKV("hasVotingKey", CheckWalletOwnsKey(pwallet, dmn->pdmnState->keyIDVoting));
         walletObj.pushKV("ownsCollateral", ownsCollateral);
         walletObj.pushKV("ownsPayeeScript", CheckWalletOwnsScript(pwallet, dmn->pdmnState->scriptPayout));
         walletObj.pushKV("ownsOperatorRewardScript", CheckWalletOwnsScript(pwallet, dmn->pdmnState->scriptOperatorPayout));

--- a/src/rpc/smartnode.cpp
+++ b/src/rpc/smartnode.cpp
@@ -582,12 +582,17 @@ static UniValue smartnodelist(const JSONRPCRequest &request) {
 
     mnList.ForEachMN(false, [&](const CDeterministicMNCPtr &dmn) {
         std::string strOutpoint = dmn->collateralOutpoint.ToStringShort();
-        Coin coin;
         std::string collateralAddressStr = "UNKNOWN";
-        if (GetUTXOCoin(dmn->collateralOutpoint, coin)) {
-            CTxDestination collateralDest;
-            if (ExtractDestination(coin.out.scriptPubKey, collateralDest)) {
-                collateralAddressStr = EncodeDestination(collateralDest);
+        // Only the "json" mode reports the collateral address, so skip the UTXO
+        // lookup (which takes cs_main and may hit the coins database) for every
+        // other mode instead of doing it once per smartnode and discarding it.
+        if (strMode == "json") {
+            Coin coin;
+            if (GetUTXOCoin(dmn->collateralOutpoint, coin)) {
+                CTxDestination collateralDest;
+                if (ExtractDestination(coin.out.scriptPubKey, collateralDest)) {
+                    collateralAddressStr = EncodeDestination(collateralDest);
+                }
             }
         }
 


### PR DESCRIPTION
Three RPC listings do a significant amount of work per listed item that is then discarded or recomputed. All three loops run while holding `cs_main`, so the cost is paid by block connection and the rest of the node, not just by the caller.

Each commit is independent and self-contained.

### 1. `smartnodelist` — collateral lookup done for every mode

Only the `json` mode reports the collateral address, but the lookup ran for all eleven modes: a `GetUTXOCoin()` call per smartnode, each taking `cs_main` and potentially hitting the coins database, with the result dropped in ten of them.

Now done only for the mode that consumes it. **Output unchanged in all eleven modes.**

### 2. `protx list <type> true` — a disk read per smartnode

`BuildDMNListEntry()` resolved each collateral with `GetTransaction()`: a txindex lookup plus a block file read and deserialization, per smartnode, under `cs_main`. On a chain with thousands of registered smartnodes that is thousands of random disk reads while block connection waits on the lock.

A listed smartnode's collateral is unspent by construction, so the coin — carrying the same `scriptPubKey` — can be read from the UTXO set instead. `GetTransaction()` is kept as a fallback for the case that still needs it: listing at a historical height at which the collateral has since been spent.

Two related fixes fall out:
- The block is now computed only when a wallet is present. It previously ran unconditionally and dropped the result, so nodes calling `protx list` without a wallet paid a disk read per smartnode for nothing.
- The vout index is bounds-checked before use.

**Output unchanged, with one exception:** on nodes running without `-txindex`, `GetTransaction()` always returned null, so `ownsCollateral` was reported `false` for every smartnode regardless of actual ownership. It is now correct. Happy to split that into its own commit if you would rather review it separately.

### 3. `gobject list` — every object and all its votes deep-copied per call

`ListObjects()` called `GetAllNewerThan()`, which copies each matching `CGovernanceObject` into a vector, including `mapCurrentMNVotes` and the vote file index. With thousands of smartnodes voting that is tens of thousands of vote copies per call, under `cs_main` and `governance.cs`, purely to iterate read-only.

Now iterated by reference. `ListObjects()` already held `governance.cs` for the whole body, so no additional locking is involved and the iteration order is the same map order as before.

Two smaller redundancies in the same loop:
- `GetHash()` recomputes the hash from the object data on every call and was invoked twice per object.
- The vote counters walked the vote map five times per object: `GetAbsoluteYesCount()` is defined as `yes - no` and called both counters again.

`GetAllNewerThan()` had no other callers and is removed. **Output unchanged.**

### Testing

- Full `raptoreumd` build, wallet enabled (`ENABLE_WALLET=1`), zero warnings in the touched files. The wallet-enabled build matters here: the `protx` change lives inside `#ifdef ENABLE_WALLET` and is skipped entirely by a wallet-disabled configure.
- Existing coverage that exercises these paths: `feature_dip3_deterministicmns.py` (`protx info`, `smartnode list` json/status), `feature_llmq_connections.py` (`protx list registered 1`, detailed format).
- Worth noting there is no functional coverage for `smartnode winners` or `gobject list`. `rpc_masternode.py` calls `masternode(...)`, an RPC this codebase does not register — it looks like it was inherited from Dash without being renamed to `smartnode`, so it cannot be exercising anything. I can send a follow-up fixing that test if useful.

### Not included

While measuring this I also looked at `combineUniqueIdPairs()` in the asset validation path, which has been described as an O(n³) DoS vector. It is not: the merge operation creates no new adjacencies, so the outer loop converges in a handful of passes regardless of input (adversarial search over adjacency-dense inputs never exceeded 6). The real cost is Θ(n²), and `n` is bounded by transaction size — at most ~810 unique-asset outputs in a standard transaction, which measures at roughly 0.25 ms. I did not touch it: it is consensus code and the merge is order-dependent, so a rewrite carries fork risk for no measurable gain.