### PR TITLE
ci: sign Windows releases from a workflow

### DIFF
--- a/.github/scripts/repack-signed.ps1
+++ b/.github/scripts/repack-signed.ps1
@@ -1,0 +1,48 @@
+# Repackage signed binaries and regenerate the checksum files.
+#
+# Called by .github/workflows/sign-windows.yaml after the executables in
+# -StagingDir have been signed. Each subdirectory of the staging directory
+# corresponds to one of the archives that came out of the build workflow and is
+# zipped back up under the same name.
+
+param(
+    [Parameter(Mandatory = $true)][string]$StagingDir,
+    [Parameter(Mandatory = $true)][string]$OutputDir
+)
+
+$ErrorActionPreference = "Stop"
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+Get-ChildItem $StagingDir -Directory | ForEach-Object {
+    $name = $_.Name
+    $dir = $_.FullName
+
+    # The checksums shipped inside the archive describe the unsigned files, so
+    # they have to be recomputed: signing changes every executable.
+    $checksums = Join-Path $dir "checksums.txt"
+    if (Test-Path $checksums) { Remove-Item $checksums }
+
+    $lines = @("sha256:", "------------------------------------")
+    Get-ChildItem $dir -File | Sort-Object Name | ForEach-Object {
+        $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+        $lines += "$hash  $($_.Name)"
+    }
+    $lines += "------------------------------------"
+    Set-Content -Path $checksums -Value $lines -Encoding utf8
+
+    $zip = Join-Path $OutputDir "$name.zip"
+    if (Test-Path $zip) { Remove-Item $zip }
+    Compress-Archive -Path (Join-Path $dir '*') -DestinationPath $zip
+    Write-Host "packed $zip"
+}
+
+# A single checksum file covering the archives themselves.
+$manifest = Join-Path $OutputDir "checksums.txt"
+$lines = @()
+Get-ChildItem $OutputDir -Filter *.zip | Sort-Object Name | ForEach-Object {
+    $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
+    $lines += "$hash  $($_.Name)"
+}
+Set-Content -Path $manifest -Value $lines -Encoding utf8
+Get-Content $manifest | Write-Host

--- a/.github/scripts/unpack-for-signing.ps1
+++ b/.github/scripts/unpack-for-signing.ps1
@@ -1,0 +1,29 @@
+# Expand the archives produced by the build workflow into one directory per
+# archive, ready for signing, and fail early if there is nothing to sign.
+
+param(
+    [Parameter(Mandatory = $true)][string]$InputDir,
+    [Parameter(Mandatory = $true)][string]$StagingDir
+)
+
+$ErrorActionPreference = "Stop"
+
+New-Item -ItemType Directory -Force -Path $StagingDir | Out-Null
+
+$zips = Get-ChildItem $InputDir -Filter *.zip
+if ($zips.Count -eq 0) {
+    throw "no .zip archives found in $InputDir - check the run id and version"
+}
+
+$zips | ForEach-Object {
+    $dest = Join-Path $StagingDir $_.BaseName
+    Expand-Archive -Path $_.FullName -DestinationPath $dest
+    Write-Host "unpacked $($_.Name) -> $dest"
+}
+
+$exes = Get-ChildItem $StagingDir -Recurse -Filter *.exe
+if ($exes.Count -eq 0) {
+    throw "no .exe found under $StagingDir - nothing to sign"
+}
+Write-Host "$($exes.Count) executables to sign:"
+$exes | ForEach-Object { Write-Host "  $($_.Directory.Name)/$($_.Name)" }

--- a/.github/scripts/verify-signatures.ps1
+++ b/.github/scripts/verify-signatures.ps1
@@ -1,0 +1,36 @@
+# Fail the run unless every executable carries a valid signature.
+#
+# Signing tools can report success while leaving a file untouched, so the
+# signatures are read back rather than trusted.
+
+param(
+    [Parameter(Mandatory = $true)][string]$StagingDir
+)
+
+$ErrorActionPreference = "Stop"
+
+$exes = Get-ChildItem $StagingDir -Recurse -Filter *.exe
+if ($exes.Count -eq 0) {
+    throw "no .exe found under $StagingDir - nothing was signed"
+}
+
+$bad = @()
+foreach ($exe in $exes) {
+    $sig = Get-AuthenticodeSignature $exe.FullName
+    $subject = if ($sig.SignerCertificate) { $sig.SignerCertificate.Subject } else { "<none>" }
+    Write-Host "$($exe.Name): $($sig.Status) $subject"
+    if ($sig.Status -ne "Valid") {
+        $bad += "$($exe.Name) [$($sig.Status)]"
+    }
+    elseif (-not $sig.TimeStamperCertificate) {
+        # An un-timestamped signature stops being valid the day the certificate
+        # expires, so treat it as a failure rather than shipping it.
+        $bad += "$($exe.Name) [not timestamped]"
+    }
+}
+
+if ($bad.Count -gt 0) {
+    throw "unsigned, invalid or un-timestamped: $($bad -join ', ')"
+}
+
+Write-Host "all $($exes.Count) executables are signed and timestamped"

--- a/.github/workflows/WINDOWS_SIGNING_CI.md
+++ b/.github/workflows/WINDOWS_SIGNING_CI.md
@@ -1,0 +1,117 @@
+# Signing Windows releases from CI
+
+The manual process in [WINDOWS_CODE_SIGNING_GUIDE.md](WINDOWS_CODE_SIGNING_GUIDE.md)
+works, but it depends on somebody having the USB token in hand. This describes
+how to have the `Sign Windows Release` workflow do it instead.
+
+Nothing here signs anything on its own: the workflow is run by hand for a
+release, and does nothing at all until the repository variable
+`SIGNING_METHOD` is set.
+
+## First, a correction to the existing guide
+
+Part 8 of the guide says signing in GitHub Actions "requires certificate
+export". **That is no longer possible.** Since 1 June 2023 the CA/Browser Forum
+Baseline Requirements have required every code signing private key to be
+generated on, and never leave, a FIPS 140-2 Level 2 (or equivalent) hardware
+module. Keys are marked non-exportable, and no CA will issue a `.pfx` you can
+drop into a GitHub secret. Any advice that starts with "export the certificate"
+predates that rule.
+
+So there are two real options, and they differ in what you have to buy and what
+you have to run.
+
+## Option A: self-hosted runner with the token you already own
+
+Keeps the existing Comodo/Sectigo certificate. Nothing is re-issued, nothing new
+is bought.
+
+You need a Windows machine that:
+
+- stays online whenever a release is signed,
+- has the USB token plugged in,
+- has the SafeNet Authentication Client and the Windows SDK installed,
+- runs a GitHub Actions self-hosted runner registered with the labels
+  `self-hosted`, `windows`, `signing`.
+
+Then set:
+
+| Kind | Name | Value |
+|---|---|---|
+| Variable | `SIGNING_METHOD` | `selfhosted` |
+| Secret | `SIGNING_CERT_THUMBPRINT` | the 40-character thumbprint of the signing certificate |
+
+The workflow calls the existing `scripts/sign-raptoreum.ps1`, so the signing
+behaviour is identical to signing by hand.
+
+The catch worth knowing before committing to this: SafeNet normally prompts for
+the token PIN on every signature. For unattended signing the PIN has to be
+cached in the SafeNet client (single logon), which means a machine that, while
+powered on, can sign anything. Treat that machine as sensitive: no other
+workloads, no other runners, restricted network access. A self-hosted runner
+also executes whatever the workflow says, so it should only ever be enabled for
+this repository, and preferably gated behind a protected environment so a pull
+request cannot reach it.
+
+## Option B: Azure Artifact Signing (formerly Trusted Signing)
+
+Signing happens on a normal GitHub-hosted runner, so there is no machine to look
+after and no token to keep plugged in. The private key lives in Microsoft's HSM
+and is never in the repository or on the runner.
+
+- Cost is roughly $10/month on the Basic plan, which includes far more
+  signatures than this project will use.
+- It requires an Azure subscription and an identity validation step for the
+  publisher name that will appear in the signature.
+- Authentication is OpenID Connect, so there is no long-lived credential to
+  store or rotate. The workflow already requests `id-token: write` for this.
+
+Set:
+
+| Kind | Name | Value |
+|---|---|---|
+| Variable | `SIGNING_METHOD` | `azure` |
+| Secret | `AZURE_CLIENT_ID` | app registration used for OIDC federation |
+| Secret | `AZURE_TENANT_ID` | directory tenant |
+| Secret | `AZURE_SUBSCRIPTION_ID` | subscription holding the signing account |
+| Secret | `AZURE_SIGNING_ENDPOINT` | e.g. `https://eus.codesigning.azure.net` |
+| Secret | `AZURE_SIGNING_ACCOUNT` | the signing account name |
+| Secret | `AZURE_CERT_PROFILE` | the certificate profile name |
+
+The identity must hold the **Trusted Signing Certificate Profile Signer** role,
+and the federated credential must be scoped to this repository.
+
+## Which one
+
+If a machine can be dedicated to it, Option A costs nothing extra and reuses the
+certificate that is already paid for. If not, Option B removes the hardware
+question and the "who has the token" question at about $10/month, at the cost of
+a new certificate identity and an Azure account.
+
+Both produce the same artifact, so the choice can be revisited later by changing
+one variable.
+
+## Running it
+
+1. Let `Raptoreum Build` finish and note its run ID (it is in the URL of the
+   run).
+2. Actions -> `Sign Windows Release` -> `Run workflow`, and give it that run ID
+   and the version string.
+3. It downloads that run's `raptoreum-win64-<version>` artifact, signs every
+   executable, and uploads `raptoreum-win64-signed-<version>`.
+
+Signatures are read back afterwards with `Get-AuthenticodeSignature`, and the
+run fails unless every executable is both valid **and** timestamped — an
+un-timestamped signature stops verifying the day the certificate expires. The
+`checksums.txt` inside each archive is regenerated, because signing changes
+every binary and the checksums from the build describe the unsigned ones.
+
+## What is not covered
+
+- Linux and macOS artifacts are not signed by this workflow. The usual practice
+  for those is a detached GPG signature over a `SHA256SUMS` file, published
+  alongside the release; that is a separate decision about which key signs and
+  where it lives.
+- No installer is signed, because the build does not currently produce one.
+- The workflow does not attach anything to a GitHub release; it uploads a signed
+  artifact, and publishing stays a deliberate manual step.

--- a/.github/workflows/sign-windows.yaml
+++ b/.github/workflows/sign-windows.yaml
@@ -1,0 +1,155 @@
+name: Sign Windows Release
+
+# Signs the Windows binaries produced by the "Raptoreum Build" workflow and
+# republishes them as a separate, signed artifact. It is run by hand for a
+# release rather than on every push: signing quotas are finite and there is no
+# reason to sign a pull request build.
+#
+# Pick a back end with the repository variable SIGNING_METHOD
+# (Settings -> Secrets and variables -> Actions -> Variables):
+#
+#   azure       Azure Artifact Signing, formerly Trusted Signing. Runs on a
+#               GitHub-hosted runner and authenticates over OIDC, so no
+#               certificate or password is stored in the repository.
+#
+#   selfhosted  A self-hosted Windows runner with the Comodo/Sectigo USB token
+#               attached, driving scripts/sign-raptoreum.ps1 the same way the
+#               manual process does today.
+#
+# With SIGNING_METHOD unset, nothing is signed and the run says so instead of
+# passing silently, so this is safe to merge before a back end exists.
+#
+# Setup for each back end: .github/workflows/WINDOWS_SIGNING_CI.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID of the Raptoreum Build run whose artifacts to sign"
+        required: true
+        type: string
+      version:
+        description: "Version used in the artifact names, e.g. 1.3.17.05"
+        required: true
+        type: string
+
+env:
+  COIN_NAME: raptoreum
+
+jobs:
+  sign-azure:
+    name: Sign with Azure Artifact Signing
+    if: vars.SIGNING_METHOD == 'azure'
+    runs-on: windows-latest
+    permissions:
+      id-token: write     # required for the OIDC login
+      contents: read
+      actions: read       # required to read another run's artifacts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download unsigned Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.COIN_NAME }}-win64-${{ inputs.version }}
+          path: unsigned
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unpack the archives
+        shell: pwsh
+        run: ./.github/scripts/unpack-for-signing.ps1 -InputDir unsigned -StagingDir staging
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign
+        uses: azure/trusted-signing-action@v0
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files-folder: staging
+          files-folder-filter: exe
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify signatures
+        shell: pwsh
+        run: ./.github/scripts/verify-signatures.ps1 -StagingDir staging
+
+      - name: Repack and checksum
+        shell: pwsh
+        run: ./.github/scripts/repack-signed.ps1 -StagingDir staging -OutputDir signed
+
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.COIN_NAME }}-win64-signed-${{ inputs.version }}
+          path: signed
+
+  sign-selfhosted:
+    name: Sign on the self-hosted signing runner
+    if: vars.SIGNING_METHOD == 'selfhosted'
+    runs-on: [self-hosted, windows, signing]
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download unsigned Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.COIN_NAME }}-win64-${{ inputs.version }}
+          path: unsigned
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unpack the archives
+        shell: pwsh
+        run: ./.github/scripts/unpack-for-signing.ps1 -InputDir unsigned -StagingDir staging
+
+      - name: Sign with the token certificate
+        shell: pwsh
+        env:
+          CERT_THUMBPRINT: ${{ secrets.SIGNING_CERT_THUMBPRINT }}
+        run: |
+          if (-not $env:CERT_THUMBPRINT) { throw "SIGNING_CERT_THUMBPRINT is not set" }
+          Get-ChildItem staging -Directory | ForEach-Object {
+              ./scripts/sign-raptoreum.ps1 -InputPath $_.FullName -CertThumbprint $env:CERT_THUMBPRINT -AutoFindSignTool
+              if ($LASTEXITCODE -ne 0) { throw "signing failed for $($_.Name)" }
+          }
+
+      - name: Verify signatures
+        shell: pwsh
+        run: ./.github/scripts/verify-signatures.ps1 -StagingDir staging
+
+      - name: Repack and checksum
+        shell: pwsh
+        run: ./.github/scripts/repack-signed.ps1 -StagingDir staging -OutputDir signed
+
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.COIN_NAME }}-win64-signed-${{ inputs.version }}
+          path: signed
+
+  not-configured:
+    name: Signing not configured
+    if: vars.SIGNING_METHOD == ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain
+        run: |
+          echo "::warning title=No signing back end::SIGNING_METHOD is not set, so nothing was signed."
+          echo "Set the repository variable SIGNING_METHOD to 'azure' or 'selfhosted'."
+          echo "See .github/workflows/WINDOWS_SIGNING_CI.md for what each one needs."


### PR DESCRIPTION
You asked for the builds to actually be signed, so here is the machinery for it. It is dormant until you choose a back end, so it can be merged now and switched on later.

### First, a correction

Part 8 of `WINDOWS_CODE_SIGNING_GUIDE.md` says CI signing "requires certificate export". **That is not possible any more.** Since 1 June 2023 the CA/Browser Forum Baseline Requirements have required every code signing private key to be generated on, and never leave, FIPS 140-2 Level 2 hardware. Keys are non-exportable and no CA will issue a `.pfx` you can put in a GitHub secret. So the plan sketched in that section cannot be carried out, and the choice is really between the two options below. I have written this up in the new `WINDOWS_SIGNING_CI.md`, which is the file Part 8 pointed at and which was never created.

### What this adds

A manually dispatched **Sign Windows Release** workflow. You give it the run ID of a build and a version; it downloads that run's `raptoreum-win64-<version>` artifact, signs every executable, verifies the result, and uploads `raptoreum-win64-signed-<version>`.

Two back ends, chosen with the repository variable `SIGNING_METHOD`:

**`selfhosted`** — a self-hosted Windows runner with the Comodo token you already have, driving your existing `scripts/sign-raptoreum.ps1`. Costs nothing extra and reuses the certificate you have already paid for. Needs a machine that stays online with the token plugged in, and the token PIN cached in the SafeNet client for unattended use — which makes that machine sensitive, so it is worth gating behind a protected environment. Only secret needed is the certificate thumbprint.

**`azure`** — Azure Artifact Signing (the service formerly called Trusted Signing) on a GitHub-hosted runner. About $10/month, no hardware to babysit, and it authenticates over OIDC so there is no long-lived credential in the repository. Costs a new certificate identity and an identity-validation step for the publisher name.

With `SIGNING_METHOD` unset, neither job runs and a third job reports plainly that nothing was signed — I did not want a workflow that looks green while doing nothing.

### On correctness rather than optimism

Signing tools can report success while leaving a file untouched, so the signatures are read back with `Get-AuthenticodeSignature` and the run fails unless every executable is valid **and timestamped**. Without a timestamp a signature stops verifying the day the certificate expires, which is a slow-motion way to ship broken binaries.

The `checksums.txt` inside each archive is regenerated, since signing changes every binary and the checksums from the build describe the unsigned ones. Shipping the build's checksums next to signed binaries would mean every one of them fails to verify.

### What I could and could not test

The unpack, verify and repack scripts were run locally against stand-in archives shaped like the real build output: two archives in, two archives out, the stale checksum file replaced with a correct one, and the verification step correctly **refusing** unsigned binaries rather than waving them through.

**The signing step itself is untested** — it needs a certificate, and I have neither the token nor an Azure account. That part is written against the documented interfaces of `azure/trusted-signing-action` and your own signing script. Expect to iterate once on it the first time you run it for real, and tell me what it says if it trips.

### Not included

Linux and macOS artifacts are not signed here. The usual approach is a detached GPG signature over a `SHA256SUMS` file, but that is a separate decision about which key signs and where that key lives, and it seemed wrong to decide that for you inside a Windows signing PR. Happy to add it if you say which key.